### PR TITLE
Fix panic on unknown message types

### DIFF
--- a/src/api/receiver_api.rs
+++ b/src/api/receiver_api.rs
@@ -1,6 +1,6 @@
 use prost::{Message, bytes::Bytes};
 use std::io::Cursor;
-use tracing::{Level, event};
+use tracing::{Level, error, event};
 
 use crate::rti::{
     AccountPnLPositionUpdate, BestBidOffer, BracketUpdates, DepthByOrder,
@@ -701,7 +701,24 @@ impl RithmicReceiverApi {
                 }
             }
             _ => {
-                panic!("Unknown message type: {:#01x?}", parsed_message)
+                error!(
+                    "Unknown message type received - template_id: {:?}, data_size: {} bytes",
+                    parsed_message.as_ref().map(|m| m.template_id),
+                    data.len()
+                );
+
+                return Err(RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::Unknown,
+                    is_update: false,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some(format!(
+                        "Unknown message type: template_id={:?}",
+                        parsed_message.as_ref().map(|m| m.template_id)
+                    )),
+                    source: self.source.clone(),
+                });
             }
         };
 

--- a/src/rti/messages.rs
+++ b/src/rti/messages.rs
@@ -63,4 +63,5 @@ pub enum RithmicMessage {
     RithmicOrderNotification(RithmicOrderNotification),
     TickBar(TickBar),
     TimeBar(TimeBar),
+    Unknown,
 }


### PR DESCRIPTION
## Summary

- Fixes critical Issue #2: Application no longer panics when receiving unknown message types from Rithmic server
- Adds `Unknown` variant to `RithmicMessage` enum and replaces `panic!()` with proper error logging and error response handling

## Changes

- **src/rti/messages.rs**: Added `Unknown` variant to `RithmicMessage` enum
- **src/api/receiver_api.rs**: Replaced panic with `error!()` logging and `Err(RithmicResponse)` return

This ensures the application remains stable when Rithmic sends unexpected message types, allowing it to log errors and continue operating instead of crashing.