### PR TITLE
Release 0.5.1: Comprehensive WebSocket Connection Error Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1]
+
+### Added
+
+#### Connection Error Handling
+- **New `RithmicMessage::ConnectionError` variant** for WebSocket connection failures
+  - Provides unified error handling for all connection-related failures
+  - Enables consumers to implement reconnection logic via pattern matching
+  - Includes comprehensive documentation with examples
+- **Comprehensive WebSocket error detection** across all plants (ticker, order, pnl, history):
+  - `ConnectionClosed`: Normal WebSocket closure
+  - `AlreadyClosed`: Attempted use of closed connection
+  - `Io` errors: Network/socket I/O failures (connection lost, timeout)
+  - `ResetWithoutClosingHandshake`: Connection reset without proper WebSocket close
+  - `SendAfterClosing`: Attempted to send data after closing frame sent
+  - `ReceivedAfterClosing`: Received data after closing frame sent
+- **Automatic error notifications** sent through subscription channel when connection fails
+  - `RithmicResponse` with `message: ConnectionError` and `is_update: true`
+  - `error` field contains specific error description
+  - `source` field identifies which plant failed
+  - Enables consumers to detect and handle connection failures in real-time
+
+#### Documentation
+- Added comprehensive documentation to `RithmicMessage::ConnectionError`
+  - Lists all handled error types
+  - Step-by-step guidance for handling connection errors
+  - Complete code examples showing pattern matching
+  - Notes on behavioral details and channel lifecycle
+- Added detailed documentation to `RithmicResponse` struct
+  - Explains error handling for both protocol and connection errors
+  - Examples showing how to handle different error scenarios
+  - Cross-references to related documentation
+
 ### Changed
+- **Improved logging consistency**: Changed `ConnectionClosed` log level from `info!` to `error!` across all plants
+  - Ensures all connection termination events are logged at error level
+  - Makes connection issues more visible in production logs
 - Replace `event!` macro with specific logging macros (`info!`, `error!`, `warn!`) across library code for better code clarity and idiomatic Rust logging
   - Updated: all plant files, `src/api/receiver_api.rs`, `src/request_handler.rs`
 
-## [0.5.0] - 2025-11-16
+### Fixed
+- **Connection error handling**: Plants now properly stop and notify consumers on all WebSocket connection failures
+  - Previously, most connection errors fell through to catch-all warning and left plants in undefined state
+  - Now all connection errors trigger clean shutdown with error notification
+  - Prevents resource leaks and zombie plant instances
+
+## [0.5.0]
 
 > **📖 Migration Guide:** See [MIGRATION_0.5.0.md](MIGRATION_0.5.0.md) for detailed step-by-step migration instructions.
 
@@ -150,9 +192,11 @@ Previous stable release. See git history for earlier changes.
 
 ## Version History Summary
 
+- **0.5.1** (2025-11-18): Connection error handling improvements - ConnectionError variant, comprehensive WebSocket error detection, automatic error notifications
 - **0.5.0** (2025-11-16): Major stability and API improvements - Connection strategies, unified config, panic fixes, connection health monitoring
 - **0.4.2** (2025-11-15): Previous stable release
 
-[Unreleased]: https://github.com/pbeets/rithmic-rs/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/pbeets/rithmic-rs/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/pbeets/rithmic-rs/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/pbeets/rithmic-rs/compare/v0.4.2...v0.5.0
 [0.4.2]: https://github.com/pbeets/rithmic-rs/releases/tag/v0.4.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rithmic-rs"
-version = "0.5.0"
+version = "0.5.1"
 description = "Rust client for the Rithmic R | Protocol API to build algo trading systems"
 license = "MIT OR Apache-2.0"
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Or manually add it to your `Cargo.toml` file.
 
 ```
 [dependencies]
-rithmic-rs = "0.5.0"
+rithmic-rs = "0.5.1"
 ```
 
 ## Breaking Changes in 0.5.0
@@ -126,6 +126,17 @@ async fn stream_live_ticks() -> Result<(), Box<dyn std::error::Error>> {
                 // Handle forced logout events
                 if matches!(update.message, RithmicMessage::ForcedLogout(_)) {
                     eprintln!("Forced logout - must reconnect");
+                    break;
+                }
+
+                // Handle connection errors (new in 0.5.1)
+                if matches!(update.message, RithmicMessage::ConnectionError) {
+                    eprintln!("Connection error from {}: {}",
+                        update.source,
+                        update.error.unwrap_or_else(|| "Unknown error".to_string())
+                    );
+                    // Plant has stopped, channel will close
+                    // Implement reconnection logic here
                     break;
                 }
 

--- a/src/api/receiver_api.rs
+++ b/src/api/receiver_api.rs
@@ -19,6 +19,72 @@ use crate::rti::{
     messages::RithmicMessage,
 };
 
+/// Response from a Rithmic plant, either from a request or a subscription update.
+///
+/// This structure wraps all messages received from Rithmic plants, including both
+/// request-response messages and subscription updates (like market data, order updates, etc.).
+///
+/// ## Fields
+///
+/// - `request_id`: Unique identifier for matching responses to requests. Empty for updates.
+/// - `message`: The actual Rithmic message data (see [`RithmicMessage`])
+/// - `is_update`: `true` if this is a subscription update, `false` if it's a request response
+/// - `has_more`: `true` if more responses are coming for this request
+/// - `multi_response`: `true` if this request type can return multiple responses
+/// - `error`: Error message if the operation failed or a connection error occurred
+/// - `source`: Name of the plant that sent this response (e.g., "ticker_plant", "order_plant")
+///
+/// ## Error Handling
+///
+/// The `error` field is populated in two scenarios:
+///
+/// ### 1. Rithmic Protocol Errors
+/// When Rithmic rejects a request or encounters an error, the response will have:
+/// - `error: Some("error description from Rithmic")`
+/// - `message`: Usually [`RithmicMessage::Reject`](crate::rti::messages::RithmicMessage::Reject)
+///
+/// ### 2. Connection Errors
+/// When a plant's WebSocket connection fails, you'll receive:
+/// - `message: RithmicMessage::ConnectionError`
+/// - `error: Some("WebSocket error description")`
+/// - `is_update: true` (routed to subscription channel)
+/// - The plant has stopped and the channel will close
+///
+/// See [`RithmicMessage::ConnectionError`](crate::rti::messages::RithmicMessage::ConnectionError)
+/// for detailed error handling guidance.
+///
+/// ## Example: Handling Errors
+///
+/// ```no_run
+/// # use rithmic_rs::api::receiver_api::RithmicResponse;
+/// # use rithmic_rs::rti::messages::RithmicMessage;
+/// # fn handle_response(response: RithmicResponse) {
+/// match response.message {
+///     RithmicMessage::ConnectionError => {
+///         // WebSocket connection failed
+///         eprintln!(
+///             "Connection error from {}: {}",
+///             response.source,
+///             response.error.as_ref().unwrap()
+///         );
+///         // Implement reconnection logic
+///     }
+///     RithmicMessage::Reject(reject) => {
+///         // Rithmic rejected a request
+///         eprintln!(
+///             "Request rejected: {}",
+///             response.error.as_ref().unwrap_or(&"Unknown".to_string())
+///         );
+///     }
+///     _ => {
+///         // Check error field even for successful-looking messages
+///         if let Some(err) = response.error {
+///             eprintln!("Error in {}: {}", response.source, err);
+///         }
+///     }
+/// }
+/// # }
+/// ```
 #[derive(Debug, Clone)]
 pub struct RithmicResponse {
     pub request_id: String,

--- a/src/plants/history_plant.rs
+++ b/src/plants/history_plant.rs
@@ -3,7 +3,7 @@ use tracing::{error, info, warn};
 
 use tokio_tungstenite::{
     MaybeTlsStream,
-    tungstenite::{Error, Message},
+    tungstenite::{Error, Message, error::ProtocolError},
 };
 
 use crate::{
@@ -289,7 +289,99 @@ impl PlantActor for HistoryPlant {
                 }
             },
             Err(Error::ConnectionClosed) => {
-                info!("history_plant: Connection closed");
+                error!("history_plant: connection closed");
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some("WebSocket connection closed".to_string()),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
+
+                stop = true;
+            }
+            Err(Error::AlreadyClosed) => {
+                error!("history_plant: connection already closed");
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some("WebSocket connection already closed".to_string()),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
+
+                stop = true;
+            }
+            Err(Error::Io(ref io_err)) => {
+                error!("history_plant: I/O error: {}", io_err);
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some(format!("WebSocket I/O error: {}", io_err)),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
+
+                stop = true;
+            }
+            Err(Error::Protocol(ProtocolError::ResetWithoutClosingHandshake)) => {
+                error!("history_plant: connection reset without closing handshake");
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some("WebSocket connection reset without closing handshake".to_string()),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
+
+                stop = true;
+            }
+            Err(Error::Protocol(ProtocolError::SendAfterClosing)) => {
+                error!("history_plant: attempted to send after closing");
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some("WebSocket attempted to send after closing".to_string()),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
+
+                stop = true;
+            }
+            Err(Error::Protocol(ProtocolError::ReceivedAfterClosing)) => {
+                error!("history_plant: received data after closing");
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some("WebSocket received data after closing".to_string()),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
+
                 stop = true;
             }
             _ => {

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -3,7 +3,7 @@ use tracing::{error, info, warn};
 
 use tokio_tungstenite::{
     MaybeTlsStream,
-    tungstenite::{Error, Message},
+    tungstenite::{Error, Message, error::ProtocolError},
 };
 
 use crate::{
@@ -359,14 +359,98 @@ impl PlantActor for OrderPlant {
                 }
             },
             Err(Error::ConnectionClosed) => {
-                error!("order_plant: Connection closed");
+                error!("order_plant: connection closed");
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some("WebSocket connection closed".to_string()),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
 
                 stop = true;
             }
-            Err(Error::Protocol(
-                tokio_tungstenite::tungstenite::error::ProtocolError::ResetWithoutClosingHandshake,
-            )) => {
+            Err(Error::AlreadyClosed) => {
+                error!("order_plant: connection already closed");
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some("WebSocket connection already closed".to_string()),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
+
+                stop = true;
+            }
+            Err(Error::Io(ref io_err)) => {
+                error!("order_plant: I/O error: {}", io_err);
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some(format!("WebSocket I/O error: {}", io_err)),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
+
+                stop = true;
+            }
+            Err(Error::Protocol(ProtocolError::ResetWithoutClosingHandshake)) => {
                 error!("order_plant: connection reset without closing handshake");
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some("WebSocket connection reset without closing handshake".to_string()),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
+
+                stop = true;
+            }
+            Err(Error::Protocol(ProtocolError::SendAfterClosing)) => {
+                error!("order_plant: attempted to send after closing");
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some("WebSocket attempted to send after closing".to_string()),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
+
+                stop = true;
+            }
+            Err(Error::Protocol(ProtocolError::ReceivedAfterClosing)) => {
+                error!("order_plant: received data after closing");
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some("WebSocket received data after closing".to_string()),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
 
                 stop = true;
             }

--- a/src/plants/pnl_plant.rs
+++ b/src/plants/pnl_plant.rs
@@ -28,7 +28,7 @@ use tokio::{
 
 use tokio_tungstenite::{
     MaybeTlsStream,
-    tungstenite::{Error, Message},
+    tungstenite::{Error, Message, error::ProtocolError},
 };
 
 pub enum PnlPlantCommand {
@@ -276,7 +276,99 @@ impl PlantActor for PnlPlant {
                 }
             },
             Err(Error::ConnectionClosed) => {
-                info!("pnl_plant: Connection closed");
+                error!("pnl_plant: connection closed");
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some("WebSocket connection closed".to_string()),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
+
+                stop = true;
+            }
+            Err(Error::AlreadyClosed) => {
+                error!("pnl_plant: connection already closed");
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some("WebSocket connection already closed".to_string()),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
+
+                stop = true;
+            }
+            Err(Error::Io(ref io_err)) => {
+                error!("pnl_plant: I/O error: {}", io_err);
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some(format!("WebSocket I/O error: {}", io_err)),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
+
+                stop = true;
+            }
+            Err(Error::Protocol(ProtocolError::ResetWithoutClosingHandshake)) => {
+                error!("pnl_plant: connection reset without closing handshake");
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some("WebSocket connection reset without closing handshake".to_string()),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
+
+                stop = true;
+            }
+            Err(Error::Protocol(ProtocolError::SendAfterClosing)) => {
+                error!("pnl_plant: attempted to send after closing");
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some("WebSocket attempted to send after closing".to_string()),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
+
+                stop = true;
+            }
+            Err(Error::Protocol(ProtocolError::ReceivedAfterClosing)) => {
+                error!("pnl_plant: received data after closing");
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some("WebSocket received data after closing".to_string()),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
+
                 stop = true;
             }
             _ => {

--- a/src/plants/ticker_plant.rs
+++ b/src/plants/ticker_plant.rs
@@ -27,7 +27,7 @@ use futures_util::{
 
 use tokio_tungstenite::{
     MaybeTlsStream,
-    tungstenite::{Error, Message},
+    tungstenite::{Error, Message, error::ProtocolError},
 };
 
 use tokio::{
@@ -411,7 +411,98 @@ impl PlantActor for TickerPlant {
                 }
             },
             Err(Error::ConnectionClosed) => {
-                info!("ticker_plant connection closed");
+                error!("ticker_plant: connection closed");
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some("WebSocket connection closed".to_string()),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
+
+                stop = true;
+            }
+            Err(Error::AlreadyClosed) => {
+                error!("ticker_plant: connection already closed");
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some("WebSocket connection already closed".to_string()),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
+
+                stop = true;
+            }
+            Err(Error::Io(ref io_err)) => {
+                error!("ticker_plant: I/O error: {}", io_err);
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some(format!("WebSocket I/O error: {}", io_err)),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
+
+                stop = true;
+            }
+            Err(Error::Protocol(ProtocolError::ResetWithoutClosingHandshake)) => {
+                error!("ticker_plant: connection reset without closing handshake");
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some("WebSocket connection reset without closing handshake".to_string()),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
+
+                stop = true;
+            }
+            Err(Error::Protocol(ProtocolError::SendAfterClosing)) => {
+                error!("ticker_plant: attempted to send after closing");
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some("WebSocket attempted to send after closing".to_string()),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
+
+                stop = true;
+            }
+            Err(Error::Protocol(ProtocolError::ReceivedAfterClosing)) => {
+                error!("ticker_plant: received data after closing");
+
+                let error_response = RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::ConnectionError,
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some("WebSocket received data after closing".to_string()),
+                    source: self.rithmic_receiver_api.source.clone(),
+                };
+                let _ = self.subscription_sender.send(error_response);
 
                 stop = true;
             }

--- a/src/rti/messages.rs
+++ b/src/rti/messages.rs
@@ -63,5 +63,63 @@ pub enum RithmicMessage {
     RithmicOrderNotification(RithmicOrderNotification),
     TickBar(TickBar),
     TimeBar(TimeBar),
+
+    /// WebSocket connection error.
+    ///
+    /// This variant is sent when a plant's WebSocket connection experiences a fatal error
+    /// and the plant is shutting down. The specific error details are in the `error` field
+    /// of the [`RithmicResponse`](crate::api::receiver_api::RithmicResponse).
+    ///
+    /// ## Error Types Handled
+    ///
+    /// - **ConnectionClosed**: Normal WebSocket closure
+    /// - **AlreadyClosed**: Attempted to use an already-closed connection
+    /// - **Io errors**: Network/socket I/O failures (e.g., connection lost, timeout)
+    /// - **ResetWithoutClosingHandshake**: Connection reset without proper WebSocket close
+    /// - **SendAfterClosing**: Attempted to send data after closing frame sent
+    /// - **ReceivedAfterClosing**: Received data after closing frame sent
+    ///
+    /// ## Handling Connection Errors
+    ///
+    /// When you receive a `ConnectionError`, the plant has already stopped and its channels
+    /// will close. Your application should:
+    ///
+    /// 1. Check the `error` field for specific error details
+    /// 2. Check the `source` field to identify which plant failed
+    /// 3. Implement reconnection logic if appropriate
+    /// 4. Clean up any state associated with that plant
+    ///
+    /// ## Example
+    ///
+    /// ```no_run
+    /// use rithmic_rs::rti::messages::RithmicMessage;
+    /// # use rithmic_rs::api::receiver_api::RithmicResponse;
+    /// # fn example(response: RithmicResponse) {
+    /// match response.message {
+    ///     RithmicMessage::ConnectionError => {
+    ///         eprintln!(
+    ///             "Plant {} connection error: {}",
+    ///             response.source,
+    ///             response.error.unwrap_or_else(|| "Unknown error".to_string())
+    ///         );
+    ///         // Implement reconnection logic here
+    ///         // The plant has stopped and channels will close
+    ///     }
+    ///     RithmicMessage::ForcedLogout(_) => {
+    ///         // Server-initiated logout - different from connection errors
+    ///     }
+    ///     _ => {}
+    /// }
+    /// # }
+    /// ```
+    ///
+    /// ## Notes
+    ///
+    /// - This message always has `is_update: true` and routes to the subscription channel
+    /// - The plant has already terminated when you receive this message
+    /// - The subscription channel will close shortly after this message
+    /// - Unlike [`ForcedLogout`], which is a server-initiated action, `ConnectionError`
+    ///   indicates a transport-level failure
+    ConnectionError,
     Unknown,
 }


### PR DESCRIPTION
## Summary

This release adds comprehensive WebSocket connection error handling across all plants, addressing the issue where connection errors like `ResetWithoutClosingHandshake` were not properly handled and left plants in undefined states.

## What's New in 0.5.1

### 🎯 New `RithmicMessage::ConnectionError` Variant

Added a dedicated message type for WebSocket connection failures, making it easy for consumers to detect and handle connection errors:

```rust
match response.message {
    RithmicMessage::ConnectionError => {
        // Connection failed, implement reconnection logic
        eprintln!("Plant {} error: {}", response.source, response.error.unwrap());
    }
    _ => {}
}
```

### 🛡️ Comprehensive Error Detection

All plants (ticker, order, pnl, history) now properly detect and handle 6 types of WebSocket connection errors:

- **ConnectionClosed**: Normal WebSocket closure
- **AlreadyClosed**: Attempted use of closed connection  
- **Io errors**: Network/socket I/O failures (connection lost, timeout)
- **ResetWithoutClosingHandshake**: Connection reset without proper close (the original reported issue!)
- **SendAfterClosing**: Attempted send after closing frame
- **ReceivedAfterClosing**: Received data after closing frame

### 📢 Automatic Error Notifications

When a connection error occurs:
1. Plant logs the specific error
2. Sends `RithmicResponse` with `ConnectionError` through subscription channel
3. Sets `stop = true` to cleanly terminate
4. Channels close automatically

This enables consumers to:
- Detect connection failures in real-time
- Identify which plant failed via `response.source`
- Get specific error details via `response.error`
- Implement reconnection logic

### 📚 Comprehensive Documentation

- **In-code docs**: Added extensive documentation to `RithmicMessage::ConnectionError` and `RithmicResponse`
  - Lists all handled error types
  - Provides step-by-step handling guidance
  - Includes complete code examples
- **README**: Added ConnectionError handling to Quick Start example
- **CHANGELOG**: Detailed 0.5.1 release notes

## Changes

### Modified Files
- `src/rti/messages.rs`: Added `ConnectionError` variant with docs
- `src/api/receiver_api.rs`: Added `RithmicResponse` documentation
- `src/plants/*.rs`: Added error handlers for all 6 connection error types
- `CHANGELOG.md`: Added 0.5.1 release notes
- `README.md`: Added error handling example
- `Cargo.toml`: Bumped version to 0.5.1

### Statistics
- 9 files changed
- 553 insertions(+)
- 15 deletions(-)

## Testing

✅ All changes compile successfully with no errors
✅ Existing tests pass
✅ Documentation examples compile

## Migration

No breaking changes. Existing code will continue to work, but consumers can now optionally handle `ConnectionError` for better reliability:

```rust
// New optional error handling (recommended)
if matches!(update.message, RithmicMessage::ConnectionError) {
    // Implement reconnection logic
    eprintln!("Connection lost: {}", update.error.unwrap());
}
```

## Fixes

- **Resolves connection error handling issue**: Plants now properly stop and notify on all WebSocket failures
  - Previously fell through to catch-all warning log
  - Left plants in undefined state
  - Could cause resource leaks
- **Improved logging**: ConnectionClosed now uses `error!` level for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)