### PR TITLE
Release version 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3] - 2025-11-22
+
+### Added
+
+#### Order Management APIs
+- **New `cancel_all_orders()` method** on `RithmicOrderPlantHandle`
+  - Cancels all active orders across all symbols and exchanges for the account
+  - Returns cancellation confirmation response
+- **New order history methods** on `RithmicOrderPlantHandle`
+  - `show_order_history_dates()`: Get dates for which order history is available
+  - `show_order_history_summary(date)`: Get order summary for a specific date (YYYYMMDD format)
+  - `show_order_history_detail(basket_id, date)`: Get detailed history for a specific order
+  - `show_order_history(basket_id)`: Get general order history with optional basket_id filter
+  - Enables comprehensive order audit trails and historical analysis
+
+#### Risk Management APIs
+- **New RMS information methods** on `RithmicOrderPlantHandle`
+  - `get_account_rms_info()`: Retrieve account-level risk management limits and settings
+  - `get_product_rms_info()`: Retrieve product-specific risk management limits
+  - `get_trade_routes(subscribe_for_updates)`: Get available trade routes with optional update subscription
+  - Critical for monitoring trading limits and route availability
+
+#### Symbol Search and Discovery APIs
+- **New `search_symbols()` method** on `RithmicTickerPlantHandle`
+  - Search for symbols by text pattern with optional filters
+  - Supports filtering by exchange, product code, and instrument type
+  - Configurable search pattern (EQUALS or CONTAINS)
+  - Returns list of matching symbols for dynamic symbol discovery
+- **New `list_exchanges()` method** on `RithmicTickerPlantHandle`
+  - Lists exchanges available to the specified user
+  - Useful for determining trading permissions
+
+#### Protocol Message Support
+- **New `TradeRoute` message type** added to `RithmicMessage` enum
+  - Handles template ID 310 for trade route information
+  - Delivered as update message (`is_update: true`)
+  - Supports trade route subscription updates
+
+#### Sender API Methods
+- Added 10 new request methods to `RithmicSenderApi`:
+  - `request_cancel_all_orders()`: Template 346
+  - `request_account_rms_info()`: Template 304
+  - `request_product_rms_info()`: Template 306
+  - `request_trade_routes(subscribe_for_updates)`: Template 310
+  - `request_search_symbols(...)`: Template 109 with extensive search filters
+  - `request_list_exchanges(user)`: Template 342
+  - `request_show_order_history_dates()`: Template 318
+  - `request_show_order_history_summary(date)`: Template 324
+  - `request_show_order_history_detail(basket_id, date)`: Template 326
+  - `request_show_order_history(basket_id)`: Template 322
+
+### Changed
+
+#### Internal Improvements
+- Extended `OrderPlantCommand` enum with 8 new command variants for order history and RMS operations
+- Extended `TickerPlantCommand` enum with 2 new command variants for symbol search and exchange listing
+- Updated receiver API to handle TradeRoute message type (template ID 310)
+- Added new imports for request types: `RequestCancelAllOrders`, `RequestAccountRmsInfo`, `RequestProductRmsInfo`, `RequestSearchSymbols`, `RequestTradeRoutes`, and order history request types
+
+### Known Issues
+
+#### Error Handling
+- New TradeRoute message handler uses `.unwrap()` on protobuf decode (line 438 in receiver_api.rs)
+- New plant handle methods use multiple `.unwrap()` calls that could panic on channel failures
+- These follow existing patterns in the codebase but should be addressed in future releases
+- Users should be aware that malformed messages or actor failures may cause panics
+
 ## [0.5.2] - 2025-11-20
 
 ### Added
@@ -255,12 +322,14 @@ Previous stable release. See git history for earlier changes.
 
 ## Version History Summary
 
+- **0.5.3** (2025-11-22): API expansion - Order history, RMS info, symbol search, trade routes, cancel all orders
 - **0.5.2** (2025-11-20): Heartbeat improvements - Optional heartbeat response handling, heartbeat timeout detection, internal refactoring
 - **0.5.1** (2025-11-18): Connection error handling improvements - ConnectionError variant, comprehensive WebSocket error detection, automatic error notifications
 - **0.5.0** (2025-11-16): Major stability and API improvements - Connection strategies, unified config, panic fixes, connection health monitoring
 - **0.4.2** (2025-11-15): Previous stable release
 
-[Unreleased]: https://github.com/pbeets/rithmic-rs/compare/v0.5.2...HEAD
+[Unreleased]: https://github.com/pbeets/rithmic-rs/compare/v0.5.3...HEAD
+[0.5.3]: https://github.com/pbeets/rithmic-rs/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/pbeets/rithmic-rs/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/pbeets/rithmic-rs/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/pbeets/rithmic-rs/compare/v0.4.2...v0.5.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rithmic-rs"
-version = "0.5.2"
+version = "0.5.3"
 description = "Rust client for the Rithmic R | Protocol API to build algo trading systems"
 license = "MIT OR Apache-2.0"
 edition = "2024"

--- a/src/api/receiver_api.rs
+++ b/src/api/receiver_api.rs
@@ -15,7 +15,7 @@ use crate::rti::{
     ResponseShowOrderHistoryDetail, ResponseShowOrderHistorySummary, ResponseShowOrders,
     ResponseSubscribeForOrderUpdates, ResponseSubscribeToBracketUpdates, ResponseTickBarReplay,
     ResponseTimeBarReplay, ResponseTradeRoutes, ResponseUpdateStopBracketLevel,
-    ResponseUpdateTargetBracketLevel, RithmicOrderNotification, TickBar, TimeBar,
+    ResponseUpdateTargetBracketLevel, RithmicOrderNotification, TickBar, TimeBar, TradeRoute,
     messages::RithmicMessage,
 };
 
@@ -431,6 +431,19 @@ impl RithmicReceiverApi {
                     has_more: false,
                     multi_response: false,
                     error,
+                    source: self.source.clone(),
+                }
+            }
+            310 => {
+                let resp = TradeRoute::decode(&mut Cursor::new(&data[4..])).unwrap();
+
+                RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::TradeRoute(resp),
+                    is_update: true,
+                    has_more: false,
+                    multi_response: false,
+                    error: None,
                     source: self.source.clone(),
                 }
             }

--- a/src/api/sender_api.rs
+++ b/src/api/sender_api.rs
@@ -3,18 +3,22 @@ use prost::Message;
 use crate::{
     config::{RithmicConfig, RithmicEnv},
     rti::{
-        RequestAccountList, RequestBracketOrder, RequestCancelOrder, RequestDepthByOrderSnapshot,
-        RequestDepthByOrderUpdates, RequestExitPosition, RequestHeartbeat, RequestLogin,
+        RequestAccountList, RequestAccountRmsInfo, RequestBracketOrder, RequestCancelAllOrders,
+        RequestCancelOrder, RequestDepthByOrderSnapshot, RequestDepthByOrderUpdates,
+        RequestExitPosition, RequestHeartbeat, RequestListExchangePermissions, RequestLogin,
         RequestLogout, RequestMarketDataUpdate, RequestModifyOrder, RequestNewOrder,
-        RequestPnLPositionSnapshot, RequestPnLPositionUpdates, RequestRithmicSystemInfo,
-        RequestShowBracketStops, RequestShowBrackets, RequestShowOrders,
+        RequestPnLPositionSnapshot, RequestPnLPositionUpdates, RequestProductRmsInfo,
+        RequestRithmicSystemInfo, RequestSearchSymbols, RequestShowBracketStops,
+        RequestShowBrackets, RequestShowOrderHistory, RequestShowOrderHistoryDates,
+        RequestShowOrderHistoryDetail, RequestShowOrderHistorySummary, RequestShowOrders,
         RequestSubscribeForOrderUpdates, RequestSubscribeToBracketUpdates, RequestTickBarReplay,
-        RequestTimeBarReplay, RequestUpdateStopBracketLevel, RequestUpdateTargetBracketLevel,
+        RequestTimeBarReplay, RequestTradeRoutes, RequestUpdateStopBracketLevel,
+        RequestUpdateTargetBracketLevel,
         request_account_list::UserType,
-        request_bracket_order, request_depth_by_order_updates,
+        request_bracket_order, request_cancel_all_orders, request_depth_by_order_updates,
         request_login::SysInfraType,
         request_market_data_update::{Request, UpdateBits},
-        request_new_order, request_pn_l_position_updates,
+        request_new_order, request_pn_l_position_updates, request_search_symbols,
         request_tick_bar_replay::{BarSubType, BarType, Direction, TimeOrder},
         request_time_bar_replay,
     },
@@ -621,6 +625,233 @@ impl RithmicSenderApi {
             symbol: Some(symbol.into()),
             exchange: Some(exchange.into()),
             depth_price: None,
+        };
+
+        self.request_to_buf(req, id)
+    }
+
+    /// Request to cancel all orders for the account
+    ///
+    /// This will cancel all active orders across all symbols and exchanges for the account.
+    ///
+    /// # Returns
+    /// A tuple of (serialized request buffer, request ID)
+    pub fn request_cancel_all_orders(&mut self) -> (Vec<u8>, String) {
+        let id = self.get_next_message_id();
+
+        let req = RequestCancelAllOrders {
+            template_id: 346,
+            fcm_id: Some(self.fcm_id.clone()),
+            ib_id: Some(self.ib_id.clone()),
+            account_id: Some(self.account_id.clone()),
+            user_type: Some(USER_TYPE),
+            manual_or_auto: Some(request_cancel_all_orders::OrderPlacement::Manual.into()),
+            user_msg: vec![id.clone()],
+        };
+
+        self.request_to_buf(req, id)
+    }
+
+    /// Request account RMS (Risk Management System) information
+    ///
+    /// Returns risk management limits and settings for the account.
+    ///
+    /// # Returns
+    /// A tuple of (serialized request buffer, request ID)
+    pub fn request_account_rms_info(&mut self) -> (Vec<u8>, String) {
+        let id = self.get_next_message_id();
+
+        let req = RequestAccountRmsInfo {
+            template_id: 304,
+            user_msg: vec![id.clone()],
+            fcm_id: Some(self.fcm_id.clone()),
+            ib_id: Some(self.ib_id.clone()),
+            user_type: Some(USER_TYPE),
+        };
+
+        self.request_to_buf(req, id)
+    }
+
+    /// Request product RMS (Risk Management System) information
+    ///
+    /// Returns risk management limits for specific products/symbols.
+    ///
+    /// # Returns
+    /// A tuple of (serialized request buffer, request ID)
+    pub fn request_product_rms_info(&mut self) -> (Vec<u8>, String) {
+        let id = self.get_next_message_id();
+
+        let req = RequestProductRmsInfo {
+            template_id: 306,
+            user_msg: vec![id.clone()],
+            fcm_id: Some(self.fcm_id.clone()),
+            ib_id: Some(self.ib_id.clone()),
+            account_id: Some(self.account_id.clone()),
+        };
+
+        self.request_to_buf(req, id)
+    }
+
+    /// Request list of available trade routes
+    ///
+    /// Returns the trade routes configured for the user's account.
+    ///
+    /// # Arguments
+    /// * `subscribe_for_updates` - Whether to receive updates when routes change
+    ///
+    /// # Returns
+    /// A tuple of (serialized request buffer, request ID)
+    pub fn request_trade_routes(&mut self, subscribe_for_updates: bool) -> (Vec<u8>, String) {
+        let id = self.get_next_message_id();
+
+        let req = RequestTradeRoutes {
+            template_id: 310,
+            user_msg: vec![id.clone()],
+            subscribe_for_updates: Some(subscribe_for_updates),
+        };
+
+        self.request_to_buf(req, id)
+    }
+
+    /// Request to search for symbols matching a pattern
+    ///
+    /// # Arguments
+    /// * `search_text` - Search query string
+    /// * `exchange` - Optional exchange filter (e.g., "CME", "COMEX")
+    /// * `product_code` - Optional product code filter (e.g., "ES", "SI")
+    /// * `instrument_type` - Optional instrument type filter
+    /// * `pattern` - Search pattern type (EQUALS or CONTAINS)
+    ///
+    /// # Returns
+    /// A tuple of (serialized request buffer, request ID)
+    pub fn request_search_symbols(
+        &mut self,
+        search_text: &str,
+        exchange: Option<&str>,
+        product_code: Option<&str>,
+        instrument_type: Option<request_search_symbols::InstrumentType>,
+        pattern: Option<request_search_symbols::Pattern>,
+    ) -> (Vec<u8>, String) {
+        let id = self.get_next_message_id();
+
+        let req = RequestSearchSymbols {
+            template_id: 109,
+            user_msg: vec![id.clone()],
+            search_text: Some(search_text.to_string()),
+            exchange: exchange.map(|e| e.to_string()),
+            product_code: product_code.map(|p| p.to_string()),
+            instrument_type: instrument_type.map(|i| i.into()),
+            pattern: pattern.map(|p| p.into()),
+        };
+
+        self.request_to_buf(req, id)
+    }
+
+    /// Request list of exchanges available to the user
+    ///
+    /// Returns the exchanges the user has permission to trade on.
+    ///
+    /// # Arguments
+    /// * `user` - Username for authentication
+    ///
+    /// # Returns
+    /// A tuple of (serialized request buffer, request ID)
+    pub fn request_list_exchanges(&mut self, user: &str) -> (Vec<u8>, String) {
+        let id = self.get_next_message_id();
+
+        let req = RequestListExchangePermissions {
+            template_id: 342,
+            user_msg: vec![id.clone()],
+            user: Some(user.to_string()),
+        };
+
+        self.request_to_buf(req, id)
+    }
+
+    /// Request order history dates
+    ///
+    /// Returns the dates for which order history is available.
+    ///
+    /// # Returns
+    /// A tuple of (serialized request buffer, request ID)
+    pub fn request_show_order_history_dates(&mut self) -> (Vec<u8>, String) {
+        let id = self.get_next_message_id();
+
+        let req = RequestShowOrderHistoryDates {
+            template_id: 318,
+            user_msg: vec![id.clone()],
+        };
+
+        self.request_to_buf(req, id)
+    }
+
+    /// Request order history summary for a specific date
+    ///
+    /// # Arguments
+    /// * `date` - Date in YYYYMMDD format (e.g., "20250122")
+    ///
+    /// # Returns
+    /// A tuple of (serialized request buffer, request ID)
+    pub fn request_show_order_history_summary(&mut self, date: &str) -> (Vec<u8>, String) {
+        let id = self.get_next_message_id();
+
+        let req = RequestShowOrderHistorySummary {
+            template_id: 324,
+            user_msg: vec![id.clone()],
+            fcm_id: Some(self.fcm_id.clone()),
+            ib_id: Some(self.ib_id.clone()),
+            account_id: Some(self.account_id.clone()),
+            date: Some(date.to_string()),
+        };
+
+        self.request_to_buf(req, id)
+    }
+
+    /// Request detailed order history for a specific order
+    ///
+    /// # Arguments
+    /// * `basket_id` - Order/basket identifier
+    /// * `date` - Date in YYYYMMDD format
+    ///
+    /// # Returns
+    /// A tuple of (serialized request buffer, request ID)
+    pub fn request_show_order_history_detail(
+        &mut self,
+        basket_id: &str,
+        date: &str,
+    ) -> (Vec<u8>, String) {
+        let id = self.get_next_message_id();
+
+        let req = RequestShowOrderHistoryDetail {
+            template_id: 326,
+            user_msg: vec![id.clone()],
+            fcm_id: Some(self.fcm_id.clone()),
+            ib_id: Some(self.ib_id.clone()),
+            account_id: Some(self.account_id.clone()),
+            basket_id: Some(basket_id.to_string()),
+            date: Some(date.to_string()),
+        };
+
+        self.request_to_buf(req, id)
+    }
+
+    /// Request general order history
+    ///
+    /// # Arguments
+    /// * `basket_id` - Optional order/basket identifier filter
+    ///
+    /// # Returns
+    /// A tuple of (serialized request buffer, request ID)
+    pub fn request_show_order_history(&mut self, basket_id: Option<&str>) -> (Vec<u8>, String) {
+        let id = self.get_next_message_id();
+
+        let req = RequestShowOrderHistory {
+            template_id: 322,
+            user_msg: vec![id.clone()],
+            fcm_id: Some(self.fcm_id.clone()),
+            ib_id: Some(self.ib_id.clone()),
+            account_id: Some(self.account_id.clone()),
+            basket_id: basket_id.map(|b| b.to_string()),
         };
 
         self.request_to_buf(req, id)

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -93,6 +93,35 @@ pub enum OrderPlantCommand {
     ShowOrders {
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, String>>,
     },
+    CancelAllOrders {
+        response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, String>>,
+    },
+    GetAccountRmsInfo {
+        response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, String>>,
+    },
+    GetProductRmsInfo {
+        response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, String>>,
+    },
+    GetTradeRoutes {
+        subscribe_for_updates: bool,
+        response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, String>>,
+    },
+    ShowOrderHistoryDates {
+        response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, String>>,
+    },
+    ShowOrderHistorySummary {
+        date: String,
+        response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, String>>,
+    },
+    ShowOrderHistoryDetail {
+        basket_id: String,
+        date: String,
+        response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, String>>,
+    },
+    ShowOrderHistory {
+        basket_id: Option<String>,
+        response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, String>>,
+    },
 }
 
 /// The RithmicOrderPlant provides functionality to manage trading orders through the Rithmic API.
@@ -734,6 +763,131 @@ impl PlantActor for OrderPlant {
                     .await
                     .unwrap();
             }
+            OrderPlantCommand::CancelAllOrders { response_sender } => {
+                let (req_buf, id) = self.rithmic_sender_api.request_cancel_all_orders();
+
+                self.request_handler.register_request(RithmicRequest {
+                    request_id: id,
+                    responder: response_sender,
+                });
+
+                self.rithmic_sender
+                    .send(Message::Binary(req_buf.into()))
+                    .await
+                    .unwrap();
+            }
+            OrderPlantCommand::GetAccountRmsInfo { response_sender } => {
+                let (req_buf, id) = self.rithmic_sender_api.request_account_rms_info();
+
+                self.request_handler.register_request(RithmicRequest {
+                    request_id: id,
+                    responder: response_sender,
+                });
+
+                self.rithmic_sender
+                    .send(Message::Binary(req_buf.into()))
+                    .await
+                    .unwrap();
+            }
+            OrderPlantCommand::GetProductRmsInfo { response_sender } => {
+                let (req_buf, id) = self.rithmic_sender_api.request_product_rms_info();
+
+                self.request_handler.register_request(RithmicRequest {
+                    request_id: id,
+                    responder: response_sender,
+                });
+
+                self.rithmic_sender
+                    .send(Message::Binary(req_buf.into()))
+                    .await
+                    .unwrap();
+            }
+            OrderPlantCommand::GetTradeRoutes {
+                subscribe_for_updates,
+                response_sender,
+            } => {
+                let (req_buf, id) = self
+                    .rithmic_sender_api
+                    .request_trade_routes(subscribe_for_updates);
+
+                self.request_handler.register_request(RithmicRequest {
+                    request_id: id,
+                    responder: response_sender,
+                });
+
+                self.rithmic_sender
+                    .send(Message::Binary(req_buf.into()))
+                    .await
+                    .unwrap();
+            }
+            OrderPlantCommand::ShowOrderHistoryDates { response_sender } => {
+                let (req_buf, id) = self.rithmic_sender_api.request_show_order_history_dates();
+
+                self.request_handler.register_request(RithmicRequest {
+                    request_id: id,
+                    responder: response_sender,
+                });
+
+                self.rithmic_sender
+                    .send(Message::Binary(req_buf.into()))
+                    .await
+                    .unwrap();
+            }
+            OrderPlantCommand::ShowOrderHistorySummary {
+                date,
+                response_sender,
+            } => {
+                let (req_buf, id) = self
+                    .rithmic_sender_api
+                    .request_show_order_history_summary(&date);
+
+                self.request_handler.register_request(RithmicRequest {
+                    request_id: id,
+                    responder: response_sender,
+                });
+
+                self.rithmic_sender
+                    .send(Message::Binary(req_buf.into()))
+                    .await
+                    .unwrap();
+            }
+            OrderPlantCommand::ShowOrderHistoryDetail {
+                basket_id,
+                date,
+                response_sender,
+            } => {
+                let (req_buf, id) = self
+                    .rithmic_sender_api
+                    .request_show_order_history_detail(&basket_id, &date);
+
+                self.request_handler.register_request(RithmicRequest {
+                    request_id: id,
+                    responder: response_sender,
+                });
+
+                self.rithmic_sender
+                    .send(Message::Binary(req_buf.into()))
+                    .await
+                    .unwrap();
+            }
+            OrderPlantCommand::ShowOrderHistory {
+                basket_id,
+                response_sender,
+            } => {
+                let (req_buf, id) = self
+                    .rithmic_sender_api
+                    .request_show_order_history(basket_id.as_deref());
+
+                self.request_handler.register_request(RithmicRequest {
+                    request_id: id,
+                    responder: response_sender,
+                });
+
+                self.rithmic_sender
+                    .send(Message::Binary(req_buf.into()))
+                    .await
+                    .unwrap();
+            }
             _ => {}
         };
     }
@@ -1025,5 +1179,164 @@ impl RithmicOrderPlantHandle {
         };
 
         let _ = self.sender.send(command).await;
+    }
+
+    /// Cancel all open orders
+    ///
+    /// # Returns
+    /// The cancellation response or an error message
+    pub async fn cancel_all_orders(&self) -> Result<RithmicResponse, String> {
+        let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, String>>();
+
+        let command = OrderPlantCommand::CancelAllOrders {
+            response_sender: tx,
+        };
+
+        let _ = self.sender.send(command).await;
+
+        Ok(rx.await.unwrap().unwrap().remove(0))
+    }
+
+    /// Get account RMS (Risk Management System) information
+    ///
+    /// # Returns
+    /// The RMS info response or an error message
+    pub async fn get_account_rms_info(&self) -> Result<RithmicResponse, String> {
+        let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, String>>();
+
+        let command = OrderPlantCommand::GetAccountRmsInfo {
+            response_sender: tx,
+        };
+
+        let _ = self.sender.send(command).await;
+
+        Ok(rx.await.unwrap().unwrap().remove(0))
+    }
+
+    /// Get product RMS (Risk Management System) information
+    ///
+    /// # Returns
+    /// The product RMS info response or an error message
+    pub async fn get_product_rms_info(&self) -> Result<RithmicResponse, String> {
+        let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, String>>();
+
+        let command = OrderPlantCommand::GetProductRmsInfo {
+            response_sender: tx,
+        };
+
+        let _ = self.sender.send(command).await;
+
+        Ok(rx.await.unwrap().unwrap().remove(0))
+    }
+
+    /// Get available trade routes
+    ///
+    /// # Arguments
+    /// * `subscribe_for_updates` - Whether to receive updates when routes change
+    ///
+    /// # Returns
+    /// The list of trade routes or an error message
+    pub async fn get_trade_routes(
+        &self,
+        subscribe_for_updates: bool,
+    ) -> Result<Vec<RithmicResponse>, String> {
+        let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, String>>();
+
+        let command = OrderPlantCommand::GetTradeRoutes {
+            subscribe_for_updates,
+            response_sender: tx,
+        };
+
+        let _ = self.sender.send(command).await;
+
+        rx.await.unwrap()
+    }
+
+    /// Get dates for which order history is available
+    ///
+    /// # Returns
+    /// The list of available dates or an error message
+    pub async fn show_order_history_dates(&self) -> Result<Vec<RithmicResponse>, String> {
+        let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, String>>();
+
+        let command = OrderPlantCommand::ShowOrderHistoryDates {
+            response_sender: tx,
+        };
+
+        let _ = self.sender.send(command).await;
+
+        rx.await.unwrap()
+    }
+
+    /// Get order history summary for a specific date
+    ///
+    /// # Arguments
+    /// * `date` - Date in YYYYMMDD format (e.g., "20250122")
+    ///
+    /// # Returns
+    /// The list of order summaries or an error message
+    pub async fn show_order_history_summary(
+        &self,
+        date: &str,
+    ) -> Result<Vec<RithmicResponse>, String> {
+        let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, String>>();
+
+        let command = OrderPlantCommand::ShowOrderHistorySummary {
+            date: date.to_string(),
+            response_sender: tx,
+        };
+
+        let _ = self.sender.send(command).await;
+
+        rx.await.unwrap()
+    }
+
+    /// Get detailed order history for a specific order
+    ///
+    /// # Arguments
+    /// * `basket_id` - Order/basket identifier
+    /// * `date` - Date in YYYYMMDD format
+    ///
+    /// # Returns
+    /// The detailed order history response or an error message
+    pub async fn show_order_history_detail(
+        &self,
+        basket_id: &str,
+        date: &str,
+    ) -> Result<RithmicResponse, String> {
+        let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, String>>();
+
+        let command = OrderPlantCommand::ShowOrderHistoryDetail {
+            basket_id: basket_id.to_string(),
+            date: date.to_string(),
+            response_sender: tx,
+        };
+
+        let _ = self.sender.send(command).await;
+
+        Ok(rx.await.unwrap().unwrap().remove(0))
+    }
+
+    /// Get general order history
+    ///
+    /// # Arguments
+    /// * `basket_id` - Optional order/basket identifier filter
+    ///
+    /// # Returns
+    /// The list of order history entries or an error message
+    pub async fn show_order_history(
+        &self,
+        basket_id: Option<&str>,
+    ) -> Result<Vec<RithmicResponse>, String> {
+        let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, String>>();
+
+        let command = OrderPlantCommand::ShowOrderHistory {
+            basket_id: basket_id.map(|s| s.to_string()),
+            response_sender: tx,
+        };
+
+        let _ = self.sender.send(command).await;
+
+        rx.await.unwrap()
     }
 }

--- a/src/plants/ticker_plant.rs
+++ b/src/plants/ticker_plant.rs
@@ -15,6 +15,7 @@ use crate::{
         request_depth_by_order_updates,
         request_login::SysInfraType,
         request_market_data_update::{Request, UpdateBits},
+        request_search_symbols,
     },
     ws::{
         HEARTBEAT_SECS, HEARTBEAT_TIMEOUT_SECS, PlantActor, RithmicStream, connect_with_strategy,
@@ -75,6 +76,18 @@ pub enum TickerPlantCommand {
     RequestDepthByOrderSnapshot {
         symbol: String,
         exchange: String,
+        response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, String>>,
+    },
+    SearchSymbols {
+        search_text: String,
+        exchange: Option<String>,
+        product_code: Option<String>,
+        instrument_type: Option<request_search_symbols::InstrumentType>,
+        pattern: Option<request_search_symbols::Pattern>,
+        response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, String>>,
+    },
+    ListExchanges {
+        user: String,
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, String>>,
     },
 }
@@ -706,6 +719,48 @@ impl PlantActor for TickerPlant {
                     .await
                     .unwrap();
             }
+            TickerPlantCommand::SearchSymbols {
+                search_text,
+                exchange,
+                product_code,
+                instrument_type,
+                pattern,
+                response_sender,
+            } => {
+                let (search_buf, id) = self.rithmic_sender_api.request_search_symbols(
+                    &search_text,
+                    exchange.as_deref(),
+                    product_code.as_deref(),
+                    instrument_type,
+                    pattern,
+                );
+
+                self.request_handler.register_request(RithmicRequest {
+                    request_id: id,
+                    responder: response_sender,
+                });
+
+                self.rithmic_sender
+                    .send(Message::Binary(search_buf.into()))
+                    .await
+                    .unwrap();
+            }
+            TickerPlantCommand::ListExchanges {
+                user,
+                response_sender,
+            } => {
+                let (list_buf, id) = self.rithmic_sender_api.request_list_exchanges(&user);
+
+                self.request_handler.register_request(RithmicRequest {
+                    request_id: id,
+                    responder: response_sender,
+                });
+
+                self.rithmic_sender
+                    .send(Message::Binary(list_buf.into()))
+                    .await
+                    .unwrap();
+            }
         }
     }
 }
@@ -905,6 +960,61 @@ impl RithmicTickerPlantHandle {
         };
 
         let _ = self.sender.send(command).await;
+    }
+
+    /// Search for symbols based on search criteria
+    ///
+    /// # Arguments
+    /// * `search_text` - The text to search for in symbols
+    /// * `exchange` - Optional exchange filter
+    /// * `product_code` - Optional product code filter
+    /// * `instrument_type` - Optional instrument type filter
+    /// * `pattern` - Optional search pattern mode
+    ///
+    /// # Returns
+    /// A vector of responses containing matching symbols or an error message
+    pub async fn search_symbols(
+        &self,
+        search_text: &str,
+        exchange: Option<&str>,
+        product_code: Option<&str>,
+        instrument_type: Option<request_search_symbols::InstrumentType>,
+        pattern: Option<request_search_symbols::Pattern>,
+    ) -> Result<Vec<RithmicResponse>, String> {
+        let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, String>>();
+
+        let command = TickerPlantCommand::SearchSymbols {
+            search_text: search_text.to_string(),
+            exchange: exchange.map(|e| e.to_string()),
+            product_code: product_code.map(|p| p.to_string()),
+            instrument_type,
+            pattern,
+            response_sender: tx,
+        };
+
+        let _ = self.sender.send(command).await;
+
+        rx.await.unwrap()
+    }
+
+    /// List exchanges available to the specified user
+    ///
+    /// # Arguments
+    /// * `user` - The username to query exchange permissions for
+    ///
+    /// # Returns
+    /// A vector of responses containing exchange information or an error message
+    pub async fn list_exchanges(&self, user: &str) -> Result<Vec<RithmicResponse>, String> {
+        let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, String>>();
+
+        let command = TickerPlantCommand::ListExchanges {
+            user: user.to_string(),
+            response_sender: tx,
+        };
+
+        let _ = self.sender.send(command).await;
+
+        rx.await.unwrap()
     }
 }
 

--- a/src/rti/messages.rs
+++ b/src/rti/messages.rs
@@ -11,7 +11,7 @@ use super::{
     ResponseShowOrderHistoryDetail, ResponseShowOrderHistorySummary, ResponseShowOrders,
     ResponseSubscribeForOrderUpdates, ResponseSubscribeToBracketUpdates, ResponseTickBarReplay,
     ResponseTimeBarReplay, ResponseTradeRoutes, ResponseUpdateStopBracketLevel,
-    ResponseUpdateTargetBracketLevel, RithmicOrderNotification, TickBar, TimeBar,
+    ResponseUpdateTargetBracketLevel, RithmicOrderNotification, TickBar, TimeBar, TradeRoute,
 };
 
 #[allow(clippy::large_enum_variant)]
@@ -63,6 +63,7 @@ pub enum RithmicMessage {
     RithmicOrderNotification(RithmicOrderNotification),
     TickBar(TickBar),
     TimeBar(TimeBar),
+    TradeRoute(TradeRoute),
 
     /// WebSocket connection error.
     ///


### PR DESCRIPTION
## Summary
Release version 0.5.3 - API expansion with new order history, RMS info, symbol search, and trade routes functionality.

### New Features
- **Order Management**: `cancel_all_orders()` method to cancel all active orders
- **Order History**: Methods to query historical orders (`show_order_history_dates()`, `show_order_history_summary()`, `show_order_history_detail()`, `show_order_history()`)
- **Risk Management**: Methods to retrieve RMS information (`get_account_rms_info()`, `get_product_rms_info()`, `get_trade_routes()`)
- **Symbol Discovery**: `search_symbols()` method with flexible filtering options
- **Exchange Permissions**: `list_exchanges()` method to query available exchanges
- **Protocol Support**: New `TradeRoute` message type for template ID 310

### API Changes
- 10 new public methods across `RithmicOrderPlantHandle` and `RithmicTickerPlantHandle`
- 10 new request methods in `RithmicSenderApi`
- 8 new command variants in `OrderPlantCommand`
- 2 new command variants in `TickerPlantCommand`

### Known Issues
- New code contains `.unwrap()` calls that follow existing patterns but may panic on errors
- TradeRoute message handler uses `.unwrap()` on protobuf decode (receiver_api.rs:438)
- Plant handle methods use multiple `.unwrap()` calls on channel operations
- These should be addressed in future releases for improved robustness

## Test plan
- [ ] Verify version bump in Cargo.toml (0.5.2 → 0.5.3)
- [ ] Review CHANGELOG.md entries for accuracy and completeness
- [ ] Confirm all new methods are properly documented
- [ ] Check that existing tests pass
- [ ] Validate that new functionality follows existing patterns

Generated with [Claude Code](https://claude.com/claude-code)