### PR TITLE
Add WebSocket ping/pong connection health monitoring

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,7 @@ pub mod config;
 /// Deprecated connection information types (use `config` module instead)
 pub mod connection_info;
 mod heartbeat_manager;
+mod ping_manager;
 /// Plants for handling different types of market data and order interactions
 pub mod plants;
 mod request_handler;

--- a/src/ping_manager.rs
+++ b/src/ping_manager.rs
@@ -1,0 +1,76 @@
+use std::time::Duration;
+use tokio::time::Instant;
+use tracing::warn;
+
+/// Manages WebSocket ping/pong timeout detection for plant actors.
+///
+/// Tracks pending ping frames and detects when pong responses don't arrive within
+/// the configured timeout. Provides a secondary layer of connection health monitoring
+/// alongside application-level heartbeats.
+///
+/// # Behavior
+///
+/// - Tracks one pending ping at a time
+/// - New ping sent before pong received: replaces pending ping, logs warning
+/// - Any pong clears pending state (WebSocket protocol guarantees correlation)
+/// - Timeout indicates dead connection
+///
+/// # Configuration
+///
+/// Default: 60s ping interval, 50s pong timeout
+#[derive(Debug)]
+pub struct PingManager {
+    /// Pending ping waiting for pong response
+    pending: Option<Instant>,
+    /// Timeout duration
+    timeout: Duration,
+}
+
+impl PingManager {
+    /// Creates a new ping manager with the given timeout in seconds.
+    pub fn new(timeout_secs: u64) -> Self {
+        Self {
+            pending: None,
+            timeout: Duration::from_secs(timeout_secs),
+        }
+    }
+
+    /// Registers that a WebSocket ping was sent.
+    ///
+    /// If a ping is already pending, replaces it and logs a warning.
+    pub fn sent(&mut self) {
+        if self.pending.replace(Instant::now()).is_some() {
+            warn!("Sent new ping before receiving pong for previous ping");
+        }
+    }
+
+    /// Registers that a pong response was received.
+    ///
+    /// Clears pending state. WebSocket protocol guarantees pongs echo pings,
+    /// so any pong corresponds to our most recent ping.
+    pub fn received(&mut self) {
+        self.pending = None;
+    }
+
+    /// Checks if the pending ping has timed out.
+    ///
+    /// Returns `true` and clears pending state if timeout exceeded.
+    /// Call when the instant from `next_timeout_at()` is reached.
+    pub fn check_timeout(&mut self) -> bool {
+        if let Some(sent_at) = self.pending
+            && sent_at.elapsed() > self.timeout
+        {
+            self.pending = None;
+            return true;
+        }
+        false
+    }
+
+    /// Returns the instant when the pending ping will timeout, if any.
+    ///
+    /// Use with `tokio::time::sleep_until()` in a select! loop.
+    /// Returns `None` if no ping is pending.
+    pub fn next_timeout_at(&self) -> Option<Instant> {
+        self.pending.map(|sent_at| sent_at + self.timeout)
+    }
+}

--- a/src/plants/history_plant.rs
+++ b/src/plants/history_plant.rs
@@ -14,13 +14,14 @@ use crate::{
     },
     config::RithmicConfig,
     heartbeat_manager::HeartbeatManager,
+    ping_manager::PingManager,
     request_handler::{RithmicRequest, RithmicRequestHandler},
     rti::{
         messages::RithmicMessage, request_login::SysInfraType, request_time_bar_replay::BarType,
     },
     ws::{
-        HEARTBEAT_SECS, HEARTBEAT_TIMEOUT_SECS, PlantActor, RithmicStream, connect_with_strategy,
-        get_heartbeat_interval,
+        HEARTBEAT_SECS, HEARTBEAT_TIMEOUT_SECS, PING_TIMEOUT_SECS, PlantActor, RithmicStream,
+        connect_with_strategy, get_heartbeat_interval, get_ping_interval,
     },
 };
 
@@ -180,6 +181,7 @@ impl RithmicStream for RithmicHistoryPlant {
 pub struct HistoryPlant {
     config: RithmicConfig,
     interval: Interval,
+    ping_interval: Interval,
     logged_in: bool,
     /// Whether to enable connection health monitoring via heartbeat timeout detection.
     ///
@@ -190,6 +192,7 @@ pub struct HistoryPlant {
     /// Use this to verify the connection is still alive during critical trading periods.
     expect_heartbeat_response: bool,
     heartbeat_manager: HeartbeatManager,
+    ping_manager: PingManager,
     request_handler: RithmicRequestHandler,
     request_receiver: mpsc::Receiver<HistoryPlantCommand>,
     rithmic_reader: SplitStream<tokio_tungstenite::WebSocketStream<MaybeTlsStream<TcpStream>>>,
@@ -221,13 +224,17 @@ impl HistoryPlant {
 
         let interval = get_heartbeat_interval(None);
         let heartbeat_manager = HeartbeatManager::new(HEARTBEAT_TIMEOUT_SECS);
+        let ping_interval = get_ping_interval(None);
+        let ping_manager = PingManager::new(PING_TIMEOUT_SECS);
 
         Ok(HistoryPlant {
             config: config.clone(),
             interval,
+            ping_interval,
             logged_in: false,
             expect_heartbeat_response: false,
             heartbeat_manager,
+            ping_manager,
             request_handler: RithmicRequestHandler::new(),
             request_receiver,
             rithmic_reader,
@@ -251,6 +258,10 @@ impl PlantActor for HistoryPlant {
                     self.handle_command(HistoryPlantCommand::SendHeartbeat { expect_response: self.expect_heartbeat_response }).await;
                 }
               }
+              _ = self.ping_interval.tick() => {
+                self.ping_manager.sent();
+                let _ = self.rithmic_sender.send(Message::Ping(vec![].into())).await;
+              }
               _ = async {
                 if let Some(timeout_at) = self.heartbeat_manager.next_timeout_at() {
                     sleep_until(timeout_at).await
@@ -272,6 +283,29 @@ impl PlantActor for HistoryPlant {
                     };
 
                     let _ = self.subscription_sender.send(error_response);
+                }
+              }
+              _ = async {
+                if let Some(timeout_at) = self.ping_manager.next_timeout_at() {
+                    sleep_until(timeout_at).await
+                } else {
+                    std::future::pending::<()>().await
+                }
+              } => {
+                if self.ping_manager.check_timeout() {
+                    error!("WebSocket ping timed out - connection appears dead");
+
+                    let error_response = RithmicResponse {
+                        request_id: "websocket_ping_timeout".to_string(),
+                        message: RithmicMessage::HeartbeatTimeout,
+                        is_update: true,
+                        has_more: false,
+                        multi_response: false,
+                        error: Some("WebSocket ping timeout - connection dead".to_string()),
+                        source: self.rithmic_receiver_api.source.clone(),
+                    };
+                    let _ = self.subscription_sender.send(error_response);
+                    break;
                 }
               }
               Some(message) = self.request_receiver.recv() => {
@@ -299,6 +333,9 @@ impl PlantActor for HistoryPlant {
             Ok(Message::Close(frame)) => {
                 info!("history_plant: Received close frame: {:?}", frame);
                 stop = true;
+            }
+            Ok(Message::Pong(_)) => {
+                self.ping_manager.received();
             }
             Ok(Message::Binary(data)) => match self.rithmic_receiver_api.buf_to_message(data) {
                 Ok(response) => {

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -15,11 +15,12 @@ use crate::{
     },
     config::RithmicConfig,
     heartbeat_manager::HeartbeatManager,
+    ping_manager::PingManager,
     request_handler::{RithmicRequest, RithmicRequestHandler},
     rti::{messages::RithmicMessage, request_login::SysInfraType},
     ws::{
-        HEARTBEAT_SECS, HEARTBEAT_TIMEOUT_SECS, PlantActor, RithmicStream, connect_with_strategy,
-        get_heartbeat_interval,
+        HEARTBEAT_SECS, HEARTBEAT_TIMEOUT_SECS, PING_TIMEOUT_SECS, PlantActor, RithmicStream,
+        connect_with_strategy, get_heartbeat_interval, get_ping_interval,
     },
 };
 
@@ -279,6 +280,7 @@ impl RithmicStream for RithmicOrderPlant {
 pub struct OrderPlant {
     config: RithmicConfig,
     interval: Interval,
+    ping_interval: Interval,
     logged_in: bool,
     /// Whether to enable connection health monitoring via heartbeat timeout detection.
     ///
@@ -289,6 +291,7 @@ pub struct OrderPlant {
     /// Use this to verify the connection is still alive during critical trading periods.
     expect_heartbeat_response: bool,
     heartbeat_manager: HeartbeatManager,
+    ping_manager: PingManager,
     request_handler: RithmicRequestHandler,
     request_receiver: mpsc::Receiver<OrderPlantCommand>,
     rithmic_reader: SplitStream<tokio_tungstenite::WebSocketStream<MaybeTlsStream<TcpStream>>>,
@@ -319,13 +322,17 @@ impl OrderPlant {
 
         let interval = get_heartbeat_interval(None);
         let heartbeat_manager = HeartbeatManager::new(HEARTBEAT_TIMEOUT_SECS);
+        let ping_interval = get_ping_interval(None);
+        let ping_manager = PingManager::new(PING_TIMEOUT_SECS);
 
         Ok(OrderPlant {
             config: config.clone(),
             interval,
+            ping_interval,
             logged_in: false,
             expect_heartbeat_response: false,
             heartbeat_manager,
+            ping_manager,
             request_handler: RithmicRequestHandler::new(),
             request_receiver,
             rithmic_reader,
@@ -349,6 +356,10 @@ impl PlantActor for OrderPlant {
                         self.handle_command(OrderPlantCommand::SendHeartbeat { expect_response: self.expect_heartbeat_response }).await;
                     }
                 }
+                _ = self.ping_interval.tick() => {
+                    self.ping_manager.sent();
+                    let _ = self.rithmic_sender.send(Message::Ping(vec![].into())).await;
+                }
                 _ = async {
                     if let Some(timeout_at) = self.heartbeat_manager.next_timeout_at() {
                         sleep_until(timeout_at).await
@@ -369,6 +380,29 @@ impl PlantActor for OrderPlant {
                             source: self.rithmic_receiver_api.source.clone(),
                         };
                         let _ = self.subscription_sender.send(error_response);
+                    }
+                }
+                _ = async {
+                    if let Some(timeout_at) = self.ping_manager.next_timeout_at() {
+                        sleep_until(timeout_at).await
+                    } else {
+                        std::future::pending::<()>().await
+                    }
+                } => {
+                    if self.ping_manager.check_timeout() {
+                        error!("WebSocket ping timed out - connection appears dead");
+
+                        let error_response = RithmicResponse {
+                            request_id: "websocket_ping_timeout".to_string(),
+                            message: RithmicMessage::HeartbeatTimeout,
+                            is_update: true,
+                            has_more: false,
+                            multi_response: false,
+                            error: Some("WebSocket ping timeout - connection dead".to_string()),
+                            source: self.rithmic_receiver_api.source.clone(),
+                        };
+                        let _ = self.subscription_sender.send(error_response);
+                        break;
                     }
                 }
                 Some(message) = self.request_receiver.recv() => {
@@ -397,6 +431,9 @@ impl PlantActor for OrderPlant {
                 info!("order_plant: Received close frame: {:?}", frame);
 
                 stop = true;
+            }
+            Ok(Message::Pong(_)) => {
+                self.ping_manager.received();
             }
             Ok(Message::Binary(data)) => match self.rithmic_receiver_api.buf_to_message(data) {
                 Ok(response) => {

--- a/src/plants/pnl_plant.rs
+++ b/src/plants/pnl_plant.rs
@@ -9,11 +9,12 @@ use crate::{
     },
     config::RithmicConfig,
     heartbeat_manager::HeartbeatManager,
+    ping_manager::PingManager,
     request_handler::{RithmicRequest, RithmicRequestHandler},
     rti::{messages::RithmicMessage, request_login::SysInfraType, request_pn_l_position_updates},
     ws::{
-        HEARTBEAT_SECS, HEARTBEAT_TIMEOUT_SECS, PlantActor, RithmicStream, connect_with_strategy,
-        get_heartbeat_interval,
+        HEARTBEAT_SECS, HEARTBEAT_TIMEOUT_SECS, PING_TIMEOUT_SECS, PlantActor, RithmicStream,
+        connect_with_strategy, get_heartbeat_interval, get_ping_interval,
     },
 };
 
@@ -172,6 +173,7 @@ impl RithmicStream for RithmicPnlPlant {
 pub struct PnlPlant {
     config: RithmicConfig,
     interval: Interval,
+    ping_interval: Interval,
     logged_in: bool,
     /// Whether to enable connection health monitoring via heartbeat timeout detection.
     ///
@@ -182,6 +184,7 @@ pub struct PnlPlant {
     /// Use this to verify the connection is still alive during critical trading periods.
     expect_heartbeat_response: bool,
     heartbeat_manager: HeartbeatManager,
+    ping_manager: PingManager,
     request_handler: RithmicRequestHandler,
     request_receiver: mpsc::Receiver<PnlPlantCommand>,
     rithmic_reader: SplitStream<tokio_tungstenite::WebSocketStream<MaybeTlsStream<TcpStream>>>,
@@ -212,12 +215,16 @@ impl PnlPlant {
 
         let interval = get_heartbeat_interval(None);
         let heartbeat_manager = HeartbeatManager::new(HEARTBEAT_TIMEOUT_SECS);
+        let ping_interval = get_ping_interval(None);
+        let ping_manager = PingManager::new(PING_TIMEOUT_SECS);
 
         Ok(PnlPlant {
             config: config.clone(),
             interval,
+            ping_interval,
             logged_in: false,
             heartbeat_manager,
+            ping_manager,
             expect_heartbeat_response: false,
             request_handler: RithmicRequestHandler::new(),
             request_receiver,
@@ -242,6 +249,10 @@ impl PlantActor for PnlPlant {
                         self.handle_command(PnlPlantCommand::SendHeartbeat { expect_response: self.expect_heartbeat_response }).await;
                     }
                 }
+                _ = self.ping_interval.tick() => {
+                    self.ping_manager.sent();
+                    let _ = self.rithmic_sender.send(Message::Ping(vec![].into())).await;
+                }
                 _ = async {
                     if let Some(timeout_at) = self.heartbeat_manager.next_timeout_at() {
                         sleep_until(timeout_at).await
@@ -262,6 +273,29 @@ impl PlantActor for PnlPlant {
                             source: self.rithmic_receiver_api.source.clone(),
                         };
                         let _ = self.subscription_sender.send(error_response);
+                    }
+                }
+                _ = async {
+                    if let Some(timeout_at) = self.ping_manager.next_timeout_at() {
+                        sleep_until(timeout_at).await
+                    } else {
+                        std::future::pending::<()>().await
+                    }
+                } => {
+                    if self.ping_manager.check_timeout() {
+                        error!("WebSocket ping timed out - connection appears dead");
+
+                        let error_response = RithmicResponse {
+                            request_id: "websocket_ping_timeout".to_string(),
+                            message: RithmicMessage::HeartbeatTimeout,
+                            is_update: true,
+                            has_more: false,
+                            multi_response: false,
+                            error: Some("WebSocket ping timeout - connection dead".to_string()),
+                            source: self.rithmic_receiver_api.source.clone(),
+                        };
+                        let _ = self.subscription_sender.send(error_response);
+                        break;
                     }
                 }
                 Some(message) = self.request_receiver.recv() => {
@@ -289,6 +323,9 @@ impl PlantActor for PnlPlant {
             Ok(Message::Close(frame)) => {
                 info!("pnl_plant: Received close frame: {:?}", frame);
                 stop = true;
+            }
+            Ok(Message::Pong(_)) => {
+                self.ping_manager.received();
             }
             Ok(Message::Binary(data)) => match self.rithmic_receiver_api.buf_to_message(data) {
                 Ok(response) => {

--- a/src/plants/ticker_plant.rs
+++ b/src/plants/ticker_plant.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     config::RithmicConfig,
     heartbeat_manager::HeartbeatManager,
+    ping_manager::PingManager,
     request_handler::{RithmicRequest, RithmicRequestHandler},
     rti::{
         messages::RithmicMessage,
@@ -18,8 +19,8 @@ use crate::{
         request_search_symbols,
     },
     ws::{
-        HEARTBEAT_SECS, HEARTBEAT_TIMEOUT_SECS, PlantActor, RithmicStream, connect_with_strategy,
-        get_heartbeat_interval,
+        HEARTBEAT_SECS, HEARTBEAT_TIMEOUT_SECS, PING_TIMEOUT_SECS, PlantActor, RithmicStream,
+        connect_with_strategy, get_heartbeat_interval, get_ping_interval,
     },
 };
 
@@ -314,6 +315,7 @@ impl RithmicStream for RithmicTickerPlant {
 pub struct TickerPlant {
     config: RithmicConfig,
     interval: Interval,
+    ping_interval: Interval,
     logged_in: bool,
     /// Whether to enable connection health monitoring via heartbeat timeout detection.
     ///
@@ -324,6 +326,7 @@ pub struct TickerPlant {
     /// Use this to verify the connection is still alive during critical trading periods.
     expect_heartbeat_response: bool,
     heartbeat_manager: HeartbeatManager,
+    ping_manager: PingManager,
     request_handler: RithmicRequestHandler,
     request_receiver: mpsc::Receiver<TickerPlantCommand>,
     rithmic_reader: SplitStream<tokio_tungstenite::WebSocketStream<MaybeTlsStream<TcpStream>>>,
@@ -355,13 +358,17 @@ impl TickerPlant {
 
         let interval = get_heartbeat_interval(None);
         let heartbeat_manager = HeartbeatManager::new(HEARTBEAT_TIMEOUT_SECS);
+        let ping_interval = get_ping_interval(None);
+        let ping_manager = PingManager::new(PING_TIMEOUT_SECS);
 
         Ok(TickerPlant {
             config: config.clone(),
             interval,
+            ping_interval,
             logged_in: false,
             expect_heartbeat_response: false,
             heartbeat_manager,
+            ping_manager,
             request_handler: RithmicRequestHandler::new(),
             request_receiver,
             rithmic_reader,
@@ -389,6 +396,10 @@ impl PlantActor for TickerPlant {
                         self.handle_command(TickerPlantCommand::SendHeartbeat { expect_response: self.expect_heartbeat_response }).await;
                     }
                 }
+                _ = self.ping_interval.tick() => {
+                    self.ping_manager.sent();
+                    let _ = self.rithmic_sender.send(Message::Ping(vec![].into())).await;
+                }
                 _ = async {
                     if let Some(timeout_at) = self.heartbeat_manager.next_timeout_at() {
                         sleep_until(timeout_at).await
@@ -409,6 +420,29 @@ impl PlantActor for TickerPlant {
                             source: self.rithmic_receiver_api.source.clone(),
                         };
                         let _ = self.subscription_sender.send(error_response);
+                    }
+                }
+                _ = async {
+                    if let Some(timeout_at) = self.ping_manager.next_timeout_at() {
+                        sleep_until(timeout_at).await
+                    } else {
+                        std::future::pending::<()>().await
+                    }
+                } => {
+                    if self.ping_manager.check_timeout() {
+                        error!("WebSocket ping timed out - connection appears dead");
+
+                        let error_response = RithmicResponse {
+                            request_id: "websocket_ping_timeout".to_string(),
+                            message: RithmicMessage::HeartbeatTimeout,
+                            is_update: true,
+                            has_more: false,
+                            multi_response: false,
+                            error: Some("WebSocket ping timeout - connection dead".to_string()),
+                            source: self.rithmic_receiver_api.source.clone(),
+                        };
+                        let _ = self.subscription_sender.send(error_response);
+                        break;
                     }
                 }
                 Some(message) = self.request_receiver.recv() => {
@@ -437,6 +471,9 @@ impl PlantActor for TickerPlant {
                 info!("ticker_plant received close frame: {:?}", frame);
 
                 stop = true;
+            }
+            Ok(Message::Pong(_)) => {
+                self.ping_manager.received();
             }
             Ok(Message::Binary(data)) => match self.rithmic_receiver_api.buf_to_message(data) {
                 Ok(response) => {

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -18,6 +18,12 @@ pub const HEARTBEAT_SECS: u64 = 60;
 /// Timeout in seconds for heartbeat response when expecting a reply.
 pub const HEARTBEAT_TIMEOUT_SECS: u64 = 30;
 
+/// Number of seconds between WebSocket ping frames sent to detect dead connections.
+pub const PING_INTERVAL_SECS: u64 = 60;
+
+/// Timeout in seconds for WebSocket pong response.
+pub const PING_TIMEOUT_SECS: u64 = 50;
+
 /// Connection attempt timeout in seconds.
 const CONNECT_TIMEOUT_SECS: u64 = 2;
 
@@ -61,6 +67,17 @@ pub fn get_heartbeat_interval(override_secs: Option<u64>) -> Interval {
     let start_offset = Instant::now() + heartbeat_interval;
 
     interval_at(start_offset, heartbeat_interval)
+}
+
+/// Creates an interval for sending WebSocket pings.
+///
+/// Returns an interval starting after the first ping period elapses.
+pub fn get_ping_interval(override_secs: Option<u64>) -> Interval {
+    let secs = override_secs.unwrap_or(PING_INTERVAL_SECS);
+    let ping_interval = Duration::from_secs(secs);
+    let start_offset = Instant::now() + ping_interval;
+
+    interval_at(start_offset, ping_interval)
 }
 
 /// Connect to a single URL without retry.


### PR DESCRIPTION
## Summary

Implements dual-layer connection health monitoring with WebSocket ping/pong as the primary dead connection detector, complementing the existing application-level heartbeat system.

## Changes

- **New module**: `ping_manager` - Minimal state tracker for WebSocket ping/pong timeouts
- **All plants updated**: Integrated ping/pong monitoring into ticker, history, order, and pnl plants
- **Constants**: Added `PING_INTERVAL_SECS` (60s) and `PING_TIMEOUT_SECS` (50s) to `ws.rs`
- **Helper function**: `get_ping_interval()` for consistent interval creation

## Implementation Highlights

✅ **Minimal & Elegant**
- State: `Option<Instant>` + `Duration` (24 bytes)
- Zero allocations in hot path
- No ID tracking or payload parsing needed

✅ **Trusts the Protocol**
- Empty ping payload (standard practice)
- tokio-tungstenite auto-responds to incoming pings
- Any pong clears pending state (WebSocket protocol guarantees correlation)

✅ **Robust Monitoring**
- Timeout triggers error response and actor loop exit (forces reconnection)
- Warns if new ping sent before previous pong received (high latency indicator)
- Integrates cleanly with existing tokio select! loops

## Testing

- ✅ Builds successfully
- ✅ Zero clippy warnings in new code
- ✅ All existing tests pass
- ✅ Consistent implementation across all four plants

## Why This Approach

The WebSocket ping/pong mechanism provides **faster dead connection detection** than application-level heartbeats alone. The 60s/50s timing provides a 10-second detection window while avoiding false positives from transient network delays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)