### PR TITLE
Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-01-08
+
 ### Breaking Changes
 
 #### Order Types Now Use Enums Instead of Raw Integers
@@ -522,6 +524,7 @@ Previous stable release. See git history for earlier changes.
 
 ## Version History Summary
 
+- **0.7.0** (2026-01-08): Breaking changes - Order types now use enums instead of raw integers, cleaner public API exports
 - **0.6.2** (2025-12-20): Expanded plant handle APIs, additional message types, OCO order support, and new sender methods
 - **0.6.1** (2025-11-24): Environment-specific configuration variables
 - **0.6.0** (2025-11-23): Major breaking changes - Removed deprecated code, simplified heartbeat handling, updated to dotenvy
@@ -531,7 +534,8 @@ Previous stable release. See git history for earlier changes.
 - **0.5.0** (2025-11-16): Major stability and API improvements - Connection strategies, unified config, panic fixes, connection health monitoring
 - **0.4.2** (2025-11-15): Previous stable release
 
-[Unreleased]: https://github.com/pbeets/rithmic-rs/compare/v0.6.2...HEAD
+[Unreleased]: https://github.com/pbeets/rithmic-rs/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/pbeets/rithmic-rs/compare/v0.6.2...v0.7.0
 [0.6.2]: https://github.com/pbeets/rithmic-rs/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/pbeets/rithmic-rs/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/pbeets/rithmic-rs/compare/v0.5.3...v0.6.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rithmic-rs"
-version = "0.6.2"
+version = "0.7.0"
 description = "Rust client for the Rithmic R | Protocol API to build algo trading systems"
 license = "MIT OR Apache-2.0"
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rithmic-rs = "0.6.2"
+rithmic-rs = "0.7.0"
 ```
 
 Set your environment variables:
@@ -56,7 +56,7 @@ See [`examples/`](examples/) for more usage patterns including [reconnection han
 
 ## Architecture
 
-This library uses the **actor pattern** where each Rithmic service (called a "plant") runs as an independent async task, communicating via tokio channels. Connect only to what you need, run them on separate tasks, and reconnect individually.
+This library uses the actor pattern where each Rithmic service runs independently in its own thread. All communication happens through tokio channels.
 
 - **`RithmicTickerPlant`** - Real-time market data (trades, quotes, order book)
 - **`RithmicOrderPlant`** - Order entry and management


### PR DESCRIPTION
## Summary
- Bump version to 0.7.0 in Cargo.toml and README.md
- Update CHANGELOG with 0.7.0 release date (2026-01-08) and version links

## Changes in 0.7.0
- **Breaking**: Order types now use enums instead of raw integers (`BracketTransactionType`, `BracketPriceType`, `BracketDuration`, `ModifyPriceType`)
- Cleaner public API with all order types re-exported from crate root
- Improved documentation and reorganized examples

## Test plan
- [x] `cargo check` passes
- [ ] Verify crates.io publish after merge