### PR TITLE
feat: Add RithmicOrder API with trigger prices and trailing stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### New Order API
+- **`RithmicOrder`**: New struct for placing standalone orders with advanced features
+  - Supports trigger prices for stop orders (StopLimit, StopMarket)
+  - Supports trailing stops via `TrailingStop` configuration
+  - Ergonomic API using `Default` trait for optional fields
+  - Comprehensive documentation with examples
+- **`TrailingStop`**: Configuration struct for trailing stop orders
+  - `trail_by_ticks`: Number of ticks to trail behind market price
+- **`place_order(RithmicOrder)`**: New method on `RithmicOrderPlantHandle`
+  - Preferred method for placing standalone orders
+  - Supports all order types including stop orders and trailing stops
+
+#### Ticker Plant Unsubscribe Methods
+- **`unsubscribe(symbol, exchange)`**: Unsubscribe from market data for a symbol
+- **`unsubscribe_order_book(symbol, exchange)`**: Unsubscribe from order book depth-by-order updates
+
+### Deprecated
+- **`place_new_order()`**: Use `place_order(RithmicOrder)` instead
+  - The new API supports trigger prices and trailing stops
+  - Marked with `#[deprecated(since = "0.7.2")]`
+
 ## [0.7.1] - 2026-01-23
 
 ### Added

--- a/src/api.rs
+++ b/src/api.rs
@@ -21,8 +21,10 @@ pub(crate) mod sender_api;
 
 // Re-export commonly used types
 pub use receiver_api::RithmicResponse;
+
 pub use rithmic_command_types::{
-    RithmicBracketOrder, RithmicCancelOrder, RithmicModifyOrder, RithmicOcoOrderLeg,
+    RithmicBracketOrder, RithmicCancelOrder, RithmicModifyOrder, RithmicOcoOrderLeg, RithmicOrder,
+    TrailingStop,
 };
 
 // Re-export bracket order enums

--- a/src/api/rithmic_command_types.rs
+++ b/src/api/rithmic_command_types.rs
@@ -1,4 +1,6 @@
-use crate::rti::{request_bracket_order, request_modify_order, request_oco_order};
+use crate::rti::{
+    request_bracket_order, request_modify_order, request_new_order, request_oco_order,
+};
 
 /// One leg of an OCO (One-Cancels-Other) order pair.
 ///
@@ -151,4 +153,126 @@ pub struct RithmicModifyOrder {
 pub struct RithmicCancelOrder {
     /// The `basket_id` from the order notification
     pub id: String,
+}
+
+/// Configuration for trailing stop orders.
+///
+/// When a trailing stop is configured, the stop price follows the market
+/// by the specified number of ticks.
+///
+/// # Example
+///
+/// ```ignore
+/// use rithmic_rs::TrailingStop;
+///
+/// let trailing = TrailingStop { trail_by_ticks: 20 };
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct TrailingStop {
+    /// Number of ticks to trail behind the market price
+    pub trail_by_ticks: i32,
+}
+
+/// A standalone order (not a bracket order).
+///
+/// Use this struct with `RithmicOrderPlantHandle::place_order()` to submit
+/// orders with advanced features like trigger prices and trailing stops.
+///
+/// For orders with automatic profit targets and stop losses, use
+/// [`RithmicBracketOrder`] instead.
+///
+/// # Example: Simple Limit Order
+///
+/// ```ignore
+/// use rithmic_rs::{RithmicOrder, NewOrderTransactionType, NewOrderPriceType};
+///
+/// let order = RithmicOrder {
+///     symbol: "ESM5".to_string(),
+///     exchange: "CME".to_string(),
+///     quantity: 1,
+///     price: 5000.0,
+///     transaction_type: NewOrderTransactionType::Buy,
+///     price_type: NewOrderPriceType::Limit,
+///     user_tag: "my-order-1".to_string(),
+///     ..Default::default()
+/// };
+/// handle.place_order(order).await?;
+/// ```
+///
+/// # Example: Stop-Limit Order with Trigger Price
+///
+/// ```ignore
+/// use rithmic_rs::{RithmicOrder, NewOrderTransactionType, NewOrderPriceType};
+///
+/// let order = RithmicOrder {
+///     symbol: "ESM5".to_string(),
+///     exchange: "CME".to_string(),
+///     quantity: 1,
+///     price: 4980.0,                // Limit price after trigger
+///     trigger_price: Some(4985.0),  // Stop triggers at this price
+///     transaction_type: NewOrderTransactionType::Sell,
+///     price_type: NewOrderPriceType::StopLimit,
+///     user_tag: "stop-order".to_string(),
+///     ..Default::default()
+/// };
+/// ```
+///
+/// # Example: Trailing Stop Order
+///
+/// ```ignore
+/// use rithmic_rs::{RithmicOrder, NewOrderTransactionType, NewOrderPriceType, TrailingStop};
+///
+/// let order = RithmicOrder {
+///     symbol: "ESM5".to_string(),
+///     exchange: "CME".to_string(),
+///     quantity: 1,
+///     price: 0.0,  // Not used for trailing stops
+///     transaction_type: NewOrderTransactionType::Sell,
+///     price_type: NewOrderPriceType::StopMarket,
+///     trailing_stop: Some(TrailingStop { trail_by_ticks: 20 }),
+///     user_tag: "trailing-stop".to_string(),
+///     ..Default::default()
+/// };
+/// ```
+#[derive(Debug, Clone)]
+pub struct RithmicOrder {
+    /// Trading symbol (e.g., "ESM5")
+    pub symbol: String,
+    /// Exchange code (e.g., "CME")
+    pub exchange: String,
+    /// Number of contracts
+    pub quantity: i32,
+    /// Order price (ignored for market orders)
+    pub price: f64,
+    /// Buy or Sell
+    pub transaction_type: request_new_order::TransactionType,
+    /// Order type (Limit, Market, StopLimit, StopMarket, etc.)
+    pub price_type: request_new_order::PriceType,
+    /// Your identifier for tracking this order
+    pub user_tag: String,
+    /// Order duration (defaults to Day if None)
+    pub duration: Option<request_new_order::Duration>,
+    /// Trigger price for stop orders (StopLimit, StopMarket, etc.)
+    ///
+    /// Required for stop orders; ignored for limit/market orders.
+    pub trigger_price: Option<f64>,
+    /// Trailing stop configuration
+    pub trailing_stop: Option<TrailingStop>,
+}
+
+impl Default for RithmicOrder {
+    fn default() -> Self {
+        Self {
+            symbol: String::new(),
+            exchange: String::new(),
+            quantity: 0,
+            price: 0.0,
+            transaction_type: request_new_order::TransactionType::Buy,
+            price_type: request_new_order::PriceType::Limit,
+            user_tag: String::new(),
+            duration: None,
+            trigger_price: None,
+            trailing_stop: None,
+        }
+    }
 }

--- a/src/api/sender_api.rs
+++ b/src/api/sender_api.rs
@@ -1,4 +1,4 @@
-use super::rithmic_command_types::{RithmicBracketOrder, RithmicOcoOrderLeg};
+use super::rithmic_command_types::{RithmicBracketOrder, RithmicOcoOrderLeg, RithmicOrder};
 use prost::Message;
 
 use crate::{
@@ -479,6 +479,49 @@ impl RithmicSenderApi {
             },
             user_msg: vec![id.clone()],
             user_tag: Some(localid.into()),
+            ..RequestNewOrder::default()
+        };
+
+        self.request_to_buf(req, id)
+    }
+
+    /// Send a new order request using [`RithmicOrder`].
+    ///
+    /// This is the preferred method for placing orders as it supports
+    /// advanced features like trigger prices and trailing stops.
+    ///
+    /// # Arguments
+    /// * `order` - The order parameters
+    ///
+    /// # Returns
+    /// A tuple of (serialized request buffer, request ID)
+    pub fn request_order(&mut self, order: &RithmicOrder) -> (Vec<u8>, String) {
+        let id = self.get_next_message_id();
+
+        let trade_route = match self.env {
+            RithmicEnv::Live => TRADE_ROUTE_LIVE,
+            RithmicEnv::Demo | RithmicEnv::Test => TRADE_ROUTE_DEMO,
+        };
+
+        let req = RequestNewOrder {
+            template_id: 312,
+            fcm_id: Some(self.fcm_id.clone()),
+            ib_id: Some(self.ib_id.clone()),
+            account_id: Some(self.account_id.clone()),
+            trade_route: Some(trade_route.into()),
+            exchange: Some(order.exchange.clone()),
+            symbol: Some(order.symbol.clone()),
+            quantity: Some(order.quantity),
+            price: Some(order.price),
+            transaction_type: Some(order.transaction_type.into()),
+            price_type: Some(order.price_type.into()),
+            manual_or_auto: Some(2),
+            duration: order.duration.map(|d| d.into()).or(Some(1)),
+            user_msg: vec![id.clone()],
+            user_tag: Some(order.user_tag.clone()),
+            trigger_price: order.trigger_price,
+            trailing_stop: order.trailing_stop.as_ref().map(|_| true),
+            trail_by_ticks: order.trailing_stop.as_ref().map(|ts| ts.trail_by_ticks),
             ..RequestNewOrder::default()
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ pub use api::{
     BracketDuration, BracketPriceType, BracketTransactionType, EasyToBorrowRequest,
     ModifyPriceType, NewOrderDuration, NewOrderPriceType, NewOrderTransactionType, OcoDuration,
     OcoPriceType, OcoTransactionType, RithmicBracketOrder, RithmicCancelOrder, RithmicModifyOrder,
-    RithmicOcoOrderLeg, RithmicResponse,
+    RithmicOcoOrderLeg, RithmicOrder, RithmicResponse, TrailingStop,
 };
 
 // Re-export utility types for convenience

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -12,6 +12,7 @@ use crate::{
         receiver_api::{RithmicReceiverApi, RithmicResponse},
         rithmic_command_types::{
             RithmicBracketOrder, RithmicCancelOrder, RithmicModifyOrder, RithmicOcoOrderLeg,
+            RithmicOrder,
         },
         sender_api::RithmicSenderApi,
     },
@@ -129,6 +130,10 @@ pub(crate) enum OrderPlantCommand {
         ordertype: request_new_order::PriceType,
         localid: String,
         duration: Option<request_new_order::Duration>,
+        response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, String>>,
+    },
+    PlaceOrder {
+        order: RithmicOrder,
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, String>>,
     },
     PlaceOcoOrder {
@@ -1000,6 +1005,22 @@ impl PlantActor for OrderPlant {
                     .await
                     .unwrap();
             }
+            OrderPlantCommand::PlaceOrder {
+                order,
+                response_sender,
+            } => {
+                let (req_buf, id) = self.rithmic_sender_api.request_order(&order);
+
+                self.request_handler.register_request(RithmicRequest {
+                    request_id: id,
+                    responder: response_sender,
+                });
+
+                self.rithmic_sender
+                    .send(Message::Binary(req_buf.into()))
+                    .await
+                    .unwrap();
+            }
             OrderPlantCommand::PlaceOcoOrder {
                 order1,
                 order2,
@@ -1740,6 +1761,10 @@ impl RithmicOrderPlantHandle {
 
     /// Place a new single order (without brackets)
     ///
+    /// # Deprecated
+    /// Use [`place_order`](Self::place_order) instead, which accepts a [`RithmicOrder`]
+    /// struct and supports trigger prices and trailing stops.
+    ///
     /// # Arguments
     /// * `exchange` - The exchange code (e.g., "CME")
     /// * `symbol` - The trading symbol (e.g., "ESM1")
@@ -1752,6 +1777,7 @@ impl RithmicOrderPlantHandle {
     ///
     /// # Returns
     /// A vector of order placement responses or an error message
+    #[deprecated(since = "0.7.2", note = "Use place_order(RithmicOrder) instead")]
     #[allow(clippy::too_many_arguments)]
     pub async fn place_new_order(
         &self,
@@ -1775,6 +1801,51 @@ impl RithmicOrderPlantHandle {
             ordertype,
             localid: localid.to_string(),
             duration,
+            response_sender: tx,
+        };
+
+        let _ = self.sender.send(command).await;
+
+        rx.await.map_err(|_| "Connection closed".to_string())?
+    }
+
+    /// Place a new order using [`RithmicOrder`]
+    ///
+    /// This is the preferred method for placing standalone orders. It supports
+    /// all order types including those with trigger prices (stop orders) and
+    /// trailing stops.
+    ///
+    /// For orders with automatic profit targets and stop losses, use
+    /// [`place_bracket_order`](Self::place_bracket_order) instead.
+    ///
+    /// # Arguments
+    /// * `order` - The order parameters
+    ///
+    /// # Returns
+    /// A vector of order placement responses or an error message
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use rithmic_rs::{RithmicOrder, NewOrderTransactionType, NewOrderPriceType};
+    ///
+    /// let order = RithmicOrder {
+    ///     symbol: "ESM5".to_string(),
+    ///     exchange: "CME".to_string(),
+    ///     quantity: 1,
+    ///     price: 5000.0,
+    ///     transaction_type: NewOrderTransactionType::Buy,
+    ///     price_type: NewOrderPriceType::Limit,
+    ///     user_tag: "my-order".to_string(),
+    ///     ..Default::default()
+    /// };
+    /// handle.place_order(order).await?;
+    /// ```
+    pub async fn place_order(&self, order: RithmicOrder) -> Result<Vec<RithmicResponse>, String> {
+        let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, String>>();
+
+        let command = OrderPlantCommand::PlaceOrder {
+            order,
             response_sender: tx,
         };
 

--- a/src/plants/ticker_plant.rs
+++ b/src/plants/ticker_plant.rs
@@ -1086,6 +1086,67 @@ impl RithmicTickerPlantHandle {
             .remove(0))
     }
 
+    /// Unsubscribe from market data for a specific symbol
+    ///
+    /// # Arguments
+    /// * `symbol` - The trading symbol (e.g., "ESM1")
+    /// * `exchange` - The exchange code (e.g., "CME")
+    ///
+    /// # Returns
+    /// The unsubscription response or an error message
+    pub async fn unsubscribe(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, String> {
+        let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, String>>();
+
+        let command = TickerPlantCommand::Subscribe {
+            symbol: symbol.to_string(),
+            exchange: exchange.to_string(),
+            fields: vec![UpdateBits::LastTrade, UpdateBits::Bbo],
+            request_type: Request::Unsubscribe,
+            response_sender: tx,
+        };
+
+        let _ = self.sender.send(command).await;
+
+        Ok(rx
+            .await
+            .map_err(|_| "Connection closed".to_string())??
+            .remove(0))
+    }
+
+    /// Unsubscribe from order book depth-by-order updates for a specific symbol
+    ///
+    /// # Arguments
+    /// * `symbol` - The trading symbol (e.g., "ESM1")
+    /// * `exchange` - The exchange code (e.g., "CME")
+    ///
+    /// # Returns
+    /// The unsubscription response or an error message
+    pub async fn unsubscribe_order_book(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, String> {
+        let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, String>>();
+
+        let command = TickerPlantCommand::SubscribeOrderBook {
+            symbol: symbol.to_string(),
+            exchange: exchange.to_string(),
+            request_type: request_depth_by_order_updates::Request::Unsubscribe,
+            response_sender: tx,
+        };
+
+        let _ = self.sender.send(command).await;
+
+        Ok(rx
+            .await
+            .map_err(|_| "Connection closed".to_string())??
+            .remove(0))
+    }
+
     /// Request a snapshot of the order book depth-by-order for a specific symbol
     ///
     /// # Arguments


### PR DESCRIPTION
## Summary

- Adds `RithmicOrder` struct for placing standalone orders with advanced features (trigger prices, trailing stops)
- Adds `TrailingStop` configuration struct for trailing stop orders
- Adds `place_order(RithmicOrder)` method as the new preferred order placement API
- Adds `unsubscribe()` and `unsubscribe_order_book()` methods to ticker plant
- Deprecates `place_new_order()` in favor of the new API

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` - no changes needed
- [x] `cargo test` - all 40 tests pass
- [x] `cargo doc --no-deps` - no warnings