### PR TITLE
[codex] Expose full raw bracket-order request fields

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -24,13 +24,14 @@ pub use crate::config::RithmicAccount;
 pub use receiver_api::RithmicResponse;
 
 pub use rithmic_command_types::{
-    LoginConfig, RithmicBracketOrder, RithmicCancelOrder, RithmicModifyOrder, RithmicOcoOrderLeg,
-    RithmicOrder, TrailingStop,
+    LoginConfig, RithmicAdvancedBracketOrder, RithmicBracketOrder, RithmicCancelOrder,
+    RithmicIfTouchedTrigger, RithmicModifyOrder, RithmicOcoOrderLeg, RithmicOrder, TrailingStop,
 };
 
 // Re-export bracket order enums
 pub use crate::rti::request_bracket_order::{
-    Duration as BracketDuration, PriceType as BracketPriceType,
+    BracketType, Condition as BracketCondition, Duration as BracketDuration,
+    PriceField as BracketPriceField, PriceType as BracketPriceType,
     TransactionType as BracketTransactionType,
 };
 

--- a/src/api/rithmic_command_types.rs
+++ b/src/api/rithmic_command_types.rs
@@ -217,6 +217,7 @@ pub struct RithmicIfTouchedTrigger {
 ///     ..Default::default()
 /// };
 /// ```
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct RithmicAdvancedBracketOrder {
     /// Buy or Sell.
@@ -233,13 +234,17 @@ pub struct RithmicAdvancedBracketOrder {
     pub price: Option<f64>,
     /// Trigger price for stop and if-touched entry types.
     pub trigger_price: Option<f64>,
-    /// Number of contracts.
+    /// Entry order size (number of contracts).
+    ///
+    /// For a coherent bracket, this should equal the sum of
+    /// `target_quantity` across all target legs. The crate does not validate
+    /// this invariant; Rithmic rejects inconsistent combinations.
     pub quantity: i32,
     /// Trading symbol (e.g., "ESH6").
     pub symbol: String,
     /// Rithmic bracket shape.
     pub bracket_type: request_bracket_order::BracketType,
-    /// Exit target quantities.
+    /// Exit target quantities, one value per target leg.
     pub target_quantity: Vec<i32>,
     /// Exit target distances in ticks.
     pub target_ticks: Vec<i32>,

--- a/src/api/rithmic_command_types.rs
+++ b/src/api/rithmic_command_types.rs
@@ -135,6 +135,230 @@ pub struct RithmicBracketOrder {
     pub symbol: String,
 }
 
+/// Conditional trigger for advanced bracket order entry.
+///
+/// This maps directly to the `if_touched_*` fields on `RequestBracketOrder`.
+///
+/// # Example
+///
+/// ```ignore
+/// use rithmic_rs::{BracketCondition, BracketPriceField, RithmicIfTouchedTrigger};
+///
+/// let trigger = RithmicIfTouchedTrigger {
+///     symbol: "NQM6".to_string(),
+///     exchange: "CME".to_string(),
+///     condition: BracketCondition::GreaterThanEqualTo,
+///     price_field: BracketPriceField::TradePrice,
+///     price: 18250.5,
+/// };
+/// ```
+#[derive(Debug, Clone)]
+pub struct RithmicIfTouchedTrigger {
+    /// Trading symbol to monitor for the condition.
+    pub symbol: String,
+    /// Exchange for the monitored symbol.
+    pub exchange: String,
+    /// Comparison operator for the trigger.
+    pub condition: request_bracket_order::Condition,
+    /// Price field to evaluate.
+    pub price_field: request_bracket_order::PriceField,
+    /// Threshold price for the condition.
+    pub price: f64,
+}
+
+/// Richer bracket order request that maps directly to `RequestBracketOrder`.
+///
+/// This type exposes the full raw venue-native request surface currently
+/// available through the protobuf schema, including triggered entry, break-even,
+/// trailing-stop, timed release/cancel fields, and if-touched entry conditions.
+///
+/// Callers are responsible for providing a coherent combination of
+/// `bracket_type`, `target_*`, and `stop_*` fields for the shape they want
+/// Rithmic to create.
+///
+/// # Example
+///
+/// ```ignore
+/// use rithmic_rs::{
+///     BracketCondition, BracketDuration, BracketPriceField, BracketPriceType,
+///     BracketTransactionType, BracketType, RithmicAdvancedBracketOrder,
+///     RithmicIfTouchedTrigger,
+/// };
+///
+/// let order = RithmicAdvancedBracketOrder {
+///     action: BracketTransactionType::Buy,
+///     duration: BracketDuration::Gtc,
+///     exchange: "CME".to_string(),
+///     localid: "advanced-bracket-1".to_string(),
+///     price_type: BracketPriceType::StopLimit,
+///     price: Some(5000.25),
+///     trigger_price: Some(4999.75),
+///     quantity: 3,
+///     symbol: "ESM6".to_string(),
+///     bracket_type: BracketType::TargetAndStop,
+///     target_quantity: vec![2, 1],
+///     target_ticks: vec![16, 24],
+///     stop_quantity: vec![3],
+///     stop_ticks: vec![8],
+///     if_touched: Some(RithmicIfTouchedTrigger {
+///         symbol: "NQM6".to_string(),
+///         exchange: "CME".to_string(),
+///         condition: BracketCondition::GreaterThanEqualTo,
+///         price_field: BracketPriceField::TradePrice,
+///         price: 18250.5,
+///     }),
+///     break_even_ticks: Some(2),
+///     break_even_trigger_ticks: Some(10),
+///     trailing_stop_trigger_ticks: Some(12),
+///     target_market_order_if_touched: Some(true),
+///     stop_market_on_reject: Some(true),
+///     release_at_ssboe: Some(35900),
+///     cancel_after_secs: Some(120),
+///     ..Default::default()
+/// };
+/// ```
+#[derive(Debug, Clone)]
+pub struct RithmicAdvancedBracketOrder {
+    /// Buy or Sell.
+    pub action: request_bracket_order::TransactionType,
+    /// Order duration.
+    pub duration: request_bracket_order::Duration,
+    /// Exchange code (e.g., "CME").
+    pub exchange: String,
+    /// Your identifier for tracking this order.
+    pub localid: String,
+    /// Order type.
+    pub price_type: request_bracket_order::PriceType,
+    /// Entry price when required by the price type.
+    pub price: Option<f64>,
+    /// Trigger price for stop and if-touched entry types.
+    pub trigger_price: Option<f64>,
+    /// Number of contracts.
+    pub quantity: i32,
+    /// Trading symbol (e.g., "ESH6").
+    pub symbol: String,
+    /// Rithmic bracket shape.
+    pub bracket_type: request_bracket_order::BracketType,
+    /// Exit target quantities.
+    pub target_quantity: Vec<i32>,
+    /// Exit target distances in ticks.
+    pub target_ticks: Vec<i32>,
+    /// Exit stop quantities.
+    pub stop_quantity: Vec<i32>,
+    /// Exit stop distances in ticks.
+    pub stop_ticks: Vec<i32>,
+    /// Optional if-touched trigger settings.
+    pub if_touched: Option<RithmicIfTouchedTrigger>,
+    /// Move stop to break-even by this many ticks.
+    pub break_even_ticks: Option<i32>,
+    /// Trigger break-even once the position reaches this many ticks.
+    pub break_even_trigger_ticks: Option<i32>,
+    /// Enable a trailing stop after this many ticks.
+    pub trailing_stop_trigger_ticks: Option<i32>,
+    /// Use last trade instead of bid/offer for trailing stop tracking.
+    pub trailing_stop_by_last_trade_price: Option<bool>,
+    /// Convert target to MIT once touched.
+    pub target_market_order_if_touched: Option<bool>,
+    /// Convert stop to market if the current stop order is rejected.
+    pub stop_market_on_reject: Option<bool>,
+    /// Convert target to market at this second-since-beginning-of-epoch value.
+    pub target_market_at_ssboe: Option<i32>,
+    /// Microsecond component for `target_market_at_ssboe`.
+    pub target_market_at_usecs: Option<i32>,
+    /// Convert stop to market at this second-since-beginning-of-epoch value.
+    pub stop_market_at_ssboe: Option<i32>,
+    /// Microsecond component for `stop_market_at_ssboe`.
+    pub stop_market_at_usecs: Option<i32>,
+    /// Convert target to market after this many seconds.
+    pub target_market_order_after_secs: Option<i32>,
+    /// Release order at this second-since-beginning-of-epoch value.
+    pub release_at_ssboe: Option<i32>,
+    /// Microsecond component for `release_at_ssboe`.
+    pub release_at_usecs: Option<i32>,
+    /// Cancel order at this second-since-beginning-of-epoch value.
+    pub cancel_at_ssboe: Option<i32>,
+    /// Microsecond component for `cancel_at_ssboe`.
+    pub cancel_at_usecs: Option<i32>,
+    /// Cancel order after this many seconds.
+    pub cancel_after_secs: Option<i32>,
+}
+
+impl Default for RithmicAdvancedBracketOrder {
+    fn default() -> Self {
+        Self {
+            action: request_bracket_order::TransactionType::Buy,
+            duration: request_bracket_order::Duration::Day,
+            exchange: String::new(),
+            localid: String::new(),
+            price_type: request_bracket_order::PriceType::Limit,
+            price: None,
+            trigger_price: None,
+            quantity: 0,
+            symbol: String::new(),
+            bracket_type: request_bracket_order::BracketType::TargetAndStopStatic,
+            target_quantity: Vec::new(),
+            target_ticks: Vec::new(),
+            stop_quantity: Vec::new(),
+            stop_ticks: Vec::new(),
+            if_touched: None,
+            break_even_ticks: None,
+            break_even_trigger_ticks: None,
+            trailing_stop_trigger_ticks: None,
+            trailing_stop_by_last_trade_price: None,
+            target_market_order_if_touched: None,
+            stop_market_on_reject: None,
+            target_market_at_ssboe: None,
+            target_market_at_usecs: None,
+            stop_market_at_ssboe: None,
+            stop_market_at_usecs: None,
+            target_market_order_after_secs: None,
+            release_at_ssboe: None,
+            release_at_usecs: None,
+            cancel_at_ssboe: None,
+            cancel_at_usecs: None,
+            cancel_after_secs: None,
+        }
+    }
+}
+
+impl From<RithmicBracketOrder> for RithmicAdvancedBracketOrder {
+    fn from(value: RithmicBracketOrder) -> Self {
+        Self {
+            action: value.action,
+            duration: value.duration,
+            exchange: value.exchange,
+            localid: value.localid,
+            price_type: value.price_type,
+            price: value.price,
+            trigger_price: None,
+            quantity: value.quantity,
+            symbol: value.symbol,
+            bracket_type: request_bracket_order::BracketType::TargetAndStopStatic,
+            target_quantity: vec![value.quantity],
+            target_ticks: vec![value.profit_ticks],
+            stop_quantity: vec![value.quantity],
+            stop_ticks: vec![value.stop_ticks],
+            if_touched: None,
+            break_even_ticks: None,
+            break_even_trigger_ticks: None,
+            trailing_stop_trigger_ticks: None,
+            trailing_stop_by_last_trade_price: None,
+            target_market_order_if_touched: None,
+            stop_market_on_reject: None,
+            target_market_at_ssboe: None,
+            target_market_at_usecs: None,
+            stop_market_at_ssboe: None,
+            stop_market_at_usecs: None,
+            target_market_order_after_secs: None,
+            release_at_ssboe: None,
+            release_at_usecs: None,
+            cancel_at_ssboe: None,
+            cancel_at_usecs: None,
+            cancel_after_secs: None,
+        }
+    }
+}
+
 /// Modify an existing order's price, quantity, or type.
 ///
 /// # Example

--- a/src/api/sender_api.rs
+++ b/src/api/sender_api.rs
@@ -1874,7 +1874,7 @@ mod tests {
     }
 
     #[test]
-    fn advanced_bracket_request_uses_supplied_account_and_trade_route() {
+    fn advanced_bracket_request_sets_account_and_trade_route_fields() {
         let mut api = RithmicSenderApi::new(&test_config());
 
         let (buf, _) = api.request_advanced_bracket_order(advanced_bracket(), &override_account());
@@ -1893,7 +1893,6 @@ mod tests {
 
         let (buf, _) = api.request_advanced_bracket_order(advanced_bracket(), &default_account());
         let request: RequestBracketOrder = decode_request(&buf);
-
         assert_eq!(request.price, Some(5000.25));
         assert_eq!(request.trigger_price, Some(4999.75));
         assert_eq!(

--- a/src/api/sender_api.rs
+++ b/src/api/sender_api.rs
@@ -1,5 +1,5 @@
 use super::rithmic_command_types::{
-    LoginConfig, RithmicBracketOrder, RithmicOcoOrderLeg, RithmicOrder,
+    LoginConfig, RithmicAdvancedBracketOrder, RithmicBracketOrder, RithmicOcoOrderLeg, RithmicOrder,
 };
 use prost::Message;
 
@@ -487,6 +487,14 @@ impl RithmicSenderApi {
         bracket_order: RithmicBracketOrder,
         account: &RithmicAccount,
     ) -> (Vec<u8>, String) {
+        self.request_advanced_bracket_order(bracket_order.into(), account)
+    }
+
+    pub fn request_advanced_bracket_order(
+        &mut self,
+        bracket_order: RithmicAdvancedBracketOrder,
+        account: &RithmicAccount,
+    ) -> (Vec<u8>, String) {
         let id = self.get_next_message_id();
 
         let trade_route = match self.env {
@@ -508,20 +516,49 @@ impl RithmicSenderApi {
             price_type: Some(bracket_order.price_type.into()),
             manual_or_auto: Some(2),
             duration: Some(bracket_order.duration.into()),
-            bracket_type: Some(
-                crate::rti::request_bracket_order::BracketType::TargetAndStopStatic.into(),
-            ),
-            target_quantity: vec![bracket_order.quantity],
-            stop_quantity: vec![bracket_order.quantity],
-            target_ticks: vec![bracket_order.profit_ticks],
-            stop_ticks: vec![bracket_order.stop_ticks],
-            price: if bracket_order.price_type
-                != crate::rti::request_bracket_order::PriceType::Market
-            {
-                bracket_order.price
-            } else {
-                None
-            },
+            bracket_type: Some(bracket_order.bracket_type.into()),
+            break_even_ticks: bracket_order.break_even_ticks,
+            break_even_trigger_ticks: bracket_order.break_even_trigger_ticks,
+            target_quantity: bracket_order.target_quantity,
+            target_ticks: bracket_order.target_ticks,
+            stop_quantity: bracket_order.stop_quantity,
+            stop_ticks: bracket_order.stop_ticks,
+            trailing_stop_trigger_ticks: bracket_order.trailing_stop_trigger_ticks,
+            trailing_stop_by_last_trade_price: bracket_order.trailing_stop_by_last_trade_price,
+            target_market_order_if_touched: bracket_order.target_market_order_if_touched,
+            stop_market_on_reject: bracket_order.stop_market_on_reject,
+            target_market_at_ssboe: bracket_order.target_market_at_ssboe,
+            target_market_at_usecs: bracket_order.target_market_at_usecs,
+            stop_market_at_ssboe: bracket_order.stop_market_at_ssboe,
+            stop_market_at_usecs: bracket_order.stop_market_at_usecs,
+            target_market_order_after_secs: bracket_order.target_market_order_after_secs,
+            release_at_ssboe: bracket_order.release_at_ssboe,
+            release_at_usecs: bracket_order.release_at_usecs,
+            cancel_at_ssboe: bracket_order.cancel_at_ssboe,
+            cancel_at_usecs: bracket_order.cancel_at_usecs,
+            cancel_after_secs: bracket_order.cancel_after_secs,
+            if_touched_symbol: bracket_order
+                .if_touched
+                .as_ref()
+                .map(|trigger| trigger.symbol.clone()),
+            if_touched_exchange: bracket_order
+                .if_touched
+                .as_ref()
+                .map(|trigger| trigger.exchange.clone()),
+            if_touched_condition: bracket_order
+                .if_touched
+                .as_ref()
+                .map(|trigger| trigger.condition.into()),
+            if_touched_price_field: bracket_order
+                .if_touched
+                .as_ref()
+                .map(|trigger| trigger.price_field.into()),
+            if_touched_price: bracket_order
+                .if_touched
+                .as_ref()
+                .map(|trigger| trigger.price),
+            price: bracket_order.price,
+            trigger_price: bracket_order.trigger_price,
             user_msg: vec![id.clone()],
             user_tag: Some(bracket_order.localid),
             ..RequestBracketOrder::default()
@@ -1709,6 +1746,50 @@ mod tests {
         T::decode(&buf[4..]).expect("decode request")
     }
 
+    fn advanced_bracket() -> RithmicAdvancedBracketOrder {
+        let mut order = RithmicAdvancedBracketOrder {
+            action: crate::rti::request_bracket_order::TransactionType::Buy,
+            duration: crate::rti::request_bracket_order::Duration::Gtc,
+            exchange: "CME".to_string(),
+            localid: "advanced-bracket-1".to_string(),
+            price_type: crate::rti::request_bracket_order::PriceType::StopLimit,
+            price: Some(5000.25),
+            trigger_price: Some(4999.75),
+            quantity: 3,
+            symbol: "ESM6".to_string(),
+            bracket_type: crate::rti::request_bracket_order::BracketType::TargetAndStop,
+            target_quantity: vec![2, 1],
+            target_ticks: vec![16, 24],
+            stop_quantity: vec![3],
+            stop_ticks: vec![8],
+            if_touched: Some(crate::api::RithmicIfTouchedTrigger {
+                symbol: "NQM6".to_string(),
+                exchange: "CME".to_string(),
+                condition: crate::rti::request_bracket_order::Condition::GreaterThanEqualTo,
+                price_field: crate::rti::request_bracket_order::PriceField::TradePrice,
+                price: 18250.5,
+            }),
+            break_even_ticks: Some(2),
+            break_even_trigger_ticks: Some(10),
+            trailing_stop_trigger_ticks: Some(12),
+            target_market_order_if_touched: Some(true),
+            stop_market_on_reject: Some(true),
+            release_at_ssboe: Some(35900),
+            cancel_after_secs: Some(120),
+            ..Default::default()
+        };
+        order.trailing_stop_by_last_trade_price = Some(true);
+        order.target_market_at_ssboe = Some(36000);
+        order.target_market_at_usecs = Some(250000);
+        order.stop_market_at_ssboe = Some(36100);
+        order.stop_market_at_usecs = Some(500000);
+        order.target_market_order_after_secs = Some(30);
+        order.release_at_usecs = Some(125000);
+        order.cancel_at_ssboe = Some(37000);
+        order.cancel_at_usecs = Some(750000);
+        order
+    }
+
     #[test]
     fn order_request_override_uses_supplied_account() {
         let mut api = RithmicSenderApi::new(&test_config());
@@ -1758,7 +1839,7 @@ mod tests {
     }
 
     #[test]
-    fn bracket_request_override_uses_supplied_account() {
+    fn bracket_request_retains_static_shape_for_simple_helper() {
         let mut api = RithmicSenderApi::new(&test_config());
         let bracket = RithmicBracketOrder {
             action: crate::rti::request_bracket_order::TransactionType::Buy,
@@ -1790,6 +1871,79 @@ mod tests {
         assert_eq!(request.price, Some(5000.0));
         assert_eq!(request.trigger_price, None);
         assert_eq!(request.user_tag.as_deref(), Some("bracket-1"));
+    }
+
+    #[test]
+    fn advanced_bracket_request_uses_supplied_account_and_trade_route() {
+        let mut api = RithmicSenderApi::new(&test_config());
+
+        let (buf, _) = api.request_advanced_bracket_order(advanced_bracket(), &override_account());
+        let request: RequestBracketOrder = decode_request(&buf);
+
+        assert_eq!(request.fcm_id.as_deref(), Some("FCM_B"));
+        assert_eq!(request.ib_id.as_deref(), Some("IB_B"));
+        assert_eq!(request.account_id.as_deref(), Some("ACCOUNT_B"));
+        assert_eq!(request.trade_route.as_deref(), Some(TRADE_ROUTE_DEMO));
+        assert_eq!(request.user_tag.as_deref(), Some("advanced-bracket-1"));
+    }
+
+    #[test]
+    fn advanced_bracket_request_encodes_trigger_and_if_touched_fields() {
+        let mut api = RithmicSenderApi::new(&test_config());
+
+        let (buf, _) = api.request_advanced_bracket_order(advanced_bracket(), &default_account());
+        let request: RequestBracketOrder = decode_request(&buf);
+
+        assert_eq!(request.price, Some(5000.25));
+        assert_eq!(request.trigger_price, Some(4999.75));
+        assert_eq!(
+            request.price_type,
+            Some(crate::rti::request_bracket_order::PriceType::StopLimit as i32)
+        );
+        assert_eq!(
+            request.bracket_type,
+            Some(crate::rti::request_bracket_order::BracketType::TargetAndStop as i32)
+        );
+        assert_eq!(request.target_quantity, vec![2, 1]);
+        assert_eq!(request.target_ticks, vec![16, 24]);
+        assert_eq!(request.stop_quantity, vec![3]);
+        assert_eq!(request.stop_ticks, vec![8]);
+        assert_eq!(request.if_touched_symbol.as_deref(), Some("NQM6"));
+        assert_eq!(request.if_touched_exchange.as_deref(), Some("CME"));
+        assert_eq!(
+            request.if_touched_condition,
+            Some(crate::rti::request_bracket_order::Condition::GreaterThanEqualTo as i32)
+        );
+        assert_eq!(
+            request.if_touched_price_field,
+            Some(crate::rti::request_bracket_order::PriceField::TradePrice as i32)
+        );
+        assert_eq!(request.if_touched_price, Some(18250.5));
+    }
+
+    #[test]
+    fn advanced_bracket_request_encodes_management_and_timing_fields() {
+        let mut api = RithmicSenderApi::new(&test_config());
+
+        let (buf, _) = api.request_advanced_bracket_order(advanced_bracket(), &default_account());
+        let request: RequestBracketOrder = decode_request(&buf);
+
+        assert_eq!(request.break_even_ticks, Some(2));
+        assert_eq!(request.break_even_trigger_ticks, Some(10));
+        assert_eq!(request.trailing_stop_trigger_ticks, Some(12));
+        assert_eq!(request.trailing_stop_by_last_trade_price, Some(true));
+        assert_eq!(request.target_market_order_if_touched, Some(true));
+        assert_eq!(request.stop_market_on_reject, Some(true));
+        assert_eq!(request.target_market_at_ssboe, Some(36000));
+        assert_eq!(request.target_market_at_usecs, Some(250000));
+        assert_eq!(request.stop_market_at_ssboe, Some(36100));
+        assert_eq!(request.stop_market_at_usecs, Some(500000));
+        assert_eq!(request.target_market_order_after_secs, Some(30));
+        assert_eq!(request.release_at_ssboe, Some(35900));
+        assert_eq!(request.release_at_usecs, Some(125000));
+        assert_eq!(request.cancel_at_ssboe, Some(37000));
+        assert_eq!(request.cancel_at_usecs, Some(750000));
+        assert_eq!(request.cancel_after_secs, Some(120));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,10 +209,11 @@ pub use ws::ConnectStrategy;
 
 // Re-export API types
 pub use api::{
-    BracketDuration, BracketPriceType, BracketTransactionType, EasyToBorrowRequest, LoginConfig,
-    ModifyPriceType, NewOrderDuration, NewOrderPriceType, NewOrderTransactionType, OcoDuration,
-    OcoPriceType, OcoTransactionType, RithmicBracketOrder, RithmicCancelOrder, RithmicModifyOrder,
-    RithmicOcoOrderLeg, RithmicOrder, RithmicResponse, TrailingStop,
+    BracketCondition, BracketDuration, BracketPriceField, BracketPriceType, BracketTransactionType,
+    BracketType, EasyToBorrowRequest, LoginConfig, ModifyPriceType, NewOrderDuration,
+    NewOrderPriceType, NewOrderTransactionType, OcoDuration, OcoPriceType, OcoTransactionType,
+    RithmicAdvancedBracketOrder, RithmicBracketOrder, RithmicCancelOrder, RithmicIfTouchedTrigger,
+    RithmicModifyOrder, RithmicOcoOrderLeg, RithmicOrder, RithmicResponse, TrailingStop,
 };
 
 // Re-export utility types for convenience

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -12,8 +12,8 @@ use crate::{
     api::{
         receiver_api::{RithmicReceiverApi, RithmicResponse},
         rithmic_command_types::{
-            LoginConfig, RithmicBracketOrder, RithmicCancelOrder, RithmicModifyOrder,
-            RithmicOcoOrderLeg, RithmicOrder,
+            LoginConfig, RithmicAdvancedBracketOrder, RithmicBracketOrder, RithmicCancelOrder,
+            RithmicModifyOrder, RithmicOcoOrderLeg, RithmicOrder,
         },
         sender_api::RithmicSenderApi,
     },
@@ -72,6 +72,11 @@ pub(crate) enum OrderPlantCommand {
     },
     PlaceBracketOrder {
         bracket_order: RithmicBracketOrder,
+        account: Arc<RithmicAccount>,
+        response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
+    },
+    PlaceAdvancedBracketOrder {
+        bracket_order: RithmicAdvancedBracketOrder,
         account: Arc<RithmicAccount>,
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
     },
@@ -818,6 +823,25 @@ impl PlantActor for OrderPlant {
                 let (req_buf, id) = self
                     .rithmic_sender_api
                     .request_bracket_order(bracket_order, &account);
+
+                let request_id = id.clone();
+
+                self.request_handler.register_request(RithmicRequest {
+                    request_id: id,
+                    responder: response_sender,
+                });
+
+                self.send_or_fail(Message::Binary(req_buf.into()), &request_id)
+                    .await;
+            }
+            OrderPlantCommand::PlaceAdvancedBracketOrder {
+                bracket_order,
+                account,
+                response_sender,
+            } => {
+                let (req_buf, id) = self
+                    .rithmic_sender_api
+                    .request_advanced_bracket_order(bracket_order, &account);
 
                 let request_id = id.clone();
 
@@ -1599,6 +1623,31 @@ impl RithmicOrderPlantHandle {
         let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, RithmicError>>();
 
         let command = OrderPlantCommand::PlaceBracketOrder {
+            bracket_order,
+            account: self.account.clone(),
+            response_sender: tx,
+        };
+
+        let _ = self.sender.send(command).await;
+
+        rx.await.map_err(|_| RithmicError::ConnectionClosed)?
+    }
+
+    /// Place an advanced bracket order using the full raw `RequestBracketOrder`
+    /// request surface currently modeled by this crate.
+    ///
+    /// # Arguments
+    /// * `bracket_order` - The advanced bracket order parameters
+    ///
+    /// # Returns
+    /// The order placement responses or an error message
+    pub async fn place_advanced_bracket_order(
+        &self,
+        bracket_order: RithmicAdvancedBracketOrder,
+    ) -> Result<Vec<RithmicResponse>, RithmicError> {
+        let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, RithmicError>>();
+
+        let command = OrderPlantCommand::PlaceAdvancedBracketOrder {
             bracket_order,
             account: self.account.clone(),
             response_sender: tx,


### PR DESCRIPTION
## Summary
- add typed advanced bracket-order request structs that expose the full raw `RequestBracketOrder` field surface
- add sender and order-plant support for submitting those richer bracket requests through the existing configured-account flow
- document the new public types and method with examples and add encoding tests for the new request fields

## Why
- the maintainer requested this be split from the multi-account redesign into its own PR
- this keeps the scope focused on full-field order support without mixing in account-scoping changes

## What Changed
- add `RithmicIfTouchedTrigger` and `RithmicAdvancedBracketOrder`
- re-export the additional bracket enums needed to construct advanced requests ergonomically
- add `request_advanced_bracket_order(...)` and `place_advanced_bracket_order(...)`
- keep `request_bracket_order(...)` on the simple helper path by translating it into the richer request shape internally

## Validation
- `cargo fmt --check`
- `cargo +stable clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test --all-targets`
- `cargo doc --no-deps`

## Related
- companion multi-account redesign: #49
