### PR TITLE
[codex] Add semantic ticker market-data helpers

### DIFF
--- a/src/plants/ticker_plant.rs
+++ b/src/plants/ticker_plant.rs
@@ -1322,7 +1322,12 @@ impl RithmicTickerPlantHandle {
         .await
     }
 
-    /// Subscribe to top-of-book depth (`OrderBook`) updates for a specific symbol
+    /// Subscribe to level-1 order book summary updates for a specific symbol.
+    ///
+    /// This uses `request_market_data_update` (proto 100) with `UpdateBits::OrderBook`
+    /// and delivers aggregated bid/ask summary ticks. It is distinct from
+    /// [`subscribe_order_book`](Self::subscribe_order_book), which uses
+    /// `request_depth_by_order_updates` (proto 104) for full depth-by-order streaming.
     ///
     /// # Arguments
     /// * `symbol` - The trading symbol (e.g., "ESH6")
@@ -1330,7 +1335,7 @@ impl RithmicTickerPlantHandle {
     ///
     /// # Returns
     /// The subscription response or an error message
-    pub async fn subscribe_order_book_depth(
+    pub async fn subscribe_order_book_summary(
         &self,
         symbol: &str,
         exchange: &str,
@@ -1344,7 +1349,11 @@ impl RithmicTickerPlantHandle {
         .await
     }
 
-    /// Unsubscribe from top-of-book depth (`OrderBook`) updates for a specific symbol
+    /// Unsubscribe from level-1 order book summary updates for a specific symbol.
+    ///
+    /// This reverses [`subscribe_order_book_summary`](Self::subscribe_order_book_summary).
+    /// Use [`unsubscribe_order_book`](Self::unsubscribe_order_book) to stop the
+    /// dedicated depth-by-order stream instead.
     ///
     /// # Arguments
     /// * `symbol` - The trading symbol (e.g., "ESH6")
@@ -1352,7 +1361,7 @@ impl RithmicTickerPlantHandle {
     ///
     /// # Returns
     /// The unsubscription response or an error message
-    pub async fn unsubscribe_order_book_depth(
+    pub async fn unsubscribe_order_book_summary(
         &self,
         symbol: &str,
         exchange: &str,
@@ -1542,7 +1551,13 @@ impl RithmicTickerPlantHandle {
         .await
     }
 
-    /// Subscribe to end-of-day price updates for a specific symbol
+    /// Subscribe to end-of-day price updates for a specific symbol.
+    ///
+    /// Subscribes to `Close`, `Settlement`, `ProjectedSettlement`, and `AdjustedClose`.
+    /// The first three are delivered as real-time updates throughout the session.
+    /// `AdjustedClose` is a reference field and will not fire as a real-time callback;
+    /// it is included for end-of-session reconciliation use cases where its value is
+    /// populated after market close.
     ///
     /// # Arguments
     /// * `symbol` - The trading symbol (e.g., "ESH6")
@@ -1569,7 +1584,10 @@ impl RithmicTickerPlantHandle {
         .await
     }
 
-    /// Unsubscribe from end-of-day price updates for a specific symbol
+    /// Unsubscribe from end-of-day price updates for a specific symbol.
+    ///
+    /// This reverses [`subscribe_end_of_day_prices`](Self::subscribe_end_of_day_prices),
+    /// including the non-streaming `AdjustedClose` reference field.
     ///
     /// # Arguments
     /// * `symbol` - The trading symbol (e.g., "ESH6")

--- a/src/plants/ticker_plant.rs
+++ b/src/plants/ticker_plant.rs
@@ -1252,6 +1252,438 @@ impl RithmicTickerPlantHandle {
             .ok_or(RithmicError::EmptyResponse)
     }
 
+    async fn request_market_data_update(
+        &self,
+        symbol: &str,
+        exchange: &str,
+        fields: Vec<UpdateBits>,
+        request_type: Request,
+    ) -> Result<RithmicResponse, RithmicError> {
+        let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, RithmicError>>();
+
+        let command = TickerPlantCommand::Subscribe {
+            symbol: symbol.to_string(),
+            exchange: exchange.to_string(),
+            fields,
+            request_type,
+            response_sender: tx,
+        };
+
+        let _ = self.sender.send(command).await;
+
+        rx.await
+            .map_err(|_| RithmicError::ConnectionClosed)??
+            .into_iter()
+            .next()
+            .ok_or(RithmicError::EmptyResponse)
+    }
+
+    /// Subscribe to instrument status updates for a specific symbol
+    ///
+    /// # Arguments
+    /// * `symbol` - The trading symbol (e.g., "ESH6")
+    /// * `exchange` - The exchange code (e.g., "CME")
+    ///
+    /// # Returns
+    /// The subscription response or an error message
+    pub async fn subscribe_instrument_status(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, RithmicError> {
+        self.request_market_data_update(
+            symbol,
+            exchange,
+            vec![UpdateBits::MarketMode],
+            Request::Subscribe,
+        )
+        .await
+    }
+
+    /// Unsubscribe from instrument status updates for a specific symbol
+    ///
+    /// # Arguments
+    /// * `symbol` - The trading symbol (e.g., "ESH6")
+    /// * `exchange` - The exchange code (e.g., "CME")
+    ///
+    /// # Returns
+    /// The unsubscription response or an error message
+    pub async fn unsubscribe_instrument_status(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, RithmicError> {
+        self.request_market_data_update(
+            symbol,
+            exchange,
+            vec![UpdateBits::MarketMode],
+            Request::Unsubscribe,
+        )
+        .await
+    }
+
+    /// Subscribe to top-of-book depth (`OrderBook`) updates for a specific symbol
+    ///
+    /// # Arguments
+    /// * `symbol` - The trading symbol (e.g., "ESH6")
+    /// * `exchange` - The exchange code (e.g., "CME")
+    ///
+    /// # Returns
+    /// The subscription response or an error message
+    pub async fn subscribe_order_book_depth(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, RithmicError> {
+        self.request_market_data_update(
+            symbol,
+            exchange,
+            vec![UpdateBits::OrderBook],
+            Request::Subscribe,
+        )
+        .await
+    }
+
+    /// Unsubscribe from top-of-book depth (`OrderBook`) updates for a specific symbol
+    ///
+    /// # Arguments
+    /// * `symbol` - The trading symbol (e.g., "ESH6")
+    /// * `exchange` - The exchange code (e.g., "CME")
+    ///
+    /// # Returns
+    /// The unsubscription response or an error message
+    pub async fn unsubscribe_order_book_depth(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, RithmicError> {
+        self.request_market_data_update(
+            symbol,
+            exchange,
+            vec![UpdateBits::OrderBook],
+            Request::Unsubscribe,
+        )
+        .await
+    }
+
+    /// Subscribe to session price updates for a specific symbol
+    ///
+    /// # Arguments
+    /// * `symbol` - The trading symbol (e.g., "ESH6")
+    /// * `exchange` - The exchange code (e.g., "CME")
+    ///
+    /// # Returns
+    /// The subscription response or an error message
+    pub async fn subscribe_session_prices(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, RithmicError> {
+        self.request_market_data_update(
+            symbol,
+            exchange,
+            vec![UpdateBits::Open, UpdateBits::HighLow],
+            Request::Subscribe,
+        )
+        .await
+    }
+
+    /// Unsubscribe from session price updates for a specific symbol
+    ///
+    /// # Arguments
+    /// * `symbol` - The trading symbol (e.g., "ESH6")
+    /// * `exchange` - The exchange code (e.g., "CME")
+    ///
+    /// # Returns
+    /// The unsubscription response or an error message
+    pub async fn unsubscribe_session_prices(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, RithmicError> {
+        self.request_market_data_update(
+            symbol,
+            exchange,
+            vec![UpdateBits::Open, UpdateBits::HighLow],
+            Request::Unsubscribe,
+        )
+        .await
+    }
+
+    /// Subscribe to quote statistics updates for a specific symbol
+    ///
+    /// # Arguments
+    /// * `symbol` - The trading symbol (e.g., "ESH6")
+    /// * `exchange` - The exchange code (e.g., "CME")
+    ///
+    /// # Returns
+    /// The subscription response or an error message
+    pub async fn subscribe_quote_statistics(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, RithmicError> {
+        self.request_market_data_update(
+            symbol,
+            exchange,
+            vec![UpdateBits::HighBidLowAsk],
+            Request::Subscribe,
+        )
+        .await
+    }
+
+    /// Unsubscribe from quote statistics updates for a specific symbol
+    ///
+    /// # Arguments
+    /// * `symbol` - The trading symbol (e.g., "ESH6")
+    /// * `exchange` - The exchange code (e.g., "CME")
+    ///
+    /// # Returns
+    /// The unsubscription response or an error message
+    pub async fn unsubscribe_quote_statistics(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, RithmicError> {
+        self.request_market_data_update(
+            symbol,
+            exchange,
+            vec![UpdateBits::HighBidLowAsk],
+            Request::Unsubscribe,
+        )
+        .await
+    }
+
+    /// Subscribe to indicator price updates for a specific symbol
+    ///
+    /// # Arguments
+    /// * `symbol` - The trading symbol (e.g., "ESH6")
+    /// * `exchange` - The exchange code (e.g., "CME")
+    ///
+    /// # Returns
+    /// The subscription response or an error message
+    pub async fn subscribe_indicator_prices(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, RithmicError> {
+        self.request_market_data_update(
+            symbol,
+            exchange,
+            vec![UpdateBits::OpeningIndicator, UpdateBits::ClosingIndicator],
+            Request::Subscribe,
+        )
+        .await
+    }
+
+    /// Unsubscribe from indicator price updates for a specific symbol
+    ///
+    /// # Arguments
+    /// * `symbol` - The trading symbol (e.g., "ESH6")
+    /// * `exchange` - The exchange code (e.g., "CME")
+    ///
+    /// # Returns
+    /// The unsubscription response or an error message
+    pub async fn unsubscribe_indicator_prices(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, RithmicError> {
+        self.request_market_data_update(
+            symbol,
+            exchange,
+            vec![UpdateBits::OpeningIndicator, UpdateBits::ClosingIndicator],
+            Request::Unsubscribe,
+        )
+        .await
+    }
+
+    /// Subscribe to open interest updates for a specific symbol
+    ///
+    /// # Arguments
+    /// * `symbol` - The trading symbol (e.g., "ESH6")
+    /// * `exchange` - The exchange code (e.g., "CME")
+    ///
+    /// # Returns
+    /// The subscription response or an error message
+    pub async fn subscribe_open_interest(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, RithmicError> {
+        self.request_market_data_update(
+            symbol,
+            exchange,
+            vec![UpdateBits::OpenInterest],
+            Request::Subscribe,
+        )
+        .await
+    }
+
+    /// Unsubscribe from open interest updates for a specific symbol
+    ///
+    /// # Arguments
+    /// * `symbol` - The trading symbol (e.g., "ESH6")
+    /// * `exchange` - The exchange code (e.g., "CME")
+    ///
+    /// # Returns
+    /// The unsubscription response or an error message
+    pub async fn unsubscribe_open_interest(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, RithmicError> {
+        self.request_market_data_update(
+            symbol,
+            exchange,
+            vec![UpdateBits::OpenInterest],
+            Request::Unsubscribe,
+        )
+        .await
+    }
+
+    /// Subscribe to end-of-day price updates for a specific symbol
+    ///
+    /// # Arguments
+    /// * `symbol` - The trading symbol (e.g., "ESH6")
+    /// * `exchange` - The exchange code (e.g., "CME")
+    ///
+    /// # Returns
+    /// The subscription response or an error message
+    pub async fn subscribe_end_of_day_prices(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, RithmicError> {
+        self.request_market_data_update(
+            symbol,
+            exchange,
+            vec![
+                UpdateBits::Close,
+                UpdateBits::Settlement,
+                UpdateBits::ProjectedSettlement,
+                UpdateBits::AdjustedClose,
+            ],
+            Request::Subscribe,
+        )
+        .await
+    }
+
+    /// Unsubscribe from end-of-day price updates for a specific symbol
+    ///
+    /// # Arguments
+    /// * `symbol` - The trading symbol (e.g., "ESH6")
+    /// * `exchange` - The exchange code (e.g., "CME")
+    ///
+    /// # Returns
+    /// The unsubscription response or an error message
+    pub async fn unsubscribe_end_of_day_prices(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, RithmicError> {
+        self.request_market_data_update(
+            symbol,
+            exchange,
+            vec![
+                UpdateBits::Close,
+                UpdateBits::Settlement,
+                UpdateBits::ProjectedSettlement,
+                UpdateBits::AdjustedClose,
+            ],
+            Request::Unsubscribe,
+        )
+        .await
+    }
+
+    /// Subscribe to order price limit updates for a specific symbol
+    ///
+    /// # Arguments
+    /// * `symbol` - The trading symbol (e.g., "ESH6")
+    /// * `exchange` - The exchange code (e.g., "CME")
+    ///
+    /// # Returns
+    /// The subscription response or an error message
+    pub async fn subscribe_order_price_limits(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, RithmicError> {
+        self.request_market_data_update(
+            symbol,
+            exchange,
+            vec![UpdateBits::HighPriceLimit, UpdateBits::LowPriceLimit],
+            Request::Subscribe,
+        )
+        .await
+    }
+
+    /// Unsubscribe from order price limit updates for a specific symbol
+    ///
+    /// # Arguments
+    /// * `symbol` - The trading symbol (e.g., "ESH6")
+    /// * `exchange` - The exchange code (e.g., "CME")
+    ///
+    /// # Returns
+    /// The unsubscription response or an error message
+    pub async fn unsubscribe_order_price_limits(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, RithmicError> {
+        self.request_market_data_update(
+            symbol,
+            exchange,
+            vec![UpdateBits::HighPriceLimit, UpdateBits::LowPriceLimit],
+            Request::Unsubscribe,
+        )
+        .await
+    }
+
+    /// Subscribe to symbol margin rate updates for a specific symbol
+    ///
+    /// # Arguments
+    /// * `symbol` - The trading symbol (e.g., "ESH6")
+    /// * `exchange` - The exchange code (e.g., "CME")
+    ///
+    /// # Returns
+    /// The subscription response or an error message
+    pub async fn subscribe_symbol_margin_rate(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, RithmicError> {
+        self.request_market_data_update(
+            symbol,
+            exchange,
+            vec![UpdateBits::MarginRate],
+            Request::Subscribe,
+        )
+        .await
+    }
+
+    /// Unsubscribe from symbol margin rate updates for a specific symbol
+    ///
+    /// # Arguments
+    /// * `symbol` - The trading symbol (e.g., "ESH6")
+    /// * `exchange` - The exchange code (e.g., "CME")
+    ///
+    /// # Returns
+    /// The unsubscription response or an error message
+    pub async fn unsubscribe_symbol_margin_rate(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, RithmicError> {
+        self.request_market_data_update(
+            symbol,
+            exchange,
+            vec![UpdateBits::MarginRate],
+            Request::Unsubscribe,
+        )
+        .await
+    }
+
     /// Request a snapshot of the order book depth-by-order for a specific symbol
     ///
     /// # Arguments


### PR DESCRIPTION
## Summary
- add explicit ticker helper methods for instrument status, order book depth, session prices, quote statistics, indicator prices, open interest, end-of-day prices, order price limits, and symbol margin rate
- keep the public surface aligned with the existing explicit-per-capability `RithmicTickerPlantHandle` style while using a private helper to avoid duplication
- use `session_prices` naming for the `Open` + `HighLow` subscription pair to match the underlying data bits

## Why
- this splits the remaining semantic ticker helper work out of the earlier mixed-scope branch into a focused follow-up
- it exposes existing `request_market_data_update` bit combinations through ergonomic typed helpers without changing the existing default `subscribe` / `unsubscribe` paths

## Validation
- `cargo fmt --check`
- `cargo test`
