### PR TITLE
[codex] Bound plant WebSocket sends and surface reconnect failures

### DIFF
--- a/examples/reconnect.rs
+++ b/examples/reconnect.rs
@@ -72,8 +72,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
 
-        // Process until disconnect. The plant emits synthetic ConnectionError or
-        // HeartbeatTimeout updates before stopping on transport loss.
+        // Process until disconnect. Unexpected transport loss emits synthetic
+        // ConnectionError or HeartbeatTimeout updates before the actor stops.
+        // A clean handle.disconnect().await on a healthy connection does not
+        // emit those messages, so it is safe to use without tripping this
+        // reconnect branch.
         while let Ok(update) = handle.subscription_receiver.recv().await {
             match &update.message {
                 RithmicMessage::HeartbeatTimeout

--- a/examples/reconnect.rs
+++ b/examples/reconnect.rs
@@ -72,7 +72,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
 
-        // Process until disconnect
+        // Process until disconnect. The plant emits synthetic ConnectionError or
+        // HeartbeatTimeout updates before stopping on transport loss.
         while let Ok(update) = handle.subscription_receiver.recv().await {
             match &update.message {
                 RithmicMessage::HeartbeatTimeout

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,9 +25,12 @@ pub enum RithmicError {
     ///
     /// Treat this as a connection-health failure for the current request path and
     /// trigger your reconnection logic if the request is required for continued
-    /// trading. The plant actor remains responsive so keep-alive failure detection
-    /// can still emit a synthetic [`crate::rti::messages::RithmicMessage::HeartbeatTimeout`]
-    /// or [`crate::rti::messages::RithmicMessage::ConnectionError`] update.
+    /// trading. This error alone does not prove that the actor has already shut
+    /// down; keep-alive failure detection can still emit a synthetic
+    /// [`crate::rti::messages::RithmicMessage::HeartbeatTimeout`] or
+    /// [`crate::rti::messages::RithmicMessage::ConnectionError`] update if the
+    /// connection is actually dead. A successful `disconnect()` on a plant
+    /// handle does not emit those synthetic health events.
     SendFailed,
     /// Server returned an empty response where at least one was expected.
     EmptyResponse,

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,7 +21,13 @@ pub enum RithmicError {
     ConnectionFailed(String),
     /// The plant's WebSocket connection is gone; pending requests will never complete.
     ConnectionClosed,
-    /// WebSocket send failed after the request was registered.
+    /// WebSocket send failed or timed out after the request was registered.
+    ///
+    /// Treat this as a connection-health failure for the current request path and
+    /// trigger your reconnection logic if the request is required for continued
+    /// trading. The plant actor remains responsive so keep-alive failure detection
+    /// can still emit a synthetic [`crate::rti::messages::RithmicMessage::HeartbeatTimeout`]
+    /// or [`crate::rti::messages::RithmicMessage::ConnectionError`] update.
     SendFailed,
     /// Server returned an empty response where at least one was expected.
     EmptyResponse,
@@ -37,7 +43,7 @@ impl fmt::Display for RithmicError {
         match self {
             RithmicError::ConnectionFailed(msg) => write!(f, "connection failed: {msg}"),
             RithmicError::ConnectionClosed => write!(f, "connection closed"),
-            RithmicError::SendFailed => write!(f, "WebSocket send failed"),
+            RithmicError::SendFailed => write!(f, "WebSocket send failed or timed out"),
             RithmicError::EmptyResponse => write!(f, "empty response"),
             RithmicError::ServerError(msg) => write!(f, "server error: {msg}"),
             RithmicError::InvalidArgument(msg) => write!(f, "invalid argument: {msg}"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,11 @@
 //! - [`ConnectStrategy::Retry`]: Indefinite retries with exponential backoff capped at 60s (recommended default)
 //! - [`ConnectStrategy::AlternateWithRetry`]: Alternates between primary and beta URLs
 //!
+//! A graceful `disconnect().await` logs out first and then closes the WebSocket.
+//! On a healthy connection, that shutdown path does not emit synthetic
+//! `HeartbeatTimeout` or `ConnectionError` subscription updates; reserve those
+//! for unexpected connection-health failures and reconnect logic.
+//!
 //! ## Configuration
 //!
 //! Use [`RithmicConfig`] for modern, ergonomic configuration:
@@ -118,6 +123,10 @@
 //!     Err(e) => eprintln!("{e}"),
 //! }
 //! ```
+//!
+//! A graceful `disconnect().await` is separate from that reconnect path: it
+//! shuts the plant down without sending synthetic `HeartbeatTimeout` or
+//! `ConnectionError` updates to subscribers when the close handshake succeeds.
 //!
 //! `RithmicError` implements [`std::error::Error`], so `?` works in functions
 //! returning `Box<dyn Error>`.

--- a/src/plants/history_plant.rs
+++ b/src/plants/history_plant.rs
@@ -221,6 +221,7 @@ impl RithmicHistoryPlant {
 #[derive(Debug)]
 struct HistoryPlant {
     config: RithmicConfig,
+    close_requested: bool,
     interval: Interval,
     logged_in: bool,
     ping_interval: Interval,
@@ -262,6 +263,7 @@ impl HistoryPlant {
 
         Ok(HistoryPlant {
             config: config.clone(),
+            close_requested: false,
             interval,
             ping_interval,
             logged_in: false,
@@ -491,7 +493,15 @@ impl PlantActor for HistoryPlant {
         match message {
             Ok(Message::Close(frame)) => {
                 info!("history_plant: Received close frame: {:?}", frame);
-                self.request_handler.drain_and_drop();
+                if self.close_requested {
+                    self.request_handler.drain_and_drop();
+                } else {
+                    self.fail_connection_and_drain(
+                        "",
+                        RithmicMessage::ConnectionError,
+                        format!("WebSocket close frame received: {:?}", frame),
+                    );
+                }
                 stop = true;
             }
             Ok(Message::Pong(_)) => {
@@ -608,6 +618,7 @@ impl PlantActor for HistoryPlant {
     async fn handle_command(&mut self, command: HistoryPlantCommand) {
         match command {
             HistoryPlantCommand::Close => {
+                self.close_requested = true;
                 self.send_close_best_effort().await;
             }
             HistoryPlantCommand::ListSystemInfo { response_sender } => {

--- a/src/plants/history_plant.rs
+++ b/src/plants/history_plant.rs
@@ -428,12 +428,12 @@ impl PlantActor for HistoryPlant {
         loop {
             tokio::select! {
               _ = self.interval.tick() => {
-                if self.logged_in && self.send_heartbeat().await {
+                if self.logged_in && !self.close_requested && self.send_heartbeat().await {
                     break;
                 }
               }
               _ = self.ping_interval.tick() => {
-                if self.send_ping().await {
+                if !self.close_requested && self.send_ping().await {
                     break;
                 }
               }
@@ -445,33 +445,27 @@ impl PlantActor for HistoryPlant {
                 }
               } => {
                 if self.ping_manager.check_timeout() {
-                    error!("WebSocket ping timed out - connection appears dead");
-                    self.fail_connection_and_drain(
-                        "websocket_ping_timeout",
-                        RithmicMessage::HeartbeatTimeout,
-                        "WebSocket ping timeout - connection dead",
-                    );
+                    if self.close_requested {
+                        self.request_handler.drain_and_drop();
+                    } else {
+                        error!("WebSocket ping timed out - connection appears dead");
+                        self.fail_connection_and_drain(
+                            "websocket_ping_timeout",
+                            RithmicMessage::HeartbeatTimeout,
+                            "WebSocket ping timeout - connection dead",
+                        );
+                    }
                     break;
                 }
               }
               Some(message) = self.request_receiver.recv() => {
                 if matches!(message, HistoryPlantCommand::Abort) {
                     info!("history_plant: abort requested, shutting down immediately");
-
-                    let error_response = RithmicResponse {
-                        request_id: "".to_string(),
-                        message: RithmicMessage::ConnectionError,
-                        is_update: true,
-                        has_more: false,
-                        multi_response: false,
-                        error: Some("Plant aborted".to_string()),
-                        source: self.rithmic_receiver_api.source.clone(),
-                    };
-
-                    let _ = self.subscription_sender.send(error_response);
-
-                    self.request_handler.drain_and_drop();
-
+                    self.fail_connection_and_drain(
+                        "",
+                        RithmicMessage::ConnectionError,
+                        "Plant aborted",
+                    );
                     break;
                 }
                 self.handle_command(message).await;

--- a/src/plants/history_plant.rs
+++ b/src/plants/history_plant.rs
@@ -221,6 +221,7 @@ impl RithmicHistoryPlant {
 #[derive(Debug)]
 struct HistoryPlant {
     config: RithmicConfig,
+    // Distinguishes an intentional local shutdown from an unexpected peer close.
     close_requested: bool,
     interval: Interval,
     logged_in: bool,
@@ -370,11 +371,11 @@ impl HistoryPlant {
     }
 
     async fn send_heartbeat(&mut self) -> bool {
-        let (heartbeat_bf, _id) = self.rithmic_sender_api.request_heartbeat();
+        let (heartbeat_buf, _id) = self.rithmic_sender_api.request_heartbeat();
 
         match send_with_timeout(
             &mut self.rithmic_sender,
-            Message::Binary(heartbeat_bf.into()),
+            Message::Binary(heartbeat_buf.into()),
             Duration::from_secs(SEND_TIMEOUT_SECS),
         )
         .await

--- a/src/plants/history_plant.rs
+++ b/src/plants/history_plant.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use tracing::{error, info, warn};
 
 use tokio_tungstenite::{
@@ -21,13 +23,13 @@ use crate::{
         request_time_bar_replay::BarType, request_time_bar_update,
     },
     ws::{
-        HEARTBEAT_SECS, PING_TIMEOUT_SECS, PlantActor, connect_with_strategy,
-        get_heartbeat_interval, get_ping_interval,
+        HEARTBEAT_SECS, PING_TIMEOUT_SECS, PlantActor, SEND_TIMEOUT_SECS, WebSocketSendError,
+        connect_with_strategy, get_heartbeat_interval, get_ping_interval, send_with_timeout,
     },
 };
 
 use futures_util::{
-    SinkExt, StreamExt,
+    StreamExt,
     stream::{SplitSink, SplitStream},
 };
 
@@ -52,7 +54,6 @@ pub(crate) enum HistoryPlantCommand {
     Logout {
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
     },
-    SendHeartbeat,
     UpdateHeartbeat {
         seconds: u64,
     },
@@ -277,15 +278,142 @@ impl HistoryPlant {
 }
 
 impl HistoryPlant {
-    async fn send_or_fail(&mut self, msg: Message, request_id: &str) {
-        if self.rithmic_sender.send(msg).await.is_err() {
-            error!(
-                "history_plant: WebSocket send failed for request {}",
-                request_id
-            );
+    fn emit_connection_health_event(
+        &self,
+        request_id: &str,
+        message: RithmicMessage,
+        error_message: impl Into<String>,
+    ) {
+        let error_response = RithmicResponse {
+            request_id: request_id.to_string(),
+            message,
+            is_update: true,
+            has_more: false,
+            multi_response: false,
+            error: Some(error_message.into()),
+            source: self.rithmic_receiver_api.source.clone(),
+        };
 
-            self.request_handler
-                .fail_request(request_id, RithmicError::SendFailed);
+        let _ = self.subscription_sender.send(error_response);
+    }
+
+    fn fail_connection_and_drain(
+        &mut self,
+        request_id: &str,
+        message: RithmicMessage,
+        error_message: impl Into<String>,
+    ) {
+        self.emit_connection_health_event(request_id, message, error_message);
+        self.request_handler.drain_and_drop();
+    }
+
+    async fn send_or_fail(&mut self, msg: Message, request_id: &str) {
+        match send_with_timeout(
+            &mut self.rithmic_sender,
+            msg,
+            Duration::from_secs(SEND_TIMEOUT_SECS),
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(WebSocketSendError::Transport(error)) => {
+                error!(
+                    "history_plant: WebSocket send failed for request {}: {}",
+                    request_id, error
+                );
+                self.request_handler
+                    .fail_request(request_id, RithmicError::SendFailed);
+            }
+            Err(WebSocketSendError::Timeout) => {
+                error!(
+                    "history_plant: WebSocket send timed out for request {}",
+                    request_id
+                );
+                self.request_handler
+                    .fail_request(request_id, RithmicError::SendFailed);
+            }
+        }
+    }
+
+    async fn send_ping(&mut self) -> bool {
+        self.ping_manager.sent();
+
+        match send_with_timeout(
+            &mut self.rithmic_sender,
+            Message::Ping(vec![].into()),
+            Duration::from_secs(SEND_TIMEOUT_SECS),
+        )
+        .await
+        {
+            Ok(()) => false,
+            Err(WebSocketSendError::Transport(error)) => {
+                error!("history_plant: WebSocket ping send failed: {}", error);
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    format!("WebSocket ping send failed: {error}"),
+                );
+                true
+            }
+            Err(WebSocketSendError::Timeout) => {
+                error!("history_plant: WebSocket ping send timed out");
+                self.fail_connection_and_drain(
+                    "websocket_ping_timeout",
+                    RithmicMessage::HeartbeatTimeout,
+                    "WebSocket ping send timed out - connection dead",
+                );
+                true
+            }
+        }
+    }
+
+    async fn send_heartbeat(&mut self) -> bool {
+        let (heartbeat_bf, _id) = self.rithmic_sender_api.request_heartbeat();
+
+        match send_with_timeout(
+            &mut self.rithmic_sender,
+            Message::Binary(heartbeat_bf.into()),
+            Duration::from_secs(SEND_TIMEOUT_SECS),
+        )
+        .await
+        {
+            Ok(()) => false,
+            Err(WebSocketSendError::Transport(error)) => {
+                error!("history_plant: heartbeat send failed: {}", error);
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    format!("Heartbeat send failed: {error}"),
+                );
+                true
+            }
+            Err(WebSocketSendError::Timeout) => {
+                error!("history_plant: heartbeat send timed out");
+                self.fail_connection_and_drain(
+                    "heartbeat_send_timeout",
+                    RithmicMessage::HeartbeatTimeout,
+                    "Heartbeat send timed out - connection dead",
+                );
+                true
+            }
+        }
+    }
+
+    async fn send_close_best_effort(&mut self) {
+        match send_with_timeout(
+            &mut self.rithmic_sender,
+            Message::Close(None),
+            Duration::from_secs(SEND_TIMEOUT_SECS),
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(WebSocketSendError::Transport(error)) => {
+                warn!("history_plant: close send failed: {}", error);
+            }
+            Err(WebSocketSendError::Timeout) => {
+                warn!("history_plant: close send timed out");
+            }
         }
     }
 }
@@ -297,13 +425,14 @@ impl PlantActor for HistoryPlant {
         loop {
             tokio::select! {
               _ = self.interval.tick() => {
-                if self.logged_in {
-                    self.handle_command(HistoryPlantCommand::SendHeartbeat).await;
+                if self.logged_in && self.send_heartbeat().await {
+                    break;
                 }
               }
               _ = self.ping_interval.tick() => {
-                self.ping_manager.sent();
-                let _ = self.rithmic_sender.send(Message::Ping(vec![].into())).await;
+                if self.send_ping().await {
+                    break;
+                }
               }
               _ = async {
                 if let Some(timeout_at) = self.ping_manager.next_timeout_at() {
@@ -314,17 +443,11 @@ impl PlantActor for HistoryPlant {
               } => {
                 if self.ping_manager.check_timeout() {
                     error!("WebSocket ping timed out - connection appears dead");
-
-                    let error_response = RithmicResponse {
-                        request_id: "websocket_ping_timeout".to_string(),
-                        message: RithmicMessage::HeartbeatTimeout,
-                        is_update: true,
-                        has_more: false,
-                        multi_response: false,
-                        error: Some("WebSocket ping timeout - connection dead".to_string()),
-                        source: self.rithmic_receiver_api.source.clone(),
-                    };
-                    let _ = self.subscription_sender.send(error_response);
+                    self.fail_connection_and_drain(
+                        "websocket_ping_timeout",
+                        RithmicMessage::HeartbeatTimeout,
+                        "WebSocket ping timeout - connection dead",
+                    );
                     break;
                 }
               }
@@ -368,6 +491,7 @@ impl PlantActor for HistoryPlant {
         match message {
             Ok(Message::Close(frame)) => {
                 info!("history_plant: Received close frame: {:?}", frame);
+                self.request_handler.drain_and_drop();
                 stop = true;
             }
             Ok(Message::Pong(_)) => {
@@ -421,98 +545,56 @@ impl PlantActor for HistoryPlant {
             },
             Err(Error::ConnectionClosed) => {
                 error!("history_plant: connection closed");
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some("WebSocket connection closed".to_string()),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket connection closed",
+                );
                 stop = true;
             }
             Err(Error::AlreadyClosed) => {
                 error!("history_plant: connection already closed");
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some("WebSocket connection already closed".to_string()),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket connection already closed",
+                );
                 stop = true;
             }
             Err(Error::Io(ref io_err)) => {
                 error!("history_plant: I/O error: {}", io_err);
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some(format!("WebSocket I/O error: {}", io_err)),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    format!("WebSocket I/O error: {}", io_err),
+                );
                 stop = true;
             }
             Err(Error::Protocol(ProtocolError::ResetWithoutClosingHandshake)) => {
                 error!("history_plant: connection reset without closing handshake");
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some("WebSocket connection reset without closing handshake".to_string()),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket connection reset without closing handshake",
+                );
                 stop = true;
             }
             Err(Error::Protocol(ProtocolError::SendAfterClosing)) => {
                 error!("history_plant: attempted to send after closing");
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some("WebSocket attempted to send after closing".to_string()),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket attempted to send after closing",
+                );
                 stop = true;
             }
             Err(Error::Protocol(ProtocolError::ReceivedAfterClosing)) => {
                 error!("history_plant: received data after closing");
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some("WebSocket received data after closing".to_string()),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket received data after closing",
+                );
                 stop = true;
             }
             _ => {
@@ -526,7 +608,7 @@ impl PlantActor for HistoryPlant {
     async fn handle_command(&mut self, command: HistoryPlantCommand) {
         match command {
             HistoryPlantCommand::Close => {
-                let _ = self.rithmic_sender.send(Message::Close(None)).await;
+                self.send_close_best_effort().await;
             }
             HistoryPlantCommand::ListSystemInfo { response_sender } => {
                 let (list_system_info_buf, id) =
@@ -580,14 +662,6 @@ impl PlantActor for HistoryPlant {
                 });
 
                 self.send_or_fail(Message::Binary(logout_buf.into()), &request_id)
-                    .await;
-            }
-            HistoryPlantCommand::SendHeartbeat => {
-                let (heartbeat_bf, _id) = self.rithmic_sender_api.request_heartbeat();
-
-                let _ = self
-                    .rithmic_sender
-                    .send(Message::Binary(heartbeat_bf.into()))
                     .await;
             }
             HistoryPlantCommand::UpdateHeartbeat { seconds } => {

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use tracing::{error, info, warn};
 
@@ -24,13 +24,13 @@ use crate::{
     request_handler::{RithmicRequest, RithmicRequestHandler},
     rti::{messages::RithmicMessage, request_easy_to_borrow_list, request_login::SysInfraType},
     ws::{
-        HEARTBEAT_SECS, PING_TIMEOUT_SECS, PlantActor, connect_with_strategy,
-        get_heartbeat_interval, get_ping_interval,
+        HEARTBEAT_SECS, PING_TIMEOUT_SECS, PlantActor, SEND_TIMEOUT_SECS, WebSocketSendError,
+        connect_with_strategy, get_heartbeat_interval, get_ping_interval, send_with_timeout,
     },
 };
 
 use futures_util::{
-    SinkExt, StreamExt,
+    StreamExt,
     stream::{SplitSink, SplitStream},
 };
 
@@ -55,7 +55,6 @@ pub(crate) enum OrderPlantCommand {
     Logout {
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
     },
-    SendHeartbeat,
     UpdateHeartbeat {
         seconds: u64,
     },
@@ -448,15 +447,142 @@ impl OrderPlant {
         })
     }
 
-    async fn send_or_fail(&mut self, msg: Message, request_id: &str) {
-        if self.rithmic_sender.send(msg).await.is_err() {
-            error!(
-                "order_plant: WebSocket send failed for request {}",
-                request_id
-            );
+    fn emit_connection_health_event(
+        &self,
+        request_id: &str,
+        message: RithmicMessage,
+        error_message: impl Into<String>,
+    ) {
+        let error_response = RithmicResponse {
+            request_id: request_id.to_string(),
+            message,
+            is_update: true,
+            has_more: false,
+            multi_response: false,
+            error: Some(error_message.into()),
+            source: self.rithmic_receiver_api.source.clone(),
+        };
 
-            self.request_handler
-                .fail_request(request_id, RithmicError::SendFailed);
+        let _ = self.subscription_sender.send(error_response);
+    }
+
+    fn fail_connection_and_drain(
+        &mut self,
+        request_id: &str,
+        message: RithmicMessage,
+        error_message: impl Into<String>,
+    ) {
+        self.emit_connection_health_event(request_id, message, error_message);
+        self.request_handler.drain_and_drop();
+    }
+
+    async fn send_or_fail(&mut self, msg: Message, request_id: &str) {
+        match send_with_timeout(
+            &mut self.rithmic_sender,
+            msg,
+            Duration::from_secs(SEND_TIMEOUT_SECS),
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(WebSocketSendError::Transport(error)) => {
+                error!(
+                    "order_plant: WebSocket send failed for request {}: {}",
+                    request_id, error
+                );
+                self.request_handler
+                    .fail_request(request_id, RithmicError::SendFailed);
+            }
+            Err(WebSocketSendError::Timeout) => {
+                error!(
+                    "order_plant: WebSocket send timed out for request {}",
+                    request_id
+                );
+                self.request_handler
+                    .fail_request(request_id, RithmicError::SendFailed);
+            }
+        }
+    }
+
+    async fn send_ping(&mut self) -> bool {
+        self.ping_manager.sent();
+
+        match send_with_timeout(
+            &mut self.rithmic_sender,
+            Message::Ping(vec![].into()),
+            Duration::from_secs(SEND_TIMEOUT_SECS),
+        )
+        .await
+        {
+            Ok(()) => false,
+            Err(WebSocketSendError::Transport(error)) => {
+                error!("order_plant: WebSocket ping send failed: {}", error);
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    format!("WebSocket ping send failed: {error}"),
+                );
+                true
+            }
+            Err(WebSocketSendError::Timeout) => {
+                error!("order_plant: WebSocket ping send timed out");
+                self.fail_connection_and_drain(
+                    "websocket_ping_timeout",
+                    RithmicMessage::HeartbeatTimeout,
+                    "WebSocket ping send timed out - connection dead",
+                );
+                true
+            }
+        }
+    }
+
+    async fn send_heartbeat(&mut self) -> bool {
+        let (heartbeat_buf, _id) = self.rithmic_sender_api.request_heartbeat();
+
+        match send_with_timeout(
+            &mut self.rithmic_sender,
+            Message::Binary(heartbeat_buf.into()),
+            Duration::from_secs(SEND_TIMEOUT_SECS),
+        )
+        .await
+        {
+            Ok(()) => false,
+            Err(WebSocketSendError::Transport(error)) => {
+                error!("order_plant: heartbeat send failed: {}", error);
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    format!("Heartbeat send failed: {error}"),
+                );
+                true
+            }
+            Err(WebSocketSendError::Timeout) => {
+                error!("order_plant: heartbeat send timed out");
+                self.fail_connection_and_drain(
+                    "heartbeat_send_timeout",
+                    RithmicMessage::HeartbeatTimeout,
+                    "Heartbeat send timed out - connection dead",
+                );
+                true
+            }
+        }
+    }
+
+    async fn send_close_best_effort(&mut self) {
+        match send_with_timeout(
+            &mut self.rithmic_sender,
+            Message::Close(None),
+            Duration::from_secs(SEND_TIMEOUT_SECS),
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(WebSocketSendError::Transport(error)) => {
+                warn!("order_plant: close send failed: {}", error);
+            }
+            Err(WebSocketSendError::Timeout) => {
+                warn!("order_plant: close send timed out");
+            }
         }
     }
 }
@@ -468,13 +594,14 @@ impl PlantActor for OrderPlant {
         loop {
             tokio::select! {
                 _ = self.interval.tick() => {
-                    if self.logged_in {
-                        self.handle_command(OrderPlantCommand::SendHeartbeat).await;
+                    if self.logged_in && self.send_heartbeat().await {
+                        break;
                     }
                 }
                 _ = self.ping_interval.tick() => {
-                    self.ping_manager.sent();
-                    let _ = self.rithmic_sender.send(Message::Ping(vec![].into())).await;
+                    if self.send_ping().await {
+                        break;
+                    }
                 }
                 _ = async {
                     if let Some(timeout_at) = self.ping_manager.next_timeout_at() {
@@ -485,19 +612,11 @@ impl PlantActor for OrderPlant {
                 } => {
                     if self.ping_manager.check_timeout() {
                         error!("WebSocket ping timed out - connection appears dead");
-
-                        let error_response = RithmicResponse {
-                            request_id: "websocket_ping_timeout".to_string(),
-                            message: RithmicMessage::HeartbeatTimeout,
-                            is_update: true,
-                            has_more: false,
-                            multi_response: false,
-                            error: Some("WebSocket ping timeout - connection dead".to_string()),
-                            source: self.rithmic_receiver_api.source.clone(),
-                        };
-
-                        let _ = self.subscription_sender.send(error_response);
-
+                        self.fail_connection_and_drain(
+                            "websocket_ping_timeout",
+                            RithmicMessage::HeartbeatTimeout,
+                            "WebSocket ping timeout - connection dead",
+                        );
                         break;
                     }
                 }
@@ -540,7 +659,7 @@ impl PlantActor for OrderPlant {
         match message {
             Ok(Message::Close(frame)) => {
                 info!("order_plant: Received close frame: {:?}", frame);
-
+                self.request_handler.drain_and_drop();
                 stop = true;
             }
             Ok(Message::Pong(_)) => {
@@ -594,98 +713,56 @@ impl PlantActor for OrderPlant {
             },
             Err(Error::ConnectionClosed) => {
                 error!("order_plant: connection closed");
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some("WebSocket connection closed".to_string()),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket connection closed",
+                );
                 stop = true;
             }
             Err(Error::AlreadyClosed) => {
                 error!("order_plant: connection already closed");
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some("WebSocket connection already closed".to_string()),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket connection already closed",
+                );
                 stop = true;
             }
             Err(Error::Io(ref io_err)) => {
                 error!("order_plant: I/O error: {}", io_err);
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some(format!("WebSocket I/O error: {}", io_err)),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    format!("WebSocket I/O error: {}", io_err),
+                );
                 stop = true;
             }
             Err(Error::Protocol(ProtocolError::ResetWithoutClosingHandshake)) => {
                 error!("order_plant: connection reset without closing handshake");
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some("WebSocket connection reset without closing handshake".to_string()),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket connection reset without closing handshake",
+                );
                 stop = true;
             }
             Err(Error::Protocol(ProtocolError::SendAfterClosing)) => {
                 error!("order_plant: attempted to send after closing");
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some("WebSocket attempted to send after closing".to_string()),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket attempted to send after closing",
+                );
                 stop = true;
             }
             Err(Error::Protocol(ProtocolError::ReceivedAfterClosing)) => {
                 error!("order_plant: received data after closing");
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some("WebSocket received data after closing".to_string()),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket received data after closing",
+                );
                 stop = true;
             }
             _ => {
@@ -699,7 +776,7 @@ impl PlantActor for OrderPlant {
     async fn handle_command(&mut self, command: OrderPlantCommand) {
         match command {
             OrderPlantCommand::Close => {
-                let _ = self.rithmic_sender.send(Message::Close(None)).await;
+                self.send_close_best_effort().await;
             }
             OrderPlantCommand::ListSystemInfo { response_sender } => {
                 let (list_system_info_buf, id) =
@@ -753,14 +830,6 @@ impl PlantActor for OrderPlant {
                 });
 
                 self.send_or_fail(Message::Binary(logout_buf.into()), &request_id)
-                    .await;
-            }
-            OrderPlantCommand::SendHeartbeat => {
-                let (heartbeat_buf, _id) = self.rithmic_sender_api.request_heartbeat();
-
-                let _ = self
-                    .rithmic_sender
-                    .send(Message::Binary(heartbeat_buf.into()))
                     .await;
             }
             OrderPlantCommand::UpdateHeartbeat { seconds } => {

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -597,12 +597,12 @@ impl PlantActor for OrderPlant {
         loop {
             tokio::select! {
                 _ = self.interval.tick() => {
-                    if self.logged_in && self.send_heartbeat().await {
+                    if self.logged_in && !self.close_requested && self.send_heartbeat().await {
                         break;
                     }
                 }
                 _ = self.ping_interval.tick() => {
-                    if self.send_ping().await {
+                    if !self.close_requested && self.send_ping().await {
                         break;
                     }
                 }
@@ -614,32 +614,27 @@ impl PlantActor for OrderPlant {
                     }
                 } => {
                     if self.ping_manager.check_timeout() {
-                        error!("WebSocket ping timed out - connection appears dead");
-                        self.fail_connection_and_drain(
-                            "websocket_ping_timeout",
-                            RithmicMessage::HeartbeatTimeout,
-                            "WebSocket ping timeout - connection dead",
-                        );
+                        if self.close_requested {
+                            self.request_handler.drain_and_drop();
+                        } else {
+                            error!("WebSocket ping timed out - connection appears dead");
+                            self.fail_connection_and_drain(
+                                "websocket_ping_timeout",
+                                RithmicMessage::HeartbeatTimeout,
+                                "WebSocket ping timeout - connection dead",
+                            );
+                        }
                         break;
                     }
                 }
                 Some(message) = self.request_receiver.recv() => {
                     if matches!(message, OrderPlantCommand::Abort) {
                         info!("order_plant: abort requested, shutting down immediately");
-
-                        let error_response = RithmicResponse {
-                            request_id: "".to_string(),
-                            message: RithmicMessage::ConnectionError,
-                            is_update: true,
-                            has_more: false,
-                            multi_response: false,
-                            error: Some("Plant aborted".to_string()),
-                            source: self.rithmic_receiver_api.source.clone(),
-                        };
-
-                        let _ = self.subscription_sender.send(error_response);
-
-                        self.request_handler.drain_and_drop();
+                        self.fail_connection_and_drain(
+                            "",
+                            RithmicMessage::ConnectionError,
+                            "Plant aborted",
+                        );
                         break;
                     }
                     self.handle_command(message).await;

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -393,6 +393,7 @@ impl RithmicOrderPlant {
 
 struct OrderPlant {
     config: RithmicConfig,
+    close_requested: bool,
     interval: Interval,
     logged_in: bool,
     ping_interval: Interval,
@@ -433,6 +434,7 @@ impl OrderPlant {
 
         Ok(OrderPlant {
             config: config.clone(),
+            close_requested: false,
             interval,
             ping_interval,
             logged_in: false,
@@ -659,7 +661,15 @@ impl PlantActor for OrderPlant {
         match message {
             Ok(Message::Close(frame)) => {
                 info!("order_plant: Received close frame: {:?}", frame);
-                self.request_handler.drain_and_drop();
+                if self.close_requested {
+                    self.request_handler.drain_and_drop();
+                } else {
+                    self.fail_connection_and_drain(
+                        "",
+                        RithmicMessage::ConnectionError,
+                        format!("WebSocket close frame received: {:?}", frame),
+                    );
+                }
                 stop = true;
             }
             Ok(Message::Pong(_)) => {
@@ -776,6 +786,7 @@ impl PlantActor for OrderPlant {
     async fn handle_command(&mut self, command: OrderPlantCommand) {
         match command {
             OrderPlantCommand::Close => {
+                self.close_requested = true;
                 self.send_close_best_effort().await;
             }
             OrderPlantCommand::ListSystemInfo { response_sender } => {

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -393,6 +393,7 @@ impl RithmicOrderPlant {
 
 struct OrderPlant {
     config: RithmicConfig,
+    // Distinguishes an intentional local shutdown from an unexpected peer close.
     close_requested: bool,
     interval: Interval,
     logged_in: bool,

--- a/src/plants/pnl_plant.rs
+++ b/src/plants/pnl_plant.rs
@@ -193,6 +193,7 @@ impl RithmicPnlPlant {
 #[derive(Debug)]
 struct PnlPlant {
     config: RithmicConfig,
+    close_requested: bool,
     interval: Interval,
     logged_in: bool,
     ping_interval: Interval,
@@ -233,6 +234,7 @@ impl PnlPlant {
 
         Ok(PnlPlant {
             config: config.clone(),
+            close_requested: false,
             interval,
             ping_interval,
             logged_in: false,
@@ -461,7 +463,15 @@ impl PlantActor for PnlPlant {
         match message {
             Ok(Message::Close(frame)) => {
                 info!("pnl_plant: Received close frame: {:?}", frame);
-                self.request_handler.drain_and_drop();
+                if self.close_requested {
+                    self.request_handler.drain_and_drop();
+                } else {
+                    self.fail_connection_and_drain(
+                        "",
+                        RithmicMessage::ConnectionError,
+                        format!("WebSocket close frame received: {:?}", frame),
+                    );
+                }
                 stop = true;
             }
             Ok(Message::Pong(_)) => {
@@ -575,6 +585,7 @@ impl PlantActor for PnlPlant {
     async fn handle_command(&mut self, command: PnlPlantCommand) {
         match command {
             PnlPlantCommand::Close => {
+                self.close_requested = true;
                 self.send_close_best_effort().await;
             }
             PnlPlantCommand::ListSystemInfo { response_sender } => {

--- a/src/plants/pnl_plant.rs
+++ b/src/plants/pnl_plant.rs
@@ -193,6 +193,7 @@ impl RithmicPnlPlant {
 #[derive(Debug)]
 struct PnlPlant {
     config: RithmicConfig,
+    // Distinguishes an intentional local shutdown from an unexpected peer close.
     close_requested: bool,
     interval: Interval,
     logged_in: bool,

--- a/src/plants/pnl_plant.rs
+++ b/src/plants/pnl_plant.rs
@@ -399,12 +399,12 @@ impl PlantActor for PnlPlant {
         loop {
             tokio::select! {
                 _ = self.interval.tick() => {
-                    if self.logged_in && self.send_heartbeat().await {
+                    if self.logged_in && !self.close_requested && self.send_heartbeat().await {
                         break;
                     }
                 }
                 _ = self.ping_interval.tick() => {
-                    if self.send_ping().await {
+                    if !self.close_requested && self.send_ping().await {
                         break;
                     }
                 }
@@ -416,32 +416,27 @@ impl PlantActor for PnlPlant {
                     }
                 } => {
                     if self.ping_manager.check_timeout() {
-                        error!("WebSocket ping timed out - connection appears dead");
-                        self.fail_connection_and_drain(
-                            "websocket_ping_timeout",
-                            RithmicMessage::HeartbeatTimeout,
-                            "WebSocket ping timeout - connection dead",
-                        );
+                        if self.close_requested {
+                            self.request_handler.drain_and_drop();
+                        } else {
+                            error!("WebSocket ping timed out - connection appears dead");
+                            self.fail_connection_and_drain(
+                                "websocket_ping_timeout",
+                                RithmicMessage::HeartbeatTimeout,
+                                "WebSocket ping timeout - connection dead",
+                            );
+                        }
                         break;
                     }
                 }
                 Some(message) = self.request_receiver.recv() => {
                     if matches!(message, PnlPlantCommand::Abort) {
                         info!("pnl_plant: abort requested, shutting down immediately");
-
-                        let error_response = RithmicResponse {
-                            request_id: "".to_string(),
-                            message: RithmicMessage::ConnectionError,
-                            is_update: true,
-                            has_more: false,
-                            multi_response: false,
-                            error: Some("Plant aborted".to_string()),
-                            source: self.rithmic_receiver_api.source.clone(),
-                        };
-
-                        let _ = self.subscription_sender.send(error_response);
-
-                        self.request_handler.drain_and_drop();
+                        self.fail_connection_and_drain(
+                            "",
+                            RithmicMessage::ConnectionError,
+                            "Plant aborted",
+                        );
                         break;
                     }
                     self.handle_command(message).await;

--- a/src/plants/pnl_plant.rs
+++ b/src/plants/pnl_plant.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use tracing::{error, info, warn};
 
@@ -16,13 +16,13 @@ use crate::{
     request_handler::{RithmicRequest, RithmicRequestHandler},
     rti::{messages::RithmicMessage, request_login::SysInfraType, request_pn_l_position_updates},
     ws::{
-        HEARTBEAT_SECS, PING_TIMEOUT_SECS, PlantActor, connect_with_strategy,
-        get_heartbeat_interval, get_ping_interval,
+        HEARTBEAT_SECS, PING_TIMEOUT_SECS, PlantActor, SEND_TIMEOUT_SECS, WebSocketSendError,
+        connect_with_strategy, get_heartbeat_interval, get_ping_interval, send_with_timeout,
     },
 };
 
 use futures_util::{
-    SinkExt, StreamExt,
+    StreamExt,
     stream::{SplitSink, SplitStream},
 };
 
@@ -55,7 +55,6 @@ pub(crate) enum PnlPlantCommand {
         account: Arc<RithmicAccount>,
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
     },
-    SendHeartbeat,
     UpdateHeartbeat {
         seconds: u64,
     },
@@ -250,15 +249,142 @@ impl PnlPlant {
 }
 
 impl PnlPlant {
-    async fn send_or_fail(&mut self, msg: Message, request_id: &str) {
-        if self.rithmic_sender.send(msg).await.is_err() {
-            error!(
-                "pnl_plant: WebSocket send failed for request {}",
-                request_id
-            );
+    fn emit_connection_health_event(
+        &self,
+        request_id: &str,
+        message: RithmicMessage,
+        error_message: impl Into<String>,
+    ) {
+        let error_response = RithmicResponse {
+            request_id: request_id.to_string(),
+            message,
+            is_update: true,
+            has_more: false,
+            multi_response: false,
+            error: Some(error_message.into()),
+            source: self.rithmic_receiver_api.source.clone(),
+        };
 
-            self.request_handler
-                .fail_request(request_id, RithmicError::SendFailed);
+        let _ = self.subscription_sender.send(error_response);
+    }
+
+    fn fail_connection_and_drain(
+        &mut self,
+        request_id: &str,
+        message: RithmicMessage,
+        error_message: impl Into<String>,
+    ) {
+        self.emit_connection_health_event(request_id, message, error_message);
+        self.request_handler.drain_and_drop();
+    }
+
+    async fn send_or_fail(&mut self, msg: Message, request_id: &str) {
+        match send_with_timeout(
+            &mut self.rithmic_sender,
+            msg,
+            Duration::from_secs(SEND_TIMEOUT_SECS),
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(WebSocketSendError::Transport(error)) => {
+                error!(
+                    "pnl_plant: WebSocket send failed for request {}: {}",
+                    request_id, error
+                );
+                self.request_handler
+                    .fail_request(request_id, RithmicError::SendFailed);
+            }
+            Err(WebSocketSendError::Timeout) => {
+                error!(
+                    "pnl_plant: WebSocket send timed out for request {}",
+                    request_id
+                );
+                self.request_handler
+                    .fail_request(request_id, RithmicError::SendFailed);
+            }
+        }
+    }
+
+    async fn send_ping(&mut self) -> bool {
+        self.ping_manager.sent();
+
+        match send_with_timeout(
+            &mut self.rithmic_sender,
+            Message::Ping(vec![].into()),
+            Duration::from_secs(SEND_TIMEOUT_SECS),
+        )
+        .await
+        {
+            Ok(()) => false,
+            Err(WebSocketSendError::Transport(error)) => {
+                error!("pnl_plant: WebSocket ping send failed: {}", error);
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    format!("WebSocket ping send failed: {error}"),
+                );
+                true
+            }
+            Err(WebSocketSendError::Timeout) => {
+                error!("pnl_plant: WebSocket ping send timed out");
+                self.fail_connection_and_drain(
+                    "websocket_ping_timeout",
+                    RithmicMessage::HeartbeatTimeout,
+                    "WebSocket ping send timed out - connection dead",
+                );
+                true
+            }
+        }
+    }
+
+    async fn send_heartbeat(&mut self) -> bool {
+        let (heartbeat_buf, _id) = self.rithmic_sender_api.request_heartbeat();
+
+        match send_with_timeout(
+            &mut self.rithmic_sender,
+            Message::Binary(heartbeat_buf.into()),
+            Duration::from_secs(SEND_TIMEOUT_SECS),
+        )
+        .await
+        {
+            Ok(()) => false,
+            Err(WebSocketSendError::Transport(error)) => {
+                error!("pnl_plant: heartbeat send failed: {}", error);
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    format!("Heartbeat send failed: {error}"),
+                );
+                true
+            }
+            Err(WebSocketSendError::Timeout) => {
+                error!("pnl_plant: heartbeat send timed out");
+                self.fail_connection_and_drain(
+                    "heartbeat_send_timeout",
+                    RithmicMessage::HeartbeatTimeout,
+                    "Heartbeat send timed out - connection dead",
+                );
+                true
+            }
+        }
+    }
+
+    async fn send_close_best_effort(&mut self) {
+        match send_with_timeout(
+            &mut self.rithmic_sender,
+            Message::Close(None),
+            Duration::from_secs(SEND_TIMEOUT_SECS),
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(WebSocketSendError::Transport(error)) => {
+                warn!("pnl_plant: close send failed: {}", error);
+            }
+            Err(WebSocketSendError::Timeout) => {
+                warn!("pnl_plant: close send timed out");
+            }
         }
     }
 }
@@ -270,14 +396,14 @@ impl PlantActor for PnlPlant {
         loop {
             tokio::select! {
                 _ = self.interval.tick() => {
-                    if self.logged_in {
-                        self.handle_command(PnlPlantCommand::SendHeartbeat).await;
+                    if self.logged_in && self.send_heartbeat().await {
+                        break;
                     }
                 }
                 _ = self.ping_interval.tick() => {
-                    self.ping_manager.sent();
-
-                    let _ = self.rithmic_sender.send(Message::Ping(vec![].into())).await;
+                    if self.send_ping().await {
+                        break;
+                    }
                 }
                 _ = async {
                     if let Some(timeout_at) = self.ping_manager.next_timeout_at() {
@@ -288,19 +414,11 @@ impl PlantActor for PnlPlant {
                 } => {
                     if self.ping_manager.check_timeout() {
                         error!("WebSocket ping timed out - connection appears dead");
-
-                        let error_response = RithmicResponse {
-                            request_id: "websocket_ping_timeout".to_string(),
-                            message: RithmicMessage::HeartbeatTimeout,
-                            is_update: true,
-                            has_more: false,
-                            multi_response: false,
-                            error: Some("WebSocket ping timeout - connection dead".to_string()),
-                            source: self.rithmic_receiver_api.source.clone(),
-                        };
-
-                        let _ = self.subscription_sender.send(error_response);
-
+                        self.fail_connection_and_drain(
+                            "websocket_ping_timeout",
+                            RithmicMessage::HeartbeatTimeout,
+                            "WebSocket ping timeout - connection dead",
+                        );
                         break;
                     }
                 }
@@ -343,6 +461,7 @@ impl PlantActor for PnlPlant {
         match message {
             Ok(Message::Close(frame)) => {
                 info!("pnl_plant: Received close frame: {:?}", frame);
+                self.request_handler.drain_and_drop();
                 stop = true;
             }
             Ok(Message::Pong(_)) => {
@@ -393,98 +512,56 @@ impl PlantActor for PnlPlant {
             },
             Err(Error::ConnectionClosed) => {
                 error!("pnl_plant: connection closed");
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some("WebSocket connection closed".to_string()),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket connection closed",
+                );
                 stop = true;
             }
             Err(Error::AlreadyClosed) => {
                 error!("pnl_plant: connection already closed");
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some("WebSocket connection already closed".to_string()),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket connection already closed",
+                );
                 stop = true;
             }
             Err(Error::Io(ref io_err)) => {
                 error!("pnl_plant: I/O error: {}", io_err);
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some(format!("WebSocket I/O error: {}", io_err)),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    format!("WebSocket I/O error: {}", io_err),
+                );
                 stop = true;
             }
             Err(Error::Protocol(ProtocolError::ResetWithoutClosingHandshake)) => {
                 error!("pnl_plant: connection reset without closing handshake");
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some("WebSocket connection reset without closing handshake".to_string()),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket connection reset without closing handshake",
+                );
                 stop = true;
             }
             Err(Error::Protocol(ProtocolError::SendAfterClosing)) => {
                 error!("pnl_plant: attempted to send after closing");
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some("WebSocket attempted to send after closing".to_string()),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket attempted to send after closing",
+                );
                 stop = true;
             }
             Err(Error::Protocol(ProtocolError::ReceivedAfterClosing)) => {
                 error!("pnl_plant: received data after closing");
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some("WebSocket received data after closing".to_string()),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket received data after closing",
+                );
                 stop = true;
             }
             _ => {
@@ -498,7 +575,7 @@ impl PlantActor for PnlPlant {
     async fn handle_command(&mut self, command: PnlPlantCommand) {
         match command {
             PnlPlantCommand::Close => {
-                let _ = self.rithmic_sender.send(Message::Close(None)).await;
+                self.send_close_best_effort().await;
             }
             PnlPlantCommand::ListSystemInfo { response_sender } => {
                 let (list_system_info_buf, id) =
@@ -552,14 +629,6 @@ impl PlantActor for PnlPlant {
                 });
 
                 self.send_or_fail(Message::Binary(logout_buf.into()), &request_id)
-                    .await;
-            }
-            PnlPlantCommand::SendHeartbeat => {
-                let (heartbeat_buf, _id) = self.rithmic_sender_api.request_heartbeat();
-
-                let _ = self
-                    .rithmic_sender
-                    .send(Message::Binary(heartbeat_buf.into()))
                     .await;
             }
             PnlPlantCommand::UpdateHeartbeat { seconds } => {

--- a/src/plants/ticker_plant.rs
+++ b/src/plants/ticker_plant.rs
@@ -302,6 +302,7 @@ impl RithmicTickerPlant {
 #[derive(Debug)]
 struct TickerPlant {
     config: RithmicConfig,
+    // Distinguishes an intentional local shutdown from an unexpected peer close.
     close_requested: bool,
     interval: Interval,
     logged_in: bool,

--- a/src/plants/ticker_plant.rs
+++ b/src/plants/ticker_plant.rs
@@ -302,6 +302,7 @@ impl RithmicTickerPlant {
 #[derive(Debug)]
 struct TickerPlant {
     config: RithmicConfig,
+    close_requested: bool,
     interval: Interval,
     logged_in: bool,
     ping_interval: Interval,
@@ -343,6 +344,7 @@ impl TickerPlant {
 
         Ok(TickerPlant {
             config: config.clone(),
+            close_requested: false,
             interval,
             ping_interval,
             logged_in: false,
@@ -576,7 +578,15 @@ impl PlantActor for TickerPlant {
         match message {
             Ok(Message::Close(frame)) => {
                 info!("ticker_plant received close frame: {:?}", frame);
-                self.request_handler.drain_and_drop();
+                if self.close_requested {
+                    self.request_handler.drain_and_drop();
+                } else {
+                    self.fail_connection_and_drain(
+                        "",
+                        RithmicMessage::ConnectionError,
+                        format!("WebSocket close frame received: {:?}", frame),
+                    );
+                }
                 stop = true;
             }
             Ok(Message::Pong(_)) => {
@@ -693,6 +703,7 @@ impl PlantActor for TickerPlant {
     async fn handle_command(&mut self, command: TickerPlantCommand) {
         match command {
             TickerPlantCommand::Close => {
+                self.close_requested = true;
                 self.send_close_best_effort().await;
             }
             TickerPlantCommand::ListSystemInfo { response_sender } => {

--- a/src/plants/ticker_plant.rs
+++ b/src/plants/ticker_plant.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use tracing::{error, info, warn};
 
 use crate::{
@@ -19,13 +21,13 @@ use crate::{
         request_market_data_update_by_underlying, request_search_symbols,
     },
     ws::{
-        HEARTBEAT_SECS, PING_TIMEOUT_SECS, PlantActor, connect_with_strategy,
-        get_heartbeat_interval, get_ping_interval,
+        HEARTBEAT_SECS, PING_TIMEOUT_SECS, PlantActor, SEND_TIMEOUT_SECS, WebSocketSendError,
+        connect_with_strategy, get_heartbeat_interval, get_ping_interval, send_with_timeout,
     },
 };
 
 use futures_util::{
-    SinkExt, StreamExt,
+    StreamExt,
     stream::{SplitSink, SplitStream},
 };
 
@@ -54,7 +56,6 @@ pub(crate) enum TickerPlantCommand {
     Logout {
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
     },
-    SendHeartbeat,
     UpdateHeartbeat {
         seconds: u64,
     },
@@ -358,15 +359,142 @@ impl TickerPlant {
 }
 
 impl TickerPlant {
-    async fn send_or_fail(&mut self, msg: Message, request_id: &str) {
-        if self.rithmic_sender.send(msg).await.is_err() {
-            error!(
-                "ticker_plant: WebSocket send failed for request {}",
-                request_id
-            );
+    fn emit_connection_health_event(
+        &self,
+        request_id: &str,
+        message: RithmicMessage,
+        error_message: impl Into<String>,
+    ) {
+        let error_response = RithmicResponse {
+            request_id: request_id.to_string(),
+            message,
+            is_update: true,
+            has_more: false,
+            multi_response: false,
+            error: Some(error_message.into()),
+            source: self.rithmic_receiver_api.source.clone(),
+        };
 
-            self.request_handler
-                .fail_request(request_id, RithmicError::SendFailed);
+        let _ = self.subscription_sender.send(error_response);
+    }
+
+    fn fail_connection_and_drain(
+        &mut self,
+        request_id: &str,
+        message: RithmicMessage,
+        error_message: impl Into<String>,
+    ) {
+        self.emit_connection_health_event(request_id, message, error_message);
+        self.request_handler.drain_and_drop();
+    }
+
+    async fn send_or_fail(&mut self, msg: Message, request_id: &str) {
+        match send_with_timeout(
+            &mut self.rithmic_sender,
+            msg,
+            Duration::from_secs(SEND_TIMEOUT_SECS),
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(WebSocketSendError::Transport(error)) => {
+                error!(
+                    "ticker_plant: WebSocket send failed for request {}: {}",
+                    request_id, error
+                );
+                self.request_handler
+                    .fail_request(request_id, RithmicError::SendFailed);
+            }
+            Err(WebSocketSendError::Timeout) => {
+                error!(
+                    "ticker_plant: WebSocket send timed out for request {}",
+                    request_id
+                );
+                self.request_handler
+                    .fail_request(request_id, RithmicError::SendFailed);
+            }
+        }
+    }
+
+    async fn send_ping(&mut self) -> bool {
+        self.ping_manager.sent();
+
+        match send_with_timeout(
+            &mut self.rithmic_sender,
+            Message::Ping(vec![].into()),
+            Duration::from_secs(SEND_TIMEOUT_SECS),
+        )
+        .await
+        {
+            Ok(()) => false,
+            Err(WebSocketSendError::Transport(error)) => {
+                error!("ticker_plant: WebSocket ping send failed: {}", error);
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    format!("WebSocket ping send failed: {error}"),
+                );
+                true
+            }
+            Err(WebSocketSendError::Timeout) => {
+                error!("ticker_plant: WebSocket ping send timed out");
+                self.fail_connection_and_drain(
+                    "websocket_ping_timeout",
+                    RithmicMessage::HeartbeatTimeout,
+                    "WebSocket ping send timed out - connection dead",
+                );
+                true
+            }
+        }
+    }
+
+    async fn send_heartbeat(&mut self) -> bool {
+        let (heartbeat_buf, _id) = self.rithmic_sender_api.request_heartbeat();
+
+        match send_with_timeout(
+            &mut self.rithmic_sender,
+            Message::Binary(heartbeat_buf.into()),
+            Duration::from_secs(SEND_TIMEOUT_SECS),
+        )
+        .await
+        {
+            Ok(()) => false,
+            Err(WebSocketSendError::Transport(error)) => {
+                error!("ticker_plant: heartbeat send failed: {}", error);
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    format!("Heartbeat send failed: {error}"),
+                );
+                true
+            }
+            Err(WebSocketSendError::Timeout) => {
+                error!("ticker_plant: heartbeat send timed out");
+                self.fail_connection_and_drain(
+                    "heartbeat_send_timeout",
+                    RithmicMessage::HeartbeatTimeout,
+                    "Heartbeat send timed out - connection dead",
+                );
+                true
+            }
+        }
+    }
+
+    async fn send_close_best_effort(&mut self) {
+        match send_with_timeout(
+            &mut self.rithmic_sender,
+            Message::Close(None),
+            Duration::from_secs(SEND_TIMEOUT_SECS),
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(WebSocketSendError::Transport(error)) => {
+                warn!("ticker_plant: close send failed: {}", error);
+            }
+            Err(WebSocketSendError::Timeout) => {
+                warn!("ticker_plant: close send timed out");
+            }
         }
     }
 }
@@ -382,13 +510,14 @@ impl PlantActor for TickerPlant {
         loop {
             tokio::select! {
                 _ = self.interval.tick() => {
-                    if self.logged_in {
-                        self.handle_command(TickerPlantCommand::SendHeartbeat).await;
+                    if self.logged_in && self.send_heartbeat().await {
+                        break;
                     }
                 }
                 _ = self.ping_interval.tick() => {
-                    self.ping_manager.sent();
-                    let _ = self.rithmic_sender.send(Message::Ping(vec![].into())).await;
+                    if self.send_ping().await {
+                        break;
+                    }
                 }
                 _ = async {
                     if let Some(timeout_at) = self.ping_manager.next_timeout_at() {
@@ -399,17 +528,11 @@ impl PlantActor for TickerPlant {
                 } => {
                     if self.ping_manager.check_timeout() {
                         error!("WebSocket ping timed out - connection appears dead");
-
-                        let error_response = RithmicResponse {
-                            request_id: "websocket_ping_timeout".to_string(),
-                            message: RithmicMessage::HeartbeatTimeout,
-                            is_update: true,
-                            has_more: false,
-                            multi_response: false,
-                            error: Some("WebSocket ping timeout - connection dead".to_string()),
-                            source: self.rithmic_receiver_api.source.clone(),
-                        };
-                        let _ = self.subscription_sender.send(error_response);
+                        self.fail_connection_and_drain(
+                            "websocket_ping_timeout",
+                            RithmicMessage::HeartbeatTimeout,
+                            "WebSocket ping timeout - connection dead",
+                        );
                         break;
                     }
                 }
@@ -453,7 +576,7 @@ impl PlantActor for TickerPlant {
         match message {
             Ok(Message::Close(frame)) => {
                 info!("ticker_plant received close frame: {:?}", frame);
-
+                self.request_handler.drain_and_drop();
                 stop = true;
             }
             Ok(Message::Pong(_)) => {
@@ -507,98 +630,56 @@ impl PlantActor for TickerPlant {
             },
             Err(Error::ConnectionClosed) => {
                 error!("ticker_plant: connection closed");
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some("WebSocket connection closed".to_string()),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket connection closed",
+                );
                 stop = true;
             }
             Err(Error::AlreadyClosed) => {
                 error!("ticker_plant: connection already closed");
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some("WebSocket connection already closed".to_string()),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket connection already closed",
+                );
                 stop = true;
             }
             Err(Error::Io(ref io_err)) => {
                 error!("ticker_plant: I/O error: {}", io_err);
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some(format!("WebSocket I/O error: {}", io_err)),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    format!("WebSocket I/O error: {}", io_err),
+                );
                 stop = true;
             }
             Err(Error::Protocol(ProtocolError::ResetWithoutClosingHandshake)) => {
                 error!("ticker_plant: connection reset without closing handshake");
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some("WebSocket connection reset without closing handshake".to_string()),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket connection reset without closing handshake",
+                );
                 stop = true;
             }
             Err(Error::Protocol(ProtocolError::SendAfterClosing)) => {
                 error!("ticker_plant: attempted to send after closing");
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some("WebSocket attempted to send after closing".to_string()),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket attempted to send after closing",
+                );
                 stop = true;
             }
             Err(Error::Protocol(ProtocolError::ReceivedAfterClosing)) => {
                 error!("ticker_plant: received data after closing");
-
-                let error_response = RithmicResponse {
-                    request_id: "".to_string(),
-                    message: RithmicMessage::ConnectionError,
-                    is_update: true,
-                    has_more: false,
-                    multi_response: false,
-                    error: Some("WebSocket received data after closing".to_string()),
-                    source: self.rithmic_receiver_api.source.clone(),
-                };
-                let _ = self.subscription_sender.send(error_response);
-
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket received data after closing",
+                );
                 stop = true;
             }
             _ => {
@@ -612,7 +693,7 @@ impl PlantActor for TickerPlant {
     async fn handle_command(&mut self, command: TickerPlantCommand) {
         match command {
             TickerPlantCommand::Close => {
-                let _ = self.rithmic_sender.send(Message::Close(None)).await;
+                self.send_close_best_effort().await;
             }
             TickerPlantCommand::ListSystemInfo { response_sender } => {
                 let (list_system_info_buf, id) =
@@ -666,14 +747,6 @@ impl PlantActor for TickerPlant {
                 });
 
                 self.send_or_fail(Message::Binary(logout_buf.into()), &request_id)
-                    .await;
-            }
-            TickerPlantCommand::SendHeartbeat => {
-                let (heartbeat_buf, _id) = self.rithmic_sender_api.request_heartbeat();
-
-                let _ = self
-                    .rithmic_sender
-                    .send(Message::Binary(heartbeat_buf.into()))
                     .await;
             }
             TickerPlantCommand::UpdateHeartbeat { seconds } => {

--- a/src/plants/ticker_plant.rs
+++ b/src/plants/ticker_plant.rs
@@ -513,12 +513,12 @@ impl PlantActor for TickerPlant {
         loop {
             tokio::select! {
                 _ = self.interval.tick() => {
-                    if self.logged_in && self.send_heartbeat().await {
+                    if self.logged_in && !self.close_requested && self.send_heartbeat().await {
                         break;
                     }
                 }
                 _ = self.ping_interval.tick() => {
-                    if self.send_ping().await {
+                    if !self.close_requested && self.send_ping().await {
                         break;
                     }
                 }
@@ -530,33 +530,27 @@ impl PlantActor for TickerPlant {
                     }
                 } => {
                     if self.ping_manager.check_timeout() {
-                        error!("WebSocket ping timed out - connection appears dead");
-                        self.fail_connection_and_drain(
-                            "websocket_ping_timeout",
-                            RithmicMessage::HeartbeatTimeout,
-                            "WebSocket ping timeout - connection dead",
-                        );
+                        if self.close_requested {
+                            self.request_handler.drain_and_drop();
+                        } else {
+                            error!("WebSocket ping timed out - connection appears dead");
+                            self.fail_connection_and_drain(
+                                "websocket_ping_timeout",
+                                RithmicMessage::HeartbeatTimeout,
+                                "WebSocket ping timeout - connection dead",
+                            );
+                        }
                         break;
                     }
                 }
                 Some(message) = self.request_receiver.recv() => {
                     if matches!(message, TickerPlantCommand::Abort) {
                         info!("ticker_plant: abort requested, shutting down immediately");
-
-                        let error_response = RithmicResponse {
-                            request_id: "".to_string(),
-                            message: RithmicMessage::ConnectionError,
-                            is_update: true,
-                            has_more: false,
-                            multi_response: false,
-                            error: Some("Plant aborted".to_string()),
-                            source: self.rithmic_receiver_api.source.clone(),
-                        };
-
-                        let _ = self.subscription_sender.send(error_response);
-
-                        self.request_handler.drain_and_drop();
-
+                        self.fail_connection_and_drain(
+                            "",
+                            RithmicMessage::ConnectionError,
+                            "Plant aborted",
+                        );
                         break;
                     }
                     self.handle_command(message).await;

--- a/src/rti/messages.rs
+++ b/src/rti/messages.rs
@@ -125,8 +125,8 @@ pub enum RithmicMessage {
     /// *Note: This is a synthetic message from rithmic-rs, not from Rithmic servers.*
     ///
     /// This means the network connection to Rithmic was lost (e.g., internet dropped,
-    /// server closed the connection, or a network timeout). The plant has stopped and
-    /// you'll need to reconnect.
+    /// the peer sent a WebSocket close frame, a write failed, or a network timeout).
+    /// The plant has stopped and you'll need to reconnect.
     ///
     /// # Example
     ///

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -1,6 +1,8 @@
 use std::time::Duration;
 use tracing::{info, warn};
 
+use futures_util::{Sink, SinkExt};
+
 use tokio::{
     net::TcpStream,
     time::{Instant, Interval, interval_at, sleep, timeout},
@@ -19,6 +21,9 @@ pub(crate) const PING_INTERVAL_SECS: u64 = 60;
 
 /// Timeout in seconds for WebSocket pong response.
 pub(crate) const PING_TIMEOUT_SECS: u64 = 50;
+
+/// Timeout in seconds for any actor-owned WebSocket write.
+pub(crate) const SEND_TIMEOUT_SECS: u64 = 10;
 
 /// Connection attempt timeout in seconds.
 const CONNECT_TIMEOUT_SECS: u64 = 2;
@@ -47,6 +52,34 @@ pub(crate) trait PlantActor {
     async fn run(&mut self);
     async fn handle_command(&mut self, command: Self::Command);
     async fn handle_rithmic_message(&mut self, message: Result<Message, Error>) -> bool;
+}
+
+/// Error returned when a bounded WebSocket send does not complete.
+#[derive(Debug)]
+pub(crate) enum WebSocketSendError {
+    /// The underlying sink returned an error before the timeout elapsed.
+    Transport(Error),
+    /// The send future did not complete within the configured timeout.
+    Timeout,
+}
+
+/// Sends a WebSocket message with a hard timeout.
+///
+/// This prevents actor loop branches from hanging indefinitely on half-open
+/// connections where the TCP write side no longer makes progress.
+pub(crate) async fn send_with_timeout<S>(
+    sink: &mut S,
+    msg: Message,
+    timeout_duration: Duration,
+) -> Result<(), WebSocketSendError>
+where
+    S: Sink<Message, Error = Error> + Unpin,
+{
+    match timeout(timeout_duration, sink.send(msg)).await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => Err(WebSocketSendError::Transport(error)),
+        Err(_) => Err(WebSocketSendError::Timeout),
+    }
 }
 
 pub(crate) fn get_heartbeat_interval(override_secs: Option<u64>) -> Interval {
@@ -194,5 +227,137 @@ pub(crate) async fn connect_with_strategy(
         ConnectStrategy::Simple => connect(primary_url).await,
         ConnectStrategy::Retry => connect_with_retry_single_url(primary_url).await,
         ConnectStrategy::AlternateWithRetry => connect_with_retry(primary_url, beta_url).await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        pin::Pin,
+        task::{Context, Poll},
+    };
+
+    use super::*;
+
+    enum MockSinkBehavior {
+        Ready,
+        Error,
+        Pending,
+    }
+
+    struct MockMessageSink {
+        behavior: MockSinkBehavior,
+        sent_messages: Vec<Message>,
+    }
+
+    impl MockMessageSink {
+        fn ready() -> Self {
+            Self {
+                behavior: MockSinkBehavior::Ready,
+                sent_messages: Vec::new(),
+            }
+        }
+
+        fn error() -> Self {
+            Self {
+                behavior: MockSinkBehavior::Error,
+                sent_messages: Vec::new(),
+            }
+        }
+
+        fn pending() -> Self {
+            Self {
+                behavior: MockSinkBehavior::Pending,
+                sent_messages: Vec::new(),
+            }
+        }
+    }
+
+    impl Sink<Message> for MockMessageSink {
+        type Error = Error;
+
+        fn poll_ready(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            match self.behavior {
+                MockSinkBehavior::Ready => Poll::Ready(Ok(())),
+                MockSinkBehavior::Error => Poll::Ready(Err(Error::ConnectionClosed)),
+                MockSinkBehavior::Pending => Poll::Pending,
+            }
+        }
+
+        fn start_send(self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
+            self.get_mut().sent_messages.push(item);
+            Ok(())
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            match self.behavior {
+                MockSinkBehavior::Ready => Poll::Ready(Ok(())),
+                MockSinkBehavior::Error => Poll::Ready(Err(Error::ConnectionClosed)),
+                MockSinkBehavior::Pending => Poll::Pending,
+            }
+        }
+
+        fn poll_close(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            match self.behavior {
+                MockSinkBehavior::Ready => Poll::Ready(Ok(())),
+                MockSinkBehavior::Error => Poll::Ready(Err(Error::ConnectionClosed)),
+                MockSinkBehavior::Pending => Poll::Pending,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn send_with_timeout_succeeds_for_ready_sink() {
+        let mut sink = MockMessageSink::ready();
+
+        let result = send_with_timeout(
+            &mut sink,
+            Message::Ping(Vec::new().into()),
+            Duration::from_millis(10),
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(sink.sent_messages.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn send_with_timeout_returns_transport_error() {
+        let mut sink = MockMessageSink::error();
+
+        let result = send_with_timeout(
+            &mut sink,
+            Message::Ping(Vec::new().into()),
+            Duration::from_millis(10),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(WebSocketSendError::Transport(Error::ConnectionClosed))
+        ));
+    }
+
+    #[tokio::test]
+    async fn send_with_timeout_returns_timeout_for_stuck_sink() {
+        let mut sink = MockMessageSink::pending();
+
+        let result = send_with_timeout(
+            &mut sink,
+            Message::Ping(Vec::new().into()),
+            Duration::from_millis(10),
+        )
+        .await;
+
+        assert!(matches!(result, Err(WebSocketSendError::Timeout)));
     }
 }

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -67,6 +67,14 @@ pub(crate) enum WebSocketSendError {
 ///
 /// This prevents actor loop branches from hanging indefinitely on half-open
 /// connections where the TCP write side no longer makes progress.
+///
+/// # Cancellation safety
+///
+/// This function is not cancel-safe with respect to the underlying sink. If the
+/// timeout fires while the sink is flushing, the message may already be buffered
+/// inside the WebSocket stream even though the future returned `Timeout`.
+/// Callers must treat the sink as poisoned after any non-`Ok` return and avoid
+/// reusing it.
 pub(crate) async fn send_with_timeout<S>(
     sink: &mut S,
     msg: Message,


### PR DESCRIPTION
## Summary
- bound all actor-owned WebSocket writes with a hard timeout across ticker, order, PnL, and history plants
- fail request-path writes as `RithmicError::SendFailed` instead of letting an actor wedge indefinitely on `send().await`
- treat keep-alive write failures, write timeouts, and unexpected peer close frames as terminal connection-health events that drain pending requests and stop the actor
- add shared timed-send unit tests and tighten reconnect-facing docs/example behavior

## Root Cause
Issue #52 comes from plant actors awaiting WebSocket writes directly inside `tokio::select!` branches. On a half-open or stalled TCP connection, `send().await` can block forever, which prevents the actor from processing reads, ping timeout checks, and downstream connection health notifications.

## Impact
This removes the silent-freeze failure mode from actor-owned outbound writes and makes the crate's external reconnect loop reliable:
- unexpected peer close frames now surface as `ConnectionError`
- keep-alive send timeouts surface as `HeartbeatTimeout`
- graceful local `disconnect()` remains quiet and does not emit a spurious reconnect signal

The crate still does **not** auto-reconnect a plant internally. This PR makes the failure signals deterministic so a supervisor loop like `examples/reconnect.rs` can reconnect cleanly.

## Validation
### Proven on this branch
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets`
- unit coverage for the timed-send helper in success, transport-error, and timeout cases
- code-path verification that request writes, ping writes, heartbeat writes, and unexpected peer `Close` frames now produce bounded failure behavior instead of indefinite actor hangs

### Not yet proven
- no live Rithmic demo/live session fault-injection was run from this branch
- no real half-open TCP stall was induced against an actual Rithmic connection
- no built-in in-place autoreconnect was added; reconnect remains an external supervisor responsibility by design
