### PR TITLE
docs: prep 2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0]
+
 ### Breaking Changes
 
-- `RithmicConfig` no longer includes `account_id`, `fcm_id`, or `ib_id`
-- `RithmicOrderPlant::get_handle()` and `RithmicPnlPlant::get_handle()` now require `&RithmicAccount`
-- `subscription_receiver` on order and PnL handles is now `SubscriptionFilter`
+- **`RithmicConfig` no longer includes `account_id`, `fcm_id`, or `ib_id`** — those fields moved to `RithmicAccount`
+- **`RithmicOrderPlant::get_handle()` and `RithmicPnlPlant::get_handle()` now require `&RithmicAccount`**
+  - Create a `RithmicAccount` with `RithmicAccount::from_env(env)` or build one directly
+  - For multi-account workflows, create one `RithmicAccount` per account and call `get_handle(&account)` for each
+- **`subscription_receiver` on order and PnL handles is now `SubscriptionFilter`** instead of `broadcast::Receiver<RithmicResponse>`
 
 ### Added
 
+- **`RithmicAccount`** — account-scoped type for order and PnL operations
+  - `RithmicAccount::from_env(RithmicEnv)` loads `RITHMIC_<ENV>_ACCOUNT_ID`, `FCM_ID`, `IB_ID`
 - **`load_tick_bars(symbol, exchange, bar_length, start_time_sec, end_time_sec)`** on `RithmicHistoryPlantHandle`
   - Fetches historical N-tick bars (e.g., 5-tick, 10-tick) for a symbol
   - `bar_length` controls the number of ticks aggregated into each bar
-  - Returns `InvalidArgument` error when `bar_length` is 0
-- **`RithmicError::InvalidArgument`** variant for rejecting invalid caller-supplied arguments before a request is sent
-- `RithmicAccount` for account-scoped order and PnL operations
+  - Returns `RithmicError::InvalidArgument` when `bar_length` is 0
+- **`RithmicError::InvalidArgument(String)`** variant for rejecting invalid caller-supplied arguments before a request is sent
+- **`RithmicAdvancedBracketOrder`** — full raw bracket order request exposing all venue-native fields
+  - Supports triggered entry, break-even, trailing-stop, timed release/cancel, and if-touched entry conditions
+  - Re-exported from crate root
+- **`RithmicIfTouchedTrigger`** — conditional trigger for advanced bracket order entry (`if_touched_*` fields)
+  - Re-exported from crate root
+- **New bracket order enums** re-exported from crate root: `BracketType`, `BracketCondition`, `BracketPriceField`
+- **Semantic ticker market-data subscription helpers** on `RithmicTickerPlantHandle` (all accept `symbol, exchange`):
+  - `subscribe_instrument_status` / `unsubscribe_instrument_status` — market mode updates
+  - `subscribe_order_book_summary` / `unsubscribe_order_book_summary` — aggregated bid/ask summary (proto 100, distinct from depth-by-order)
+  - `subscribe_session_prices` / `unsubscribe_session_prices` — high/low/open trade statistics
+  - `subscribe_quote_statistics` / `unsubscribe_quote_statistics` — quote-related statistics
+  - `subscribe_indicator_prices` / `unsubscribe_indicator_prices` — settlement and projected settlement prices
+  - `subscribe_open_interest` / `unsubscribe_open_interest` — open interest updates
+  - `subscribe_end_of_day_prices` / `unsubscribe_end_of_day_prices` — end-of-day price data
+  - `subscribe_order_price_limits` / `unsubscribe_order_price_limits` — high/low price limits
+  - `subscribe_symbol_margin_rate` / `unsubscribe_symbol_margin_rate` — margin rate updates
 
 ### Changed
 
+- **`RithmicError::SendFailed`** now also covers send timeouts — all plant WebSocket sends are bounded to 10 seconds; a hung sink surfaces as `SendFailed` rather than blocking the actor indefinitely
 - **`load_ticks`** now delegates to `load_tick_bars` with `bar_length = 1` — no behavioral change for existing callers
 - **`request_tick_bar_replay`** on `RithmicSenderApi` now accepts a `bar_type_specifier` parameter instead of hard-coding `"1"`
+
+### Fixed
+
+- **`rp_code = ["7", "no data"]`** is now treated as a successful empty result (not an error) across all list/replay/search responses — previously this caused methods like `replay_executions` to return `ServerError("no data")` when the query matched zero records
 
 ## [1.0.0]
 
@@ -647,6 +673,7 @@ Previous stable release. See git history for earlier changes.
 
 ## Version History Summary
 
+- **2.0.0**: Breaking changes - `RithmicAccount` split from `RithmicConfig`, account-scoped `get_handle()`, `SubscriptionFilter`; advanced bracket orders, semantic ticker subscriptions, bounded WebSocket sends
 - **1.0.0**: Breaking changes - typed `RithmicError` enum, prost 0.14, async-trait removed, `LoginConfig` for advanced login, `await_shutdown()`, non_exhaustive annotations, MSRV 1.85
 - **0.7.2** (2026-02-07): New RithmicOrder API with trigger prices and trailing stops, ticker plant unsubscribe methods, serde-compatible order types
 - **0.7.1** (2026-01-23): New utility module (InstrumentInfo, OrderStatus, timestamp helpers), RithmicResponse helper methods, optional serde support, improved error handling
@@ -660,7 +687,8 @@ Previous stable release. See git history for earlier changes.
 - **0.5.0** (2025-11-16): Major stability and API improvements - Connection strategies, unified config, panic fixes, connection health monitoring
 - **0.4.2** (2025-11-15): Previous stable release
 
-[Unreleased]: https://github.com/pbeets/rithmic-rs/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/pbeets/rithmic-rs/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/pbeets/rithmic-rs/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/pbeets/rithmic-rs/compare/v0.7.2...v1.0.0
 [0.7.2]: https://github.com/pbeets/rithmic-rs/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/pbeets/rithmic-rs/compare/v0.7.0...v0.7.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rithmic-rs"
-version = "1.0.0"
+version = "2.0.0"
 description = "Rust client for the Rithmic R | Protocol API to build algo trading systems"
 license = "MIT OR Apache-2.0"
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rithmic-rs = "1.0.0"
+rithmic-rs = "2.0.0"
 ```
 
 Set your environment variables:
@@ -83,6 +83,12 @@ handle.subscribe("ESM6", "CME").await?;
 // Unsubscribe when done
 handle.unsubscribe("ESM6", "CME").await?;
 
+// Additional market data subscriptions
+handle.subscribe_instrument_status("ESM6", "CME").await?;
+handle.subscribe_open_interest("ESM6", "CME").await?;
+handle.subscribe_session_prices("ESM6", "CME").await?;
+handle.subscribe_order_price_limits("ESM6", "CME").await?;
+
 // Symbol discovery
 let symbols = handle.search_symbols("ES", Some("CME"), None, None, None).await?;
 let front_month = handle.get_front_month_contract("ES", "CME", false).await?;
@@ -115,8 +121,9 @@ let order = RithmicOrder {
 };
 handle.place_order(order).await?;
 
-// Bracket orders, OCO orders
+// Bracket orders, OCO orders, advanced bracket orders
 handle.place_bracket_order(...).await?;
+handle.place_advanced_bracket_order(advanced_order).await?;
 
 // Manage positions
 handle.cancel_order(order_id).await?;
@@ -132,6 +139,9 @@ For multi-account workflows, create one [`RithmicAccount`] per account and call
 // Load historical data (bar_type, period, start_time, end_time as i32 unix seconds)
 let bars = handle.load_time_bars("ESM6", "CME", BarType::MinuteBar, 5, start, end).await?;
 let ticks = handle.load_ticks("ESM6", "CME", start, end).await?;
+
+// Load N-tick bars (e.g., 5-tick bars)
+let tick_bars = handle.load_tick_bars("ESM6", "CME", 5, start, end).await?;
 ```
 
 ### PnL Plant
@@ -165,6 +175,7 @@ match handle.subscribe("ESM6", "CME").await {
         handle.abort();
         // reconnect — see examples/reconnect.rs
     }
+    Err(RithmicError::InvalidArgument(msg)) => eprintln!("Bad argument: {}", msg),
     Err(RithmicError::ServerError(msg)) => eprintln!("Server rejected: {}", msg),
     Err(e) => eprintln!("{}", e),
 }

--- a/src/plants/ticker_plant.rs
+++ b/src/plants/ticker_plant.rs
@@ -1365,6 +1365,10 @@ impl RithmicTickerPlantHandle {
     ///
     /// # Returns
     /// The subscription response or an error message
+    ///
+    /// # Updates
+    /// After subscribing, market mode changes arrive as [`RithmicMessage::MarketMode`]
+    /// on `subscription_receiver`.
     pub async fn subscribe_instrument_status(
         &self,
         symbol: &str,
@@ -1414,6 +1418,10 @@ impl RithmicTickerPlantHandle {
     ///
     /// # Returns
     /// The subscription response or an error message
+    ///
+    /// # Updates
+    /// After subscribing, aggregated bid/ask updates arrive as [`RithmicMessage::OrderBook`]
+    /// on `subscription_receiver`.
     pub async fn subscribe_order_book_summary(
         &self,
         symbol: &str,
@@ -1462,6 +1470,10 @@ impl RithmicTickerPlantHandle {
     ///
     /// # Returns
     /// The subscription response or an error message
+    ///
+    /// # Updates
+    /// After subscribing, intraday high, low, and open price updates arrive as
+    /// [`RithmicMessage::TradeStatistics`] on `subscription_receiver`.
     pub async fn subscribe_session_prices(
         &self,
         symbol: &str,
@@ -1506,6 +1518,10 @@ impl RithmicTickerPlantHandle {
     ///
     /// # Returns
     /// The subscription response or an error message
+    ///
+    /// # Updates
+    /// After subscribing, high bid / low ask updates arrive as
+    /// [`RithmicMessage::QuoteStatistics`] on `subscription_receiver`.
     pub async fn subscribe_quote_statistics(
         &self,
         symbol: &str,
@@ -1550,6 +1566,10 @@ impl RithmicTickerPlantHandle {
     ///
     /// # Returns
     /// The subscription response or an error message
+    ///
+    /// # Updates
+    /// After subscribing, opening and closing indicator prices arrive as
+    /// [`RithmicMessage::IndicatorPrices`] on `subscription_receiver`.
     pub async fn subscribe_indicator_prices(
         &self,
         symbol: &str,
@@ -1594,6 +1614,10 @@ impl RithmicTickerPlantHandle {
     ///
     /// # Returns
     /// The subscription response or an error message
+    ///
+    /// # Updates
+    /// After subscribing, open interest updates arrive as [`RithmicMessage::OpenInterest`]
+    /// on `subscription_receiver`.
     pub async fn subscribe_open_interest(
         &self,
         symbol: &str,
@@ -1644,6 +1668,10 @@ impl RithmicTickerPlantHandle {
     ///
     /// # Returns
     /// The subscription response or an error message
+    ///
+    /// # Updates
+    /// After subscribing, close, settlement, and projected settlement updates arrive as
+    /// [`RithmicMessage::EndOfDayPrices`] on `subscription_receiver`.
     pub async fn subscribe_end_of_day_prices(
         &self,
         symbol: &str,
@@ -1701,6 +1729,10 @@ impl RithmicTickerPlantHandle {
     ///
     /// # Returns
     /// The subscription response or an error message
+    ///
+    /// # Updates
+    /// After subscribing, high and low price limit updates arrive as
+    /// [`RithmicMessage::OrderPriceLimits`] on `subscription_receiver`.
     pub async fn subscribe_order_price_limits(
         &self,
         symbol: &str,
@@ -1745,6 +1777,10 @@ impl RithmicTickerPlantHandle {
     ///
     /// # Returns
     /// The subscription response or an error message
+    ///
+    /// # Updates
+    /// After subscribing, margin rate updates arrive as [`RithmicMessage::SymbolMarginRate`]
+    /// on `subscription_receiver`.
     pub async fn subscribe_symbol_margin_rate(
         &self,
         symbol: &str,


### PR DESCRIPTION
## Summary

- Promotes `[Unreleased]` to `[2.0.0]` in CHANGELOG with complete breaking changes, added features, and fixes documented
- Bumps version to `2.0.0` in `Cargo.toml` and `README.md`
- Updates README with new API surface: semantic ticker subscriptions, `load_tick_bars`, `RithmicAdvancedBracketOrder`, `InvalidArgument` error arm
- Adds `# Updates` doc section to all 9 new `subscribe_*` methods on `RithmicTickerPlantHandle` — each now names the `RithmicMessage` variant that arrives on `subscription_receiver`

## What's in 2.0.0

**Breaking changes** (from commits since 1.0.0):
- `RithmicConfig` no longer includes `account_id`/`fcm_id`/`ib_id` — moved to `RithmicAccount`
- `get_handle()` on order and PnL plants now requires `&RithmicAccount`
- `subscription_receiver` on order and PnL handles is now `SubscriptionFilter`

**Added:**
- `RithmicAccount` with `from_env()` and `new()` constructors
- `load_tick_bars()` for configurable N-tick bar replay
- `RithmicError::InvalidArgument`
- `RithmicAdvancedBracketOrder` + `RithmicIfTouchedTrigger` + `BracketType`/`BracketCondition`/`BracketPriceField` enums
- 9 semantic ticker subscription helpers (`subscribe_instrument_status`, `subscribe_open_interest`, etc.)

**Changed:** `SendFailed` now covers 10s send timeouts across all plants

**Fixed:** `rp_code = ["7", "no data"]` treated as empty result, not an error

## Test plan
- [ ] `cargo check` passes (verified locally)
- [ ] Review CHANGELOG for accuracy against merged PRs #46, #49, #50, #53, #54, #55
- [ ] Confirm version is `2.0.0` in `Cargo.toml`