### PR TITLE
refactor: extract PlantCore generic over WebSocket sink + error-path tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,5 @@ tracing = "0.1.44"
 dotenvy = "0.15.7"
 prost-build = "0.14.3"
 temp-env = "0.3"
+tokio = { version = "1.50.0", features = ["test-util"] }
 tracing-subscriber = "0.3.23"

--- a/src/api/receiver_api.rs
+++ b/src/api/receiver_api.rs
@@ -1891,8 +1891,18 @@ mod tests {
     }
 
     // =========================================================================
-    // get_error() / rp_code["7", "no data"] tests
+    // get_error() / has_multiple() unit tests
     // =========================================================================
+
+    #[test]
+    fn get_error_returns_none_for_empty_rp_code() {
+        assert_eq!(super::get_error(&[]), None);
+    }
+
+    #[test]
+    fn get_error_returns_none_for_zero_rp_code() {
+        assert_eq!(super::get_error(&["0".to_string()]), None);
+    }
 
     #[test]
     fn get_error_returns_none_for_no_data_rp_code() {
@@ -1913,6 +1923,50 @@ mod tests {
         // code "7" with a different message is still an error
         let rp_code = vec!["7".to_string(), "permission denied".to_string()];
         assert!(get_error(&rp_code).is_some());
+    }
+
+    #[test]
+    fn get_error_returns_some_for_code_7_with_error() {
+        assert_eq!(
+            super::get_error(&["7".to_string(), "permission denied".to_string()]),
+            Some("permission denied".to_string())
+        );
+    }
+
+    #[test]
+    fn get_error_returns_second_element_for_non_zero_non_7_code() {
+        assert_eq!(
+            super::get_error(&["3".to_string(), "bad request".to_string()]),
+            Some("bad request".to_string())
+        );
+    }
+
+    #[test]
+    fn get_error_returns_first_element_when_no_second() {
+        assert_eq!(
+            super::get_error(&["5".to_string()]),
+            Some("5".to_string())
+        );
+    }
+
+    #[test]
+    fn has_multiple_returns_true_for_zero_code() {
+        assert!(super::has_multiple(&["0".to_string()]));
+    }
+
+    #[test]
+    fn has_multiple_returns_false_for_empty() {
+        assert!(!super::has_multiple(&[]));
+    }
+
+    #[test]
+    fn has_multiple_returns_false_for_non_zero_code() {
+        assert!(!super::has_multiple(&["7".to_string()]));
+    }
+
+    #[test]
+    fn has_multiple_returns_false_for_zero_as_second_element() {
+        assert!(!super::has_multiple(&["1".to_string(), "0".to_string()]));
     }
 
     #[test]

--- a/src/api/receiver_api.rs
+++ b/src/api/receiver_api.rs
@@ -1943,10 +1943,7 @@ mod tests {
 
     #[test]
     fn get_error_returns_first_element_when_no_second() {
-        assert_eq!(
-            super::get_error(&["5".to_string()]),
-            Some("5".to_string())
-        );
+        assert_eq!(super::get_error(&["5".to_string()]), Some("5".to_string()));
     }
 
     #[test]

--- a/src/ping_manager.rs
+++ b/src/ping_manager.rs
@@ -80,8 +80,6 @@ mod tests {
     use super::*;
     use std::time::Duration;
 
-    // ── synchronous tests ────────────────────────────────────────────────────
-
     #[test]
     fn new_has_no_pending() {
         let mut mgr = PingManager::new(60);
@@ -126,8 +124,6 @@ mod tests {
         mgr.sent(); // should not panic, just log a warning
         assert!(mgr.next_timeout_at().is_some());
     }
-
-    // ── timing tests (paused tokio clock) ───────────────────────────────────
 
     #[tokio::test]
     async fn check_timeout_returns_true_after_deadline() {

--- a/src/ping_manager.rs
+++ b/src/ping_manager.rs
@@ -165,6 +165,9 @@ mod tests {
         } else {
             expected - deadline
         };
-        assert!(delta <= Duration::from_millis(1), "deadline delta too large: {delta:?}");
+        assert!(
+            delta <= Duration::from_millis(1),
+            "deadline delta too large: {delta:?}"
+        );
     }
 }

--- a/src/ping_manager.rs
+++ b/src/ping_manager.rs
@@ -74,3 +74,97 @@ impl PingManager {
         self.pending.map(|sent_at| sent_at + self.timeout)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    // ── synchronous tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn new_has_no_pending() {
+        let mut mgr = PingManager::new(60);
+        assert!(mgr.next_timeout_at().is_none());
+        assert!(!mgr.check_timeout());
+    }
+
+    #[test]
+    fn sent_marks_pending() {
+        let mut mgr = PingManager::new(60);
+        mgr.sent();
+        assert!(mgr.next_timeout_at().is_some());
+    }
+
+    #[test]
+    fn received_clears_pending() {
+        let mut mgr = PingManager::new(60);
+        mgr.sent();
+        mgr.received();
+        assert!(mgr.next_timeout_at().is_none());
+        assert!(!mgr.check_timeout());
+    }
+
+    #[test]
+    fn check_timeout_returns_false_before_deadline() {
+        let mut mgr = PingManager::new(60);
+        mgr.sent();
+        // Called immediately — timeout has not elapsed yet.
+        assert!(!mgr.check_timeout());
+    }
+
+    #[test]
+    fn check_timeout_false_when_no_pending() {
+        let mut mgr = PingManager::new(60);
+        assert!(!mgr.check_timeout());
+    }
+
+    #[test]
+    fn sent_twice_replaces_pending() {
+        let mut mgr = PingManager::new(60);
+        mgr.sent();
+        mgr.sent(); // should not panic, just log a warning
+        assert!(mgr.next_timeout_at().is_some());
+    }
+
+    // ── timing tests (paused tokio clock) ───────────────────────────────────
+
+    #[tokio::test]
+    async fn check_timeout_returns_true_after_deadline() {
+        tokio::time::pause();
+        let mut mgr = PingManager::new(1);
+        mgr.sent();
+        tokio::time::advance(Duration::from_secs(2)).await;
+        assert!(mgr.check_timeout());
+    }
+
+    #[tokio::test]
+    async fn check_timeout_clears_pending_after_trigger() {
+        tokio::time::pause();
+        let mut mgr = PingManager::new(1);
+        mgr.sent();
+        tokio::time::advance(Duration::from_secs(2)).await;
+        assert!(mgr.check_timeout());
+        // State must be cleared — no double-trigger.
+        assert!(mgr.next_timeout_at().is_none());
+        assert!(!mgr.check_timeout());
+    }
+
+    #[tokio::test]
+    async fn next_timeout_at_is_sent_at_plus_timeout() {
+        tokio::time::pause();
+        let timeout_secs = 30_u64;
+        let mut mgr = PingManager::new(timeout_secs);
+        let before = Instant::now();
+        mgr.sent();
+        let deadline = mgr.next_timeout_at().expect("should have a deadline");
+        let expected = before + Duration::from_secs(timeout_secs);
+        // Allow a tiny delta (1 ms) for any sub-millisecond clock granularity.
+        let delta = if deadline >= expected {
+            deadline - expected
+        } else {
+            expected - deadline
+        };
+        assert!(delta <= Duration::from_millis(1), "deadline delta too large: {delta:?}");
+    }
+}

--- a/src/plants.rs
+++ b/src/plants.rs
@@ -10,6 +10,7 @@
 //! - **PnlPlant**: Position and profit/loss tracking
 //! - **HistoryPlant**: Historical data retrieval
 
+pub(crate) mod core;
 /// Access to historical market data
 pub mod history_plant;
 /// Order entry and management

--- a/src/plants/core.rs
+++ b/src/plants/core.rs
@@ -1,0 +1,1095 @@
+use std::time::Duration;
+use tracing::{error, info, warn};
+
+use futures_util::{
+    Sink, StreamExt,
+    stream::{SplitSink, SplitStream},
+};
+
+use tokio::{
+    net::TcpStream,
+    sync::{broadcast, oneshot},
+    time::Interval,
+};
+
+use tokio_tungstenite::{
+    MaybeTlsStream, WebSocketStream,
+    tungstenite::{Error, Message, error::ProtocolError},
+};
+
+use crate::{
+    ConnectStrategy,
+    api::{
+        receiver_api::{RithmicReceiverApi, RithmicResponse},
+        rithmic_command_types::LoginConfig,
+        sender_api::RithmicSenderApi,
+    },
+    config::RithmicConfig,
+    error::RithmicError,
+    ping_manager::PingManager,
+    request_handler::{RithmicRequest, RithmicRequestHandler},
+    rti::{messages::RithmicMessage, request_login::SysInfraType},
+    ws::{
+        PING_TIMEOUT_SECS, SEND_TIMEOUT_SECS, WebSocketSendError, connect_with_strategy,
+        get_heartbeat_interval, get_ping_interval, send_with_timeout,
+    },
+};
+
+// Type aliases for the split WebSocket stream components.
+pub(crate) type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
+pub(crate) type WsSink = SplitSink<WsStream, Message>;
+pub(crate) type WsReader = SplitStream<WsStream>;
+
+/// Result of a single iteration of the plant's `select!` loop.
+pub(crate) enum SelectResult<C> {
+    HeartbeatFired,
+    PingFired,
+    PingTimeout,
+    Command(C),
+    RithmicMessage(Result<Message, Error>),
+    /// The WebSocket reader stream returned `None` (clean EOF from the peer).
+    StreamClosed,
+}
+
+/// Shared infrastructure for all Rithmic plant actors.
+///
+/// Holds the WebSocket connection, heartbeat/ping timers, request handler,
+/// and sender/receiver APIs that every plant uses. Each plant wraps a
+/// `PlantCore` plus its own command receiver.
+///
+/// The type parameter `S` is the WebSocket sink type. It defaults to [`WsSink`]
+/// (the concrete split-sink from a real TLS connection) but can be replaced
+/// with a mock sink in tests.
+#[derive(Debug)]
+pub(crate) struct PlantCore<S = WsSink> {
+    pub(crate) config: RithmicConfig,
+    pub(crate) close_requested: bool,
+    pub(crate) interval: Interval,
+    pub(crate) logged_in: bool,
+    pub(crate) ping_interval: Interval,
+    pub(crate) ping_manager: PingManager,
+    pub(crate) request_handler: RithmicRequestHandler,
+    pub(crate) rithmic_reader: WsReader,
+    pub(crate) rithmic_receiver_api: RithmicReceiverApi,
+    pub(crate) rithmic_sender: S,
+    pub(crate) rithmic_sender_api: RithmicSenderApi,
+    pub(crate) subscription_sender: broadcast::Sender<RithmicResponse>,
+}
+
+impl PlantCore<WsSink> {
+    pub(crate) async fn new(
+        subscription_sender: broadcast::Sender<RithmicResponse>,
+        config: &RithmicConfig,
+        strategy: ConnectStrategy,
+        source: &'static str,
+    ) -> Result<PlantCore, RithmicError> {
+        let ws_stream = connect_with_strategy(&config.url, &config.beta_url, strategy)
+            .await
+            .map_err(|e| RithmicError::ConnectionFailed(e.to_string()))?;
+
+        let (rithmic_sender, rithmic_reader) = ws_stream.split();
+
+        let rithmic_sender_api = RithmicSenderApi::new(config);
+        let rithmic_receiver_api = RithmicReceiverApi {
+            source: source.to_string(),
+        };
+
+        let interval = get_heartbeat_interval(None);
+        let ping_interval = get_ping_interval(None);
+        let ping_manager = PingManager::new(PING_TIMEOUT_SECS);
+
+        Ok(PlantCore {
+            config: config.clone(),
+            close_requested: false,
+            interval,
+            logged_in: false,
+            ping_interval,
+            ping_manager,
+            request_handler: RithmicRequestHandler::new(),
+            rithmic_reader,
+            rithmic_receiver_api,
+            rithmic_sender,
+            rithmic_sender_api,
+            subscription_sender,
+        })
+    }
+}
+
+// ── Infrastructure methods ────────────────────────────────────────────────────
+
+impl<S> PlantCore<S>
+where
+    S: Sink<Message, Error = Error> + Unpin,
+{
+    pub(crate) fn emit_connection_health_event(
+        &self,
+        request_id: &str,
+        message: RithmicMessage,
+        error_message: impl Into<String>,
+    ) {
+        let error_response = RithmicResponse {
+            request_id: request_id.to_string(),
+            message,
+            is_update: true,
+            has_more: false,
+            multi_response: false,
+            error: Some(error_message.into()),
+            source: self.rithmic_receiver_api.source.clone(),
+        };
+
+        let _ = self.subscription_sender.send(error_response);
+    }
+
+    pub(crate) fn fail_connection_and_drain(
+        &mut self,
+        request_id: &str,
+        message: RithmicMessage,
+        error_message: impl Into<String>,
+    ) {
+        self.emit_connection_health_event(request_id, message, error_message);
+        self.request_handler.drain_and_drop();
+    }
+
+    pub(crate) async fn send_or_fail(&mut self, msg: Message, request_id: &str) {
+        match send_with_timeout(
+            &mut self.rithmic_sender,
+            msg,
+            Duration::from_secs(SEND_TIMEOUT_SECS),
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(WebSocketSendError::Transport(error)) => {
+                error!(
+                    "{}: WebSocket send failed for request {}: {}",
+                    self.rithmic_receiver_api.source, request_id, error
+                );
+                // Fail only this request.  The dead sink will be detected on the
+                // next reader poll or ping, which will drain remaining requests and
+                // emit the connection-health event from a code path that can stop
+                // the actor loop.
+                self.request_handler
+                    .fail_request(request_id, RithmicError::SendFailed);
+            }
+            Err(WebSocketSendError::Timeout) => {
+                error!(
+                    "{}: WebSocket send timed out for request {}",
+                    self.rithmic_receiver_api.source, request_id
+                );
+                self.request_handler
+                    .fail_request(request_id, RithmicError::SendFailed);
+            }
+        }
+    }
+
+    /// Send a WebSocket ping frame. Returns `true` if the actor should stop.
+    ///
+    /// Skips (returns `false`) when a close has already been requested.
+    pub(crate) async fn send_ping(&mut self) -> bool {
+        if self.close_requested {
+            return false;
+        }
+
+        match send_with_timeout(
+            &mut self.rithmic_sender,
+            Message::Ping(vec![].into()),
+            Duration::from_secs(SEND_TIMEOUT_SECS),
+        )
+        .await
+        {
+            Ok(()) => {
+                self.ping_manager.sent();
+                false
+            }
+            Err(WebSocketSendError::Transport(error)) => {
+                error!(
+                    "{}: WebSocket ping send failed: {}",
+                    self.rithmic_receiver_api.source, error
+                );
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    format!("WebSocket ping send failed: {error}"),
+                );
+                true
+            }
+            Err(WebSocketSendError::Timeout) => {
+                error!(
+                    "{}: WebSocket ping send timed out",
+                    self.rithmic_receiver_api.source
+                );
+                self.fail_connection_and_drain(
+                    "websocket_ping_timeout",
+                    RithmicMessage::HeartbeatTimeout,
+                    "WebSocket ping send timed out - connection dead",
+                );
+                true
+            }
+        }
+    }
+
+    /// Send a Rithmic heartbeat message. Returns `true` if the actor should stop.
+    ///
+    /// Skips (returns `false`) when not yet logged in or a close has been requested.
+    pub(crate) async fn send_heartbeat(&mut self) -> bool {
+        if !self.logged_in || self.close_requested {
+            return false;
+        }
+
+        let (heartbeat_buf, _id) = self.rithmic_sender_api.request_heartbeat();
+
+        match send_with_timeout(
+            &mut self.rithmic_sender,
+            Message::Binary(heartbeat_buf.into()),
+            Duration::from_secs(SEND_TIMEOUT_SECS),
+        )
+        .await
+        {
+            Ok(()) => false,
+            Err(WebSocketSendError::Transport(error)) => {
+                error!(
+                    "{}: heartbeat send failed: {}",
+                    self.rithmic_receiver_api.source, error
+                );
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    format!("Heartbeat send failed: {error}"),
+                );
+                true
+            }
+            Err(WebSocketSendError::Timeout) => {
+                error!(
+                    "{}: heartbeat send timed out",
+                    self.rithmic_receiver_api.source
+                );
+                self.fail_connection_and_drain(
+                    "heartbeat_send_timeout",
+                    RithmicMessage::HeartbeatTimeout,
+                    "Heartbeat send timed out - connection dead",
+                );
+                true
+            }
+        }
+    }
+
+    pub(crate) async fn send_close_best_effort(&mut self) {
+        match send_with_timeout(
+            &mut self.rithmic_sender,
+            Message::Close(None),
+            Duration::from_secs(SEND_TIMEOUT_SECS),
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(WebSocketSendError::Transport(error)) => {
+                warn!(
+                    "{}: close send failed: {}",
+                    self.rithmic_receiver_api.source, error
+                );
+            }
+            Err(WebSocketSendError::Timeout) => {
+                warn!("{}: close send timed out", self.rithmic_receiver_api.source);
+            }
+        }
+    }
+
+    /// Handle a raw WebSocket message. Returns `true` if the actor should stop.
+    pub(crate) async fn handle_rithmic_message(&mut self, message: Result<Message, Error>) -> bool {
+        let mut stop = false;
+
+        match message {
+            Ok(Message::Close(frame)) => {
+                let source = self.rithmic_receiver_api.source.clone();
+                info!("{}: received close frame: {:?}", source, frame);
+                if self.close_requested {
+                    self.request_handler.drain_and_drop();
+                } else {
+                    self.fail_connection_and_drain(
+                        "",
+                        RithmicMessage::ConnectionError,
+                        format!("WebSocket close frame received: {:?}", frame),
+                    );
+                }
+                stop = true;
+            }
+            Ok(Message::Pong(_)) => {
+                self.ping_manager.received();
+            }
+            Ok(Message::Binary(data)) => {
+                let source = self.rithmic_receiver_api.source.clone();
+                match self.rithmic_receiver_api.buf_to_message(data) {
+                    Ok(response) => {
+                        // Handle heartbeat responses: only forward if they contain an error
+                        if matches!(response.message, RithmicMessage::ResponseHeartbeat(_)) {
+                            if let Some(error) = response.error {
+                                let error_response = RithmicResponse {
+                                    request_id: response.request_id,
+                                    message: RithmicMessage::HeartbeatTimeout,
+                                    is_update: true,
+                                    has_more: false,
+                                    multi_response: false,
+                                    error: Some(error),
+                                    source: self.rithmic_receiver_api.source.clone(),
+                                };
+
+                                let _ = self.subscription_sender.send(error_response);
+                            }
+
+                            // Always drop heartbeat responses (successful or error)
+                            return false;
+                        }
+
+                        if response.is_update {
+                            match self.subscription_sender.send(response) {
+                                Ok(_) => {}
+                                Err(e) => {
+                                    warn!("{}: no active subscribers: {:?}", source, e);
+                                }
+                            }
+                        } else {
+                            self.request_handler.handle_response(response);
+                        }
+                    }
+                    Err(err_response) => {
+                        error!("{}: error response from server: {:?}", source, err_response);
+
+                        if err_response.is_update {
+                            let _ = self.subscription_sender.send(err_response);
+                        } else {
+                            self.request_handler.handle_response(err_response);
+                        }
+                    }
+                }
+            }
+            Ok(Message::Ping(data)) => {
+                // RFC 6455 §5.5.3: a Ping must be answered with a Pong carrying
+                // the same payload.  With a split sink/stream the tungstenite
+                // internal write buffer is only flushed when the sink side is
+                // polled, so we send the Pong explicitly to guarantee delivery.
+                let source = self.rithmic_receiver_api.source.clone();
+                match send_with_timeout(
+                    &mut self.rithmic_sender,
+                    Message::Pong(data),
+                    Duration::from_secs(SEND_TIMEOUT_SECS),
+                )
+                .await
+                {
+                    Ok(()) => {}
+                    Err(e) => {
+                        warn!("{}: failed to send pong: {:?}", source, e);
+                        self.fail_connection_and_drain(
+                            "",
+                            RithmicMessage::ConnectionError,
+                            "Failed to send pong — sink dead",
+                        );
+                        stop = true;
+                    }
+                }
+            }
+            Err(Error::ConnectionClosed) => {
+                let source = self.rithmic_receiver_api.source.clone();
+                error!("{}: connection closed", source);
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket connection closed",
+                );
+                stop = true;
+            }
+            Err(Error::AlreadyClosed) => {
+                let source = self.rithmic_receiver_api.source.clone();
+                error!("{}: connection already closed", source);
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket connection already closed",
+                );
+                stop = true;
+            }
+            Err(Error::Io(ref io_err)) => {
+                let source = self.rithmic_receiver_api.source.clone();
+                error!("{}: I/O error: {}", source, io_err);
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    format!("WebSocket I/O error: {}", io_err),
+                );
+                stop = true;
+            }
+            Err(Error::Protocol(ProtocolError::ResetWithoutClosingHandshake)) => {
+                let source = self.rithmic_receiver_api.source.clone();
+                error!("{}: connection reset without closing handshake", source);
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket connection reset without closing handshake",
+                );
+                stop = true;
+            }
+            Err(Error::Protocol(ProtocolError::SendAfterClosing)) => {
+                let source = self.rithmic_receiver_api.source.clone();
+                error!("{}: attempted to send after closing", source);
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket attempted to send after closing",
+                );
+                stop = true;
+            }
+            Err(Error::Protocol(ProtocolError::ReceivedAfterClosing)) => {
+                let source = self.rithmic_receiver_api.source.clone();
+                error!("{}: received data after closing", source);
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    "WebSocket received data after closing",
+                );
+                stop = true;
+            }
+            Err(e) => {
+                let source = self.rithmic_receiver_api.source.clone();
+                error!("{}: unhandled WebSocket error, closing: {}", source, e);
+                self.fail_connection_and_drain(
+                    "",
+                    RithmicMessage::ConnectionError,
+                    format!("WebSocket error: {e}"),
+                );
+                stop = true;
+            }
+            Ok(_) => {
+                warn!(
+                    "{}: received unhandled message type",
+                    self.rithmic_receiver_api.source
+                );
+            }
+        }
+
+        stop
+    }
+
+    /// Handle a clean EOF on the WebSocket reader stream. Returns `true` (stop).
+    ///
+    /// A `None` from `reader.next()` means the peer closed the TCP connection
+    /// without sending a WebSocket Close frame — treat it as an unexpected drop.
+    pub(crate) fn handle_stream_closed(&mut self) -> bool {
+        let source = &self.rithmic_receiver_api.source;
+        error!("{}: WebSocket stream closed unexpectedly (EOF)", source);
+        self.fail_connection_and_drain(
+            "",
+            RithmicMessage::ConnectionError,
+            "WebSocket stream closed unexpectedly",
+        );
+        true
+    }
+}
+
+// ── Shared command handlers ───────────────────────────────────────────────────
+
+impl<S> PlantCore<S>
+where
+    S: Sink<Message, Error = Error> + Unpin,
+{
+    pub(crate) async fn handle_close(&mut self) {
+        self.close_requested = true;
+        // Drain pending requests immediately so callers are not left waiting for
+        // a server close-echo that may never arrive (e.g. on network drop).
+        self.request_handler.drain_and_drop();
+        self.send_close_best_effort().await;
+    }
+
+    pub(crate) async fn handle_list_system_info(
+        &mut self,
+        response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
+    ) {
+        let (list_system_info_buf, id) = self.rithmic_sender_api.request_rithmic_system_info();
+
+        self.request_handler.register_request(RithmicRequest {
+            request_id: id.clone(),
+            responder: response_sender,
+        });
+
+        self.send_or_fail(Message::Binary(list_system_info_buf.into()), &id)
+            .await;
+    }
+
+    pub(crate) async fn handle_login(
+        &mut self,
+        config: LoginConfig,
+        sys_infra_type: SysInfraType,
+        response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
+    ) {
+        let (login_buf, id) = self.rithmic_sender_api.request_login(
+            &self.config.system_name,
+            sys_infra_type,
+            &self.config.user,
+            &self.config.password,
+            &config,
+        );
+
+        info!(
+            "{}: sending login request {}",
+            self.rithmic_receiver_api.source, id
+        );
+
+        self.request_handler.register_request(RithmicRequest {
+            request_id: id.clone(),
+            responder: response_sender,
+        });
+
+        self.send_or_fail(Message::Binary(login_buf.into()), &id)
+            .await;
+    }
+
+    pub(crate) fn handle_set_login(&mut self) {
+        self.logged_in = true;
+    }
+
+    pub(crate) async fn handle_logout(
+        &mut self,
+        response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
+    ) {
+        let (logout_buf, id) = self.rithmic_sender_api.request_logout();
+
+        self.request_handler.register_request(RithmicRequest {
+            request_id: id.clone(),
+            responder: response_sender,
+        });
+
+        self.send_or_fail(Message::Binary(logout_buf.into()), &id)
+            .await;
+    }
+
+    pub(crate) fn handle_update_heartbeat(&mut self, seconds: u64) {
+        self.interval = get_heartbeat_interval(Some(seconds));
+    }
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        pin::Pin,
+        task::{Context, Poll},
+    };
+
+    use futures_util::StreamExt;
+    use tokio::sync::{broadcast, oneshot};
+    use tokio_tungstenite::tungstenite::{Error, Message, error::ProtocolError};
+
+    use super::*;
+    use crate::{
+        api::{receiver_api::RithmicResponse, sender_api::RithmicSenderApi},
+        config::{RithmicConfig, RithmicEnv},
+        error::RithmicError,
+        ping_manager::PingManager,
+        request_handler::{RithmicRequest, RithmicRequestHandler},
+        rti::messages::RithmicMessage,
+        ws::{PING_TIMEOUT_SECS, get_heartbeat_interval, get_ping_interval},
+    };
+
+    // ── Mock sink ──────────────────────────────────────────────────────────────
+
+    enum MockSinkBehavior {
+        Ready,
+        Error,
+        Pending,
+    }
+
+    struct MockMessageSink {
+        behavior: MockSinkBehavior,
+        pub sent_messages: Vec<Message>,
+    }
+
+    impl MockMessageSink {
+        fn ready() -> Self {
+            Self {
+                behavior: MockSinkBehavior::Ready,
+                sent_messages: Vec::new(),
+            }
+        }
+
+        fn error() -> Self {
+            Self {
+                behavior: MockSinkBehavior::Error,
+                sent_messages: Vec::new(),
+            }
+        }
+
+        fn pending() -> Self {
+            Self {
+                behavior: MockSinkBehavior::Pending,
+                sent_messages: Vec::new(),
+            }
+        }
+    }
+
+    impl std::fmt::Debug for MockMessageSink {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("MockMessageSink").finish()
+        }
+    }
+
+    impl Sink<Message> for MockMessageSink {
+        type Error = Error;
+
+        fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            match self.behavior {
+                MockSinkBehavior::Ready => Poll::Ready(Ok(())),
+                MockSinkBehavior::Error => Poll::Ready(Err(Error::ConnectionClosed)),
+                MockSinkBehavior::Pending => Poll::Pending,
+            }
+        }
+
+        fn start_send(self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
+            self.get_mut().sent_messages.push(item);
+            Ok(())
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            match self.behavior {
+                MockSinkBehavior::Ready => Poll::Ready(Ok(())),
+                MockSinkBehavior::Error => Poll::Ready(Err(Error::ConnectionClosed)),
+                MockSinkBehavior::Pending => Poll::Pending,
+            }
+        }
+
+        fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            match self.behavior {
+                MockSinkBehavior::Ready => Poll::Ready(Ok(())),
+                MockSinkBehavior::Error => Poll::Ready(Err(Error::ConnectionClosed)),
+                MockSinkBehavior::Pending => Poll::Pending,
+            }
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn test_config() -> RithmicConfig {
+        RithmicConfig::builder(RithmicEnv::Demo)
+            .user("test_user")
+            .password("test_password")
+            .url("ws://localhost:9999")
+            .beta_url("ws://localhost:9998")
+            .app_name("test_app")
+            .app_version("1.0")
+            .build()
+            .unwrap()
+    }
+
+    /// Create a real-but-dormant `WsReader` by establishing a local WebSocket
+    /// connection so the type is satisfied. The reader is never actually polled
+    /// in any of the tests below.
+    async fn make_dormant_ws_reader() -> WsReader {
+        use tokio::net::{TcpListener, TcpStream};
+        use tokio_tungstenite::tungstenite::protocol::Role;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let (client_tcp, server_result) = tokio::join!(
+            TcpStream::connect(addr),
+            async { listener.accept().await }
+        );
+
+        let client_tcp = client_tcp.unwrap();
+        let (server_tcp, _) = server_result.unwrap();
+
+        // Wrap both sides in MaybeTlsStream::Plain so the type matches WsStream.
+        let server_stream = MaybeTlsStream::Plain(server_tcp);
+
+        // Build a raw WebSocket on the server side (no HTTP upgrade needed for
+        // our purposes — we only need the type, not actual messages).
+        let server_ws = WebSocketStream::from_raw_socket(server_stream, Role::Server, None).await;
+
+        // Drop the client TCP so the server stream sits idle; split and return
+        // only the reader half.
+        drop(client_tcp);
+        let (_, reader) = server_ws.split();
+        reader
+    }
+
+    fn make_test_core(
+        sink: MockMessageSink,
+        rithmic_reader: WsReader,
+    ) -> (PlantCore<MockMessageSink>, broadcast::Receiver<RithmicResponse>) {
+        let config = test_config();
+        let (sub_tx, sub_rx) = broadcast::channel(16);
+        let rithmic_sender_api = RithmicSenderApi::new(&config);
+        let rithmic_receiver_api = RithmicReceiverApi {
+            source: "test".to_string(),
+        };
+
+        let core = PlantCore {
+            config,
+            close_requested: false,
+            interval: get_heartbeat_interval(None),
+            logged_in: false,
+            ping_interval: get_ping_interval(None),
+            ping_manager: PingManager::new(PING_TIMEOUT_SECS),
+            request_handler: RithmicRequestHandler::new(),
+            rithmic_reader,
+            rithmic_receiver_api,
+            rithmic_sender: sink,
+            rithmic_sender_api,
+            subscription_sender: sub_tx,
+        };
+
+        (core, sub_rx)
+    }
+
+    fn register_request(core: &mut PlantCore<MockMessageSink>, id: &str) -> oneshot::Receiver<Result<Vec<RithmicResponse>, RithmicError>> {
+        let (tx, rx) = oneshot::channel();
+        core.request_handler.register_request(RithmicRequest {
+            request_id: id.to_string(),
+            responder: tx,
+        });
+        rx
+    }
+
+    // ── fail_connection_and_drain ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn fail_connection_and_drain_broadcasts_and_drains_pending() {
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, mut sub_rx) = make_test_core(MockMessageSink::ready(), reader);
+
+        let mut rx1 = register_request(&mut core, "req-1");
+
+        core.fail_connection_and_drain("", RithmicMessage::ConnectionError, "test error");
+
+        // Subscription broadcast received the event
+        let broadcast_msg = sub_rx.try_recv().unwrap();
+        assert!(matches!(broadcast_msg.message, RithmicMessage::ConnectionError));
+        assert_eq!(broadcast_msg.error.as_deref(), Some("test error"));
+
+        // Pending request was drained with ConnectionClosed
+        let result = rx1.try_recv().unwrap();
+        assert!(matches!(result, Err(RithmicError::ConnectionClosed)));
+    }
+
+    #[tokio::test]
+    async fn fail_connection_and_drain_with_no_pending_requests() {
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, mut sub_rx) = make_test_core(MockMessageSink::ready(), reader);
+
+        // No registered requests — should not panic
+        core.fail_connection_and_drain("", RithmicMessage::ConnectionError, "no requests");
+
+        let broadcast_msg = sub_rx.try_recv().unwrap();
+        assert!(matches!(broadcast_msg.message, RithmicMessage::ConnectionError));
+    }
+
+    // ── send_or_fail ──────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn send_or_fail_transport_error_fails_only_that_request() {
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, _sub_rx) = make_test_core(MockMessageSink::error(), reader);
+
+        let mut rx1 = register_request(&mut core, "req-1");
+        let mut rx2 = register_request(&mut core, "req-2");
+
+        core.send_or_fail(Message::Ping(vec![].into()), "req-1").await;
+
+        // req-1 received SendFailed
+        let result = rx1.try_recv().unwrap();
+        assert!(matches!(result, Err(RithmicError::SendFailed)));
+
+        // req-2 is still pending
+        assert!(matches!(rx2.try_recv(), Err(oneshot::error::TryRecvError::Empty)));
+    }
+
+    #[tokio::test]
+    async fn send_or_fail_timeout_fails_only_that_request() {
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, _sub_rx) = make_test_core(MockMessageSink::pending(), reader);
+
+        let mut rx1 = register_request(&mut core, "req-1");
+
+        // The send_or_fail uses SEND_TIMEOUT_SECS — pause time so it resolves fast
+        tokio::time::pause();
+        let fut = core.send_or_fail(Message::Ping(vec![].into()), "req-1");
+        // Advance far enough past SEND_TIMEOUT_SECS
+        tokio::time::advance(std::time::Duration::from_secs(SEND_TIMEOUT_SECS + 1)).await;
+        fut.await;
+
+        let result = rx1.try_recv().unwrap();
+        assert!(matches!(result, Err(RithmicError::SendFailed)));
+    }
+
+    // ── send_ping ─────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn send_ping_skips_when_close_requested() {
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, _sub_rx) = make_test_core(MockMessageSink::ready(), reader);
+
+        core.close_requested = true;
+        let stop = core.send_ping().await;
+
+        assert!(!stop, "send_ping should return false when close is requested");
+        assert!(
+            core.ping_manager.next_timeout_at().is_none(),
+            "no ping should have been registered"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_ping_success_marks_ping_manager() {
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, _sub_rx) = make_test_core(MockMessageSink::ready(), reader);
+
+        let stop = core.send_ping().await;
+
+        assert!(!stop, "send_ping should return false on success");
+        assert!(
+            core.ping_manager.next_timeout_at().is_some(),
+            "ping_manager should track the pending ping"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_ping_transport_error_stops_and_broadcasts_connection_error() {
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, mut sub_rx) = make_test_core(MockMessageSink::error(), reader);
+
+        let stop = core.send_ping().await;
+
+        assert!(stop, "send_ping should return true on transport error");
+        let broadcast_msg = sub_rx.try_recv().unwrap();
+        assert!(matches!(broadcast_msg.message, RithmicMessage::ConnectionError));
+    }
+
+    #[tokio::test]
+    async fn send_ping_timeout_stops_and_broadcasts_heartbeat_timeout() {
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, mut sub_rx) = make_test_core(MockMessageSink::pending(), reader);
+
+        tokio::time::pause();
+        let fut = core.send_ping();
+        tokio::time::advance(std::time::Duration::from_secs(SEND_TIMEOUT_SECS + 1)).await;
+        let stop = fut.await;
+
+        assert!(stop, "send_ping should return true on timeout");
+        let broadcast_msg = sub_rx.try_recv().unwrap();
+        assert!(matches!(broadcast_msg.message, RithmicMessage::HeartbeatTimeout));
+    }
+
+    // ── send_heartbeat ────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn send_heartbeat_skips_when_not_logged_in() {
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, mut sub_rx) = make_test_core(MockMessageSink::ready(), reader);
+
+        // logged_in defaults to false
+        let stop = core.send_heartbeat().await;
+
+        assert!(!stop, "send_heartbeat should return false when not logged in");
+        assert!(
+            sub_rx.try_recv().is_err(),
+            "no broadcast should have been sent"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_heartbeat_skips_when_close_requested() {
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, mut sub_rx) = make_test_core(MockMessageSink::ready(), reader);
+
+        core.logged_in = true;
+        core.close_requested = true;
+        let stop = core.send_heartbeat().await;
+
+        assert!(!stop, "send_heartbeat should return false when close is requested");
+        assert!(
+            sub_rx.try_recv().is_err(),
+            "no broadcast should have been sent"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_heartbeat_transport_error_stops_and_broadcasts_connection_error() {
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, mut sub_rx) = make_test_core(MockMessageSink::error(), reader);
+
+        core.logged_in = true;
+        let stop = core.send_heartbeat().await;
+
+        assert!(stop, "send_heartbeat should return true on transport error");
+        let broadcast_msg = sub_rx.try_recv().unwrap();
+        assert!(matches!(broadcast_msg.message, RithmicMessage::ConnectionError));
+    }
+
+    #[tokio::test]
+    async fn send_heartbeat_timeout_stops_and_broadcasts_heartbeat_timeout() {
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, mut sub_rx) = make_test_core(MockMessageSink::pending(), reader);
+
+        core.logged_in = true;
+
+        tokio::time::pause();
+        let fut = core.send_heartbeat();
+        tokio::time::advance(std::time::Duration::from_secs(SEND_TIMEOUT_SECS + 1)).await;
+        let stop = fut.await;
+
+        assert!(stop, "send_heartbeat should return true on timeout");
+        let broadcast_msg = sub_rx.try_recv().unwrap();
+        assert!(matches!(broadcast_msg.message, RithmicMessage::HeartbeatTimeout));
+    }
+
+    // ── handle_rithmic_message ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn handle_rithmic_message_close_with_close_requested_drains_silently() {
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, mut sub_rx) = make_test_core(MockMessageSink::ready(), reader);
+
+        core.close_requested = true;
+        let mut rx1 = register_request(&mut core, "req-1");
+
+        let stop = core.handle_rithmic_message(Ok(Message::Close(None))).await;
+
+        assert!(stop, "should stop when close frame received");
+        // Oneshot drained with ConnectionClosed
+        let result = rx1.try_recv().unwrap();
+        assert!(matches!(result, Err(RithmicError::ConnectionClosed)));
+        // Broadcast should be EMPTY (silent drain)
+        assert!(
+            sub_rx.try_recv().is_err(),
+            "no broadcast should be sent on clean close"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_rithmic_message_close_without_close_requested_emits_and_drains() {
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, mut sub_rx) = make_test_core(MockMessageSink::ready(), reader);
+
+        // close_requested defaults to false
+        let mut rx1 = register_request(&mut core, "req-1");
+
+        let stop = core.handle_rithmic_message(Ok(Message::Close(None))).await;
+
+        assert!(stop, "should stop when unexpected close frame received");
+        // Oneshot drained with ConnectionClosed
+        let result = rx1.try_recv().unwrap();
+        assert!(matches!(result, Err(RithmicError::ConnectionClosed)));
+        // Broadcast should contain ConnectionError
+        let broadcast_msg = sub_rx.try_recv().unwrap();
+        assert!(matches!(broadcast_msg.message, RithmicMessage::ConnectionError));
+    }
+
+    #[tokio::test]
+    async fn handle_rithmic_message_pong_clears_ping_manager() {
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, _sub_rx) = make_test_core(MockMessageSink::ready(), reader);
+
+        // Register a pending ping
+        core.ping_manager.sent();
+        assert!(core.ping_manager.next_timeout_at().is_some());
+
+        let stop = core
+            .handle_rithmic_message(Ok(Message::Pong(vec![].into())))
+            .await;
+
+        assert!(!stop, "pong should not stop the actor");
+        assert!(
+            core.ping_manager.next_timeout_at().is_none(),
+            "ping_manager should be cleared after pong"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_rithmic_message_ping_with_ready_sink_sends_pong() {
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, _sub_rx) = make_test_core(MockMessageSink::ready(), reader);
+
+        let stop = core
+            .handle_rithmic_message(Ok(Message::Ping(b"hello".as_ref().into())))
+            .await;
+
+        assert!(!stop, "ping with working sink should not stop actor");
+        // Verify a Pong was sent
+        let last_sent = core.rithmic_sender.sent_messages.last().unwrap();
+        assert!(matches!(last_sent, Message::Pong(_)));
+    }
+
+    #[tokio::test]
+    async fn handle_rithmic_message_ping_with_failing_sink_stops_actor() {
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, mut sub_rx) = make_test_core(MockMessageSink::error(), reader);
+
+        let stop = core
+            .handle_rithmic_message(Ok(Message::Ping(b"hello".as_ref().into())))
+            .await;
+
+        assert!(stop, "ping with failing sink should stop actor");
+        let broadcast_msg = sub_rx.try_recv().unwrap();
+        assert!(matches!(broadcast_msg.message, RithmicMessage::ConnectionError));
+    }
+
+    #[tokio::test]
+    async fn handle_rithmic_message_connection_closed_error_stops_actor() {
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, mut sub_rx) = make_test_core(MockMessageSink::ready(), reader);
+
+        let stop = core
+            .handle_rithmic_message(Err(Error::ConnectionClosed))
+            .await;
+
+        assert!(stop, "ConnectionClosed error should stop actor");
+        let broadcast_msg = sub_rx.try_recv().unwrap();
+        assert!(matches!(broadcast_msg.message, RithmicMessage::ConnectionError));
+    }
+
+    #[tokio::test]
+    async fn handle_rithmic_message_already_closed_stops_actor() {
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, mut sub_rx) = make_test_core(MockMessageSink::ready(), reader);
+
+        let stop = core
+            .handle_rithmic_message(Err(Error::AlreadyClosed))
+            .await;
+
+        assert!(stop, "AlreadyClosed error should stop actor");
+        let broadcast_msg = sub_rx.try_recv().unwrap();
+        assert!(matches!(broadcast_msg.message, RithmicMessage::ConnectionError));
+    }
+
+    #[tokio::test]
+    async fn handle_rithmic_message_protocol_reset_stops_actor() {
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, mut sub_rx) = make_test_core(MockMessageSink::ready(), reader);
+
+        let stop = core
+            .handle_rithmic_message(Err(Error::Protocol(
+                ProtocolError::ResetWithoutClosingHandshake,
+            )))
+            .await;
+
+        assert!(stop, "protocol reset should stop actor");
+        let broadcast_msg = sub_rx.try_recv().unwrap();
+        assert!(matches!(broadcast_msg.message, RithmicMessage::ConnectionError));
+    }
+
+    // ── handle_stream_closed ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn handle_stream_closed_stops_and_emits_connection_error() {
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, mut sub_rx) = make_test_core(MockMessageSink::ready(), reader);
+
+        let mut rx1 = register_request(&mut core, "req-1");
+
+        let stop = core.handle_stream_closed();
+
+        assert!(stop, "handle_stream_closed should return true");
+        let broadcast_msg = sub_rx.try_recv().unwrap();
+        assert!(matches!(broadcast_msg.message, RithmicMessage::ConnectionError));
+        let result = rx1.try_recv().unwrap();
+        assert!(matches!(result, Err(RithmicError::ConnectionClosed)));
+    }
+}

--- a/src/plants/core.rs
+++ b/src/plants/core.rs
@@ -35,7 +35,6 @@ use crate::{
     },
 };
 
-// Type aliases for the split WebSocket stream components.
 pub(crate) type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
 pub(crate) type WsSink = SplitSink<WsStream, Message>;
 pub(crate) type WsReader = SplitStream<WsStream>;
@@ -114,8 +113,6 @@ impl PlantCore<WsSink> {
         })
     }
 }
-
-// ── Infrastructure methods ────────────────────────────────────────────────────
 
 impl<S> PlantCore<S>
 where
@@ -484,8 +481,6 @@ where
     }
 }
 
-// ── Shared command handlers ───────────────────────────────────────────────────
-
 impl<S> PlantCore<S>
 where
     S: Sink<Message, Error = Error> + Unpin,
@@ -565,8 +560,6 @@ where
     }
 }
 
-// ── Unit tests ────────────────────────────────────────────────────────────────
-
 #[cfg(test)]
 mod tests {
     use std::{
@@ -588,8 +581,6 @@ mod tests {
         rti::messages::RithmicMessage,
         ws::{PING_TIMEOUT_SECS, get_heartbeat_interval, get_ping_interval},
     };
-
-    // ── Mock sink ──────────────────────────────────────────────────────────────
 
     enum MockSinkBehavior {
         Ready,
@@ -672,8 +663,6 @@ mod tests {
             }
         }
     }
-
-    // ── Helpers ───────────────────────────────────────────────────────────────
 
     fn test_config() -> RithmicConfig {
         RithmicConfig::builder(RithmicEnv::Demo)
@@ -761,8 +750,6 @@ mod tests {
         rx
     }
 
-    // ── fail_connection_and_drain ─────────────────────────────────────────────
-
     #[tokio::test]
     async fn fail_connection_and_drain_broadcasts_and_drains_pending() {
         let reader = make_dormant_ws_reader().await;
@@ -790,7 +777,6 @@ mod tests {
         let reader = make_dormant_ws_reader().await;
         let (mut core, mut sub_rx) = make_test_core(MockMessageSink::ready(), reader);
 
-        // No registered requests — should not panic
         core.fail_connection_and_drain("", RithmicMessage::ConnectionError, "no requests");
 
         let broadcast_msg = sub_rx.try_recv().unwrap();
@@ -799,8 +785,6 @@ mod tests {
             RithmicMessage::ConnectionError
         ));
     }
-
-    // ── send_or_fail ──────────────────────────────────────────────────────────
 
     #[tokio::test]
     async fn send_or_fail_transport_error_fails_only_that_request() {
@@ -813,11 +797,9 @@ mod tests {
         core.send_or_fail(Message::Ping(vec![].into()), "req-1")
             .await;
 
-        // req-1 received SendFailed
         let result = rx1.try_recv().unwrap();
         assert!(matches!(result, Err(RithmicError::SendFailed)));
 
-        // req-2 is still pending
         assert!(matches!(
             rx2.try_recv(),
             Err(oneshot::error::TryRecvError::Empty)
@@ -831,18 +813,14 @@ mod tests {
 
         let mut rx1 = register_request(&mut core, "req-1");
 
-        // The send_or_fail uses SEND_TIMEOUT_SECS — pause time so it resolves fast
         tokio::time::pause();
         let fut = core.send_or_fail(Message::Ping(vec![].into()), "req-1");
-        // Advance far enough past SEND_TIMEOUT_SECS
         tokio::time::advance(std::time::Duration::from_secs(SEND_TIMEOUT_SECS + 1)).await;
         fut.await;
 
         let result = rx1.try_recv().unwrap();
         assert!(matches!(result, Err(RithmicError::SendFailed)));
     }
-
-    // ── send_ping ─────────────────────────────────────────────────────────────
 
     #[tokio::test]
     async fn send_ping_skips_when_close_requested() {
@@ -908,8 +886,6 @@ mod tests {
             RithmicMessage::HeartbeatTimeout
         ));
     }
-
-    // ── send_heartbeat ────────────────────────────────────────────────────────
 
     #[tokio::test]
     async fn send_heartbeat_skips_when_not_logged_in() {
@@ -983,8 +959,6 @@ mod tests {
             RithmicMessage::HeartbeatTimeout
         ));
     }
-
-    // ── handle_rithmic_message ────────────────────────────────────────────────
 
     #[tokio::test]
     async fn handle_rithmic_message_close_with_close_requested_drains_silently() {
@@ -1131,8 +1105,6 @@ mod tests {
             RithmicMessage::ConnectionError
         ));
     }
-
-    // ── handle_stream_closed ──────────────────────────────────────────────────
 
     #[tokio::test]
     async fn handle_stream_closed_stops_and_emits_connection_error() {

--- a/src/plants/core.rs
+++ b/src/plants/core.rs
@@ -634,7 +634,10 @@ mod tests {
     impl Sink<Message> for MockMessageSink {
         type Error = Error;
 
-        fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        fn poll_ready(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
             match self.behavior {
                 MockSinkBehavior::Ready => Poll::Ready(Ok(())),
                 MockSinkBehavior::Error => Poll::Ready(Err(Error::ConnectionClosed)),
@@ -647,7 +650,10 @@ mod tests {
             Ok(())
         }
 
-        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
             match self.behavior {
                 MockSinkBehavior::Ready => Poll::Ready(Ok(())),
                 MockSinkBehavior::Error => Poll::Ready(Err(Error::ConnectionClosed)),
@@ -655,7 +661,10 @@ mod tests {
             }
         }
 
-        fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        fn poll_close(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
             match self.behavior {
                 MockSinkBehavior::Ready => Poll::Ready(Ok(())),
                 MockSinkBehavior::Error => Poll::Ready(Err(Error::ConnectionClosed)),
@@ -688,10 +697,8 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
 
-        let (client_tcp, server_result) = tokio::join!(
-            TcpStream::connect(addr),
-            async { listener.accept().await }
-        );
+        let (client_tcp, server_result) =
+            tokio::join!(TcpStream::connect(addr), async { listener.accept().await });
 
         let client_tcp = client_tcp.unwrap();
         let (server_tcp, _) = server_result.unwrap();
@@ -713,7 +720,10 @@ mod tests {
     fn make_test_core(
         sink: MockMessageSink,
         rithmic_reader: WsReader,
-    ) -> (PlantCore<MockMessageSink>, broadcast::Receiver<RithmicResponse>) {
+    ) -> (
+        PlantCore<MockMessageSink>,
+        broadcast::Receiver<RithmicResponse>,
+    ) {
         let config = test_config();
         let (sub_tx, sub_rx) = broadcast::channel(16);
         let rithmic_sender_api = RithmicSenderApi::new(&config);
@@ -739,7 +749,10 @@ mod tests {
         (core, sub_rx)
     }
 
-    fn register_request(core: &mut PlantCore<MockMessageSink>, id: &str) -> oneshot::Receiver<Result<Vec<RithmicResponse>, RithmicError>> {
+    fn register_request(
+        core: &mut PlantCore<MockMessageSink>,
+        id: &str,
+    ) -> oneshot::Receiver<Result<Vec<RithmicResponse>, RithmicError>> {
         let (tx, rx) = oneshot::channel();
         core.request_handler.register_request(RithmicRequest {
             request_id: id.to_string(),
@@ -761,7 +774,10 @@ mod tests {
 
         // Subscription broadcast received the event
         let broadcast_msg = sub_rx.try_recv().unwrap();
-        assert!(matches!(broadcast_msg.message, RithmicMessage::ConnectionError));
+        assert!(matches!(
+            broadcast_msg.message,
+            RithmicMessage::ConnectionError
+        ));
         assert_eq!(broadcast_msg.error.as_deref(), Some("test error"));
 
         // Pending request was drained with ConnectionClosed
@@ -778,7 +794,10 @@ mod tests {
         core.fail_connection_and_drain("", RithmicMessage::ConnectionError, "no requests");
 
         let broadcast_msg = sub_rx.try_recv().unwrap();
-        assert!(matches!(broadcast_msg.message, RithmicMessage::ConnectionError));
+        assert!(matches!(
+            broadcast_msg.message,
+            RithmicMessage::ConnectionError
+        ));
     }
 
     // ── send_or_fail ──────────────────────────────────────────────────────────
@@ -791,14 +810,18 @@ mod tests {
         let mut rx1 = register_request(&mut core, "req-1");
         let mut rx2 = register_request(&mut core, "req-2");
 
-        core.send_or_fail(Message::Ping(vec![].into()), "req-1").await;
+        core.send_or_fail(Message::Ping(vec![].into()), "req-1")
+            .await;
 
         // req-1 received SendFailed
         let result = rx1.try_recv().unwrap();
         assert!(matches!(result, Err(RithmicError::SendFailed)));
 
         // req-2 is still pending
-        assert!(matches!(rx2.try_recv(), Err(oneshot::error::TryRecvError::Empty)));
+        assert!(matches!(
+            rx2.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
     }
 
     #[tokio::test]
@@ -829,7 +852,10 @@ mod tests {
         core.close_requested = true;
         let stop = core.send_ping().await;
 
-        assert!(!stop, "send_ping should return false when close is requested");
+        assert!(
+            !stop,
+            "send_ping should return false when close is requested"
+        );
         assert!(
             core.ping_manager.next_timeout_at().is_none(),
             "no ping should have been registered"
@@ -859,7 +885,10 @@ mod tests {
 
         assert!(stop, "send_ping should return true on transport error");
         let broadcast_msg = sub_rx.try_recv().unwrap();
-        assert!(matches!(broadcast_msg.message, RithmicMessage::ConnectionError));
+        assert!(matches!(
+            broadcast_msg.message,
+            RithmicMessage::ConnectionError
+        ));
     }
 
     #[tokio::test]
@@ -874,7 +903,10 @@ mod tests {
 
         assert!(stop, "send_ping should return true on timeout");
         let broadcast_msg = sub_rx.try_recv().unwrap();
-        assert!(matches!(broadcast_msg.message, RithmicMessage::HeartbeatTimeout));
+        assert!(matches!(
+            broadcast_msg.message,
+            RithmicMessage::HeartbeatTimeout
+        ));
     }
 
     // ── send_heartbeat ────────────────────────────────────────────────────────
@@ -887,7 +919,10 @@ mod tests {
         // logged_in defaults to false
         let stop = core.send_heartbeat().await;
 
-        assert!(!stop, "send_heartbeat should return false when not logged in");
+        assert!(
+            !stop,
+            "send_heartbeat should return false when not logged in"
+        );
         assert!(
             sub_rx.try_recv().is_err(),
             "no broadcast should have been sent"
@@ -903,7 +938,10 @@ mod tests {
         core.close_requested = true;
         let stop = core.send_heartbeat().await;
 
-        assert!(!stop, "send_heartbeat should return false when close is requested");
+        assert!(
+            !stop,
+            "send_heartbeat should return false when close is requested"
+        );
         assert!(
             sub_rx.try_recv().is_err(),
             "no broadcast should have been sent"
@@ -920,7 +958,10 @@ mod tests {
 
         assert!(stop, "send_heartbeat should return true on transport error");
         let broadcast_msg = sub_rx.try_recv().unwrap();
-        assert!(matches!(broadcast_msg.message, RithmicMessage::ConnectionError));
+        assert!(matches!(
+            broadcast_msg.message,
+            RithmicMessage::ConnectionError
+        ));
     }
 
     #[tokio::test]
@@ -937,7 +978,10 @@ mod tests {
 
         assert!(stop, "send_heartbeat should return true on timeout");
         let broadcast_msg = sub_rx.try_recv().unwrap();
-        assert!(matches!(broadcast_msg.message, RithmicMessage::HeartbeatTimeout));
+        assert!(matches!(
+            broadcast_msg.message,
+            RithmicMessage::HeartbeatTimeout
+        ));
     }
 
     // ── handle_rithmic_message ────────────────────────────────────────────────
@@ -979,7 +1023,10 @@ mod tests {
         assert!(matches!(result, Err(RithmicError::ConnectionClosed)));
         // Broadcast should contain ConnectionError
         let broadcast_msg = sub_rx.try_recv().unwrap();
-        assert!(matches!(broadcast_msg.message, RithmicMessage::ConnectionError));
+        assert!(matches!(
+            broadcast_msg.message,
+            RithmicMessage::ConnectionError
+        ));
     }
 
     #[tokio::test]
@@ -1028,7 +1075,10 @@ mod tests {
 
         assert!(stop, "ping with failing sink should stop actor");
         let broadcast_msg = sub_rx.try_recv().unwrap();
-        assert!(matches!(broadcast_msg.message, RithmicMessage::ConnectionError));
+        assert!(matches!(
+            broadcast_msg.message,
+            RithmicMessage::ConnectionError
+        ));
     }
 
     #[tokio::test]
@@ -1042,7 +1092,10 @@ mod tests {
 
         assert!(stop, "ConnectionClosed error should stop actor");
         let broadcast_msg = sub_rx.try_recv().unwrap();
-        assert!(matches!(broadcast_msg.message, RithmicMessage::ConnectionError));
+        assert!(matches!(
+            broadcast_msg.message,
+            RithmicMessage::ConnectionError
+        ));
     }
 
     #[tokio::test]
@@ -1050,13 +1103,14 @@ mod tests {
         let reader = make_dormant_ws_reader().await;
         let (mut core, mut sub_rx) = make_test_core(MockMessageSink::ready(), reader);
 
-        let stop = core
-            .handle_rithmic_message(Err(Error::AlreadyClosed))
-            .await;
+        let stop = core.handle_rithmic_message(Err(Error::AlreadyClosed)).await;
 
         assert!(stop, "AlreadyClosed error should stop actor");
         let broadcast_msg = sub_rx.try_recv().unwrap();
-        assert!(matches!(broadcast_msg.message, RithmicMessage::ConnectionError));
+        assert!(matches!(
+            broadcast_msg.message,
+            RithmicMessage::ConnectionError
+        ));
     }
 
     #[tokio::test]
@@ -1072,7 +1126,10 @@ mod tests {
 
         assert!(stop, "protocol reset should stop actor");
         let broadcast_msg = sub_rx.try_recv().unwrap();
-        assert!(matches!(broadcast_msg.message, RithmicMessage::ConnectionError));
+        assert!(matches!(
+            broadcast_msg.message,
+            RithmicMessage::ConnectionError
+        ));
     }
 
     // ── handle_stream_closed ──────────────────────────────────────────────────
@@ -1088,7 +1145,10 @@ mod tests {
 
         assert!(stop, "handle_stream_closed should return true");
         let broadcast_msg = sub_rx.try_recv().unwrap();
-        assert!(matches!(broadcast_msg.message, RithmicMessage::ConnectionError));
+        assert!(matches!(
+            broadcast_msg.message,
+            RithmicMessage::ConnectionError
+        ));
         let result = rx1.try_recv().unwrap();
         assert!(matches!(result, Err(RithmicError::ConnectionClosed)));
     }

--- a/src/plants/history_plant.rs
+++ b/src/plants/history_plant.rs
@@ -259,7 +259,9 @@ impl PlantActor for HistoryPlant {
                 SelectResult::PingTimeout => {
                     if self.core.ping_manager.check_timeout() {
                         if self.core.close_requested {
-                            warn!("history_plant: ping timed out while waiting for server close echo — terminating");
+                            warn!(
+                                "history_plant: ping timed out while waiting for server close echo — terminating"
+                            );
                             self.core.request_handler.drain_and_drop();
                         } else {
                             self.core.fail_connection_and_drain(

--- a/src/plants/history_plant.rs
+++ b/src/plants/history_plant.rs
@@ -1,44 +1,28 @@
-use std::time::Duration;
-
 use tracing::{error, info, warn};
-
-use tokio_tungstenite::{
-    MaybeTlsStream,
-    tungstenite::{Error, Message, error::ProtocolError},
-};
 
 use crate::{
     ConnectStrategy,
-    api::{
-        receiver_api::{RithmicReceiverApi, RithmicResponse},
-        rithmic_command_types::LoginConfig,
-        sender_api::RithmicSenderApi,
-    },
+    api::{receiver_api::RithmicResponse, rithmic_command_types::LoginConfig},
     config::RithmicConfig,
     error::RithmicError,
-    ping_manager::PingManager,
-    request_handler::{RithmicRequest, RithmicRequestHandler},
+    plants::core::{PlantCore, SelectResult},
+    request_handler::RithmicRequest,
     rti::{
         messages::RithmicMessage, request_login::SysInfraType, request_tick_bar_update,
         request_time_bar_replay::BarType, request_time_bar_update,
     },
-    ws::{
-        HEARTBEAT_SECS, PING_TIMEOUT_SECS, PlantActor, SEND_TIMEOUT_SECS, WebSocketSendError,
-        connect_with_strategy, get_heartbeat_interval, get_ping_interval, send_with_timeout,
-    },
+    ws::{HEARTBEAT_SECS, PlantActor},
 };
 
-use futures_util::{
-    StreamExt,
-    stream::{SplitSink, SplitStream},
-};
+use futures_util::StreamExt;
 
 use tokio::{
-    net::TcpStream,
     sync::{broadcast, mpsc, oneshot},
     task::JoinHandle,
-    time::{Interval, sleep_until},
+    time::sleep_until,
 };
+
+use tokio_tungstenite::tungstenite::Message;
 
 pub(crate) enum HistoryPlantCommand {
     Close,
@@ -220,24 +204,8 @@ impl RithmicHistoryPlant {
 
 #[derive(Debug)]
 struct HistoryPlant {
-    config: RithmicConfig,
-    // Distinguishes an intentional local shutdown from an unexpected peer close.
-    close_requested: bool,
-    interval: Interval,
-    logged_in: bool,
-    ping_interval: Interval,
-    ping_manager: PingManager,
-    request_handler: RithmicRequestHandler,
+    core: PlantCore,
     request_receiver: mpsc::Receiver<HistoryPlantCommand>,
-    rithmic_reader: SplitStream<tokio_tungstenite::WebSocketStream<MaybeTlsStream<TcpStream>>>,
-    rithmic_receiver_api: RithmicReceiverApi,
-    rithmic_sender: SplitSink<
-        tokio_tungstenite::WebSocketStream<MaybeTlsStream<TcpStream>>,
-        tokio_tungstenite::tungstenite::Message,
-    >,
-
-    rithmic_sender_api: RithmicSenderApi,
-    subscription_sender: broadcast::Sender<RithmicResponse>,
 }
 
 impl HistoryPlant {
@@ -247,177 +215,11 @@ impl HistoryPlant {
         config: &RithmicConfig,
         strategy: ConnectStrategy,
     ) -> Result<HistoryPlant, RithmicError> {
-        let ws_stream = connect_with_strategy(&config.url, &config.beta_url, strategy)
-            .await
-            .map_err(|e| RithmicError::ConnectionFailed(e.to_string()))?;
-
-        let (rithmic_sender, rithmic_reader) = ws_stream.split();
-
-        let rithmic_sender_api = RithmicSenderApi::new(config);
-        let rithmic_receiver_api = RithmicReceiverApi {
-            source: "history_plant".to_string(),
-        };
-
-        let interval = get_heartbeat_interval(None);
-        let ping_interval = get_ping_interval(None);
-        let ping_manager = PingManager::new(PING_TIMEOUT_SECS);
-
+        let core = PlantCore::new(subscription_sender, config, strategy, "history_plant").await?;
         Ok(HistoryPlant {
-            config: config.clone(),
-            close_requested: false,
-            interval,
-            ping_interval,
-            logged_in: false,
-            ping_manager,
-            request_handler: RithmicRequestHandler::new(),
+            core,
             request_receiver,
-            rithmic_reader,
-            rithmic_receiver_api,
-            rithmic_sender,
-            rithmic_sender_api,
-            subscription_sender,
         })
-    }
-}
-
-impl HistoryPlant {
-    fn emit_connection_health_event(
-        &self,
-        request_id: &str,
-        message: RithmicMessage,
-        error_message: impl Into<String>,
-    ) {
-        let error_response = RithmicResponse {
-            request_id: request_id.to_string(),
-            message,
-            is_update: true,
-            has_more: false,
-            multi_response: false,
-            error: Some(error_message.into()),
-            source: self.rithmic_receiver_api.source.clone(),
-        };
-
-        let _ = self.subscription_sender.send(error_response);
-    }
-
-    fn fail_connection_and_drain(
-        &mut self,
-        request_id: &str,
-        message: RithmicMessage,
-        error_message: impl Into<String>,
-    ) {
-        self.emit_connection_health_event(request_id, message, error_message);
-        self.request_handler.drain_and_drop();
-    }
-
-    async fn send_or_fail(&mut self, msg: Message, request_id: &str) {
-        match send_with_timeout(
-            &mut self.rithmic_sender,
-            msg,
-            Duration::from_secs(SEND_TIMEOUT_SECS),
-        )
-        .await
-        {
-            Ok(()) => {}
-            Err(WebSocketSendError::Transport(error)) => {
-                error!(
-                    "history_plant: WebSocket send failed for request {}: {}",
-                    request_id, error
-                );
-                self.request_handler
-                    .fail_request(request_id, RithmicError::SendFailed);
-            }
-            Err(WebSocketSendError::Timeout) => {
-                error!(
-                    "history_plant: WebSocket send timed out for request {}",
-                    request_id
-                );
-                self.request_handler
-                    .fail_request(request_id, RithmicError::SendFailed);
-            }
-        }
-    }
-
-    async fn send_ping(&mut self) -> bool {
-        self.ping_manager.sent();
-
-        match send_with_timeout(
-            &mut self.rithmic_sender,
-            Message::Ping(vec![].into()),
-            Duration::from_secs(SEND_TIMEOUT_SECS),
-        )
-        .await
-        {
-            Ok(()) => false,
-            Err(WebSocketSendError::Transport(error)) => {
-                error!("history_plant: WebSocket ping send failed: {}", error);
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    format!("WebSocket ping send failed: {error}"),
-                );
-                true
-            }
-            Err(WebSocketSendError::Timeout) => {
-                error!("history_plant: WebSocket ping send timed out");
-                self.fail_connection_and_drain(
-                    "websocket_ping_timeout",
-                    RithmicMessage::HeartbeatTimeout,
-                    "WebSocket ping send timed out - connection dead",
-                );
-                true
-            }
-        }
-    }
-
-    async fn send_heartbeat(&mut self) -> bool {
-        let (heartbeat_buf, _id) = self.rithmic_sender_api.request_heartbeat();
-
-        match send_with_timeout(
-            &mut self.rithmic_sender,
-            Message::Binary(heartbeat_buf.into()),
-            Duration::from_secs(SEND_TIMEOUT_SECS),
-        )
-        .await
-        {
-            Ok(()) => false,
-            Err(WebSocketSendError::Transport(error)) => {
-                error!("history_plant: heartbeat send failed: {}", error);
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    format!("Heartbeat send failed: {error}"),
-                );
-                true
-            }
-            Err(WebSocketSendError::Timeout) => {
-                error!("history_plant: heartbeat send timed out");
-                self.fail_connection_and_drain(
-                    "heartbeat_send_timeout",
-                    RithmicMessage::HeartbeatTimeout,
-                    "Heartbeat send timed out - connection dead",
-                );
-                true
-            }
-        }
-    }
-
-    async fn send_close_best_effort(&mut self) {
-        match send_with_timeout(
-            &mut self.rithmic_sender,
-            Message::Close(None),
-            Duration::from_secs(SEND_TIMEOUT_SECS),
-        )
-        .await
-        {
-            Ok(()) => {}
-            Err(WebSocketSendError::Transport(error)) => {
-                warn!("history_plant: close send failed: {}", error);
-            }
-            Err(WebSocketSendError::Timeout) => {
-                warn!("history_plant: close send timed out");
-            }
-        }
     }
 }
 
@@ -426,246 +228,102 @@ impl PlantActor for HistoryPlant {
 
     async fn run(&mut self) {
         loop {
-            tokio::select! {
-              _ = self.interval.tick() => {
-                if self.logged_in && !self.close_requested && self.send_heartbeat().await {
-                    break;
+            let result = {
+                let interval = &mut self.core.interval;
+                let ping_interval = &mut self.core.ping_interval;
+                let ping_manager = &mut self.core.ping_manager;
+                let reader = &mut self.core.rithmic_reader;
+                let receiver = &mut self.request_receiver;
+
+                tokio::select! {
+                    _ = interval.tick()      => SelectResult::HeartbeatFired,
+                    _ = ping_interval.tick() => SelectResult::PingFired,
+                    _ = async {
+                        if let Some(t) = ping_manager.next_timeout_at() {
+                            sleep_until(t).await
+                        } else {
+                            std::future::pending::<()>().await
+                        }
+                    } => SelectResult::PingTimeout,
+                    Some(cmd) = receiver.recv() => SelectResult::Command(cmd),
+                    msg = reader.next() => match msg {
+                        Some(m) => SelectResult::RithmicMessage(m),
+                        None => SelectResult::StreamClosed,
+                    },
                 }
-              }
-              _ = self.ping_interval.tick() => {
-                if !self.close_requested && self.send_ping().await {
-                    break;
-                }
-              }
-              _ = async {
-                if let Some(timeout_at) = self.ping_manager.next_timeout_at() {
-                    sleep_until(timeout_at).await
-                } else {
-                    std::future::pending::<()>().await
-                }
-              } => {
-                if self.ping_manager.check_timeout() {
-                    if self.close_requested {
-                        self.request_handler.drain_and_drop();
+            };
+
+            let stop = match result {
+                SelectResult::HeartbeatFired => self.core.send_heartbeat().await,
+                SelectResult::PingFired => self.core.send_ping().await,
+                SelectResult::PingTimeout => {
+                    if self.core.ping_manager.check_timeout() {
+                        if self.core.close_requested {
+                            warn!("history_plant: ping timed out while waiting for server close echo — terminating");
+                            self.core.request_handler.drain_and_drop();
+                        } else {
+                            self.core.fail_connection_and_drain(
+                                "websocket_ping_timeout",
+                                RithmicMessage::HeartbeatTimeout,
+                                "WebSocket ping timeout - connection dead",
+                            );
+                        }
+                        true
                     } else {
-                        error!("WebSocket ping timed out - connection appears dead");
-                        self.fail_connection_and_drain(
-                            "websocket_ping_timeout",
-                            RithmicMessage::HeartbeatTimeout,
-                            "WebSocket ping timeout - connection dead",
+                        false
+                    }
+                }
+                SelectResult::Command(cmd) => {
+                    if matches!(cmd, HistoryPlantCommand::Abort) {
+                        info!("history_plant: abort requested, shutting down immediately");
+
+                        self.core.fail_connection_and_drain(
+                            "",
+                            RithmicMessage::ConnectionError,
+                            "Plant aborted",
                         );
-                    }
-                    break;
-                }
-              }
-              Some(message) = self.request_receiver.recv() => {
-                if matches!(message, HistoryPlantCommand::Abort) {
-                    info!("history_plant: abort requested, shutting down immediately");
-                    self.fail_connection_and_drain(
-                        "",
-                        RithmicMessage::ConnectionError,
-                        "Plant aborted",
-                    );
-                    break;
-                }
-                self.handle_command(message).await;
-              }
-              Some(message) = self.rithmic_reader.next() => {
-                let stop = self.handle_rithmic_message(message).await;
 
-                if stop {
-                  break;
+                        true
+                    } else {
+                        self.handle_command(cmd).await;
+
+                        false
+                    }
                 }
-              }
-              else => { break; }
+                SelectResult::RithmicMessage(msg) => self.core.handle_rithmic_message(msg).await,
+                SelectResult::StreamClosed => self.core.handle_stream_closed(),
+            };
+
+            if stop {
+                break;
             }
         }
-    }
-
-    async fn handle_rithmic_message(&mut self, message: Result<Message, Error>) -> bool {
-        let mut stop = false;
-
-        match message {
-            Ok(Message::Close(frame)) => {
-                info!("history_plant: Received close frame: {:?}", frame);
-                if self.close_requested {
-                    self.request_handler.drain_and_drop();
-                } else {
-                    self.fail_connection_and_drain(
-                        "",
-                        RithmicMessage::ConnectionError,
-                        format!("WebSocket close frame received: {:?}", frame),
-                    );
-                }
-                stop = true;
-            }
-            Ok(Message::Pong(_)) => {
-                self.ping_manager.received();
-            }
-            Ok(Message::Binary(data)) => match self.rithmic_receiver_api.buf_to_message(data) {
-                Ok(response) => {
-                    // Handle heartbeat responses: only forward if they contain an error
-                    if matches!(response.message, RithmicMessage::ResponseHeartbeat(_)) {
-                        if let Some(error) = response.error {
-                            let error_response = RithmicResponse {
-                                request_id: response.request_id,
-                                message: RithmicMessage::HeartbeatTimeout,
-                                is_update: true,
-                                has_more: false,
-                                multi_response: false,
-                                error: Some(error),
-                                source: self.rithmic_receiver_api.source.clone(),
-                            };
-
-                            let _ = self.subscription_sender.send(error_response);
-                        }
-
-                        // Always drop heartbeat responses (successful or error)
-                        return false;
-                    }
-
-                    if response.is_update {
-                        match self.subscription_sender.send(response) {
-                            Ok(_) => {}
-                            Err(e) => {
-                                warn!("history_plant: no active subscribers: {:?}", e);
-                            }
-                        }
-                    } else {
-                        self.request_handler.handle_response(response);
-                    }
-                }
-                Err(err_response) => {
-                    error!(
-                        "history_plant: error response from server: {:?}",
-                        err_response
-                    );
-
-                    if err_response.is_update {
-                        let _ = self.subscription_sender.send(err_response);
-                    } else {
-                        self.request_handler.handle_response(err_response);
-                    }
-                }
-            },
-            Err(Error::ConnectionClosed) => {
-                error!("history_plant: connection closed");
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    "WebSocket connection closed",
-                );
-                stop = true;
-            }
-            Err(Error::AlreadyClosed) => {
-                error!("history_plant: connection already closed");
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    "WebSocket connection already closed",
-                );
-                stop = true;
-            }
-            Err(Error::Io(ref io_err)) => {
-                error!("history_plant: I/O error: {}", io_err);
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    format!("WebSocket I/O error: {}", io_err),
-                );
-                stop = true;
-            }
-            Err(Error::Protocol(ProtocolError::ResetWithoutClosingHandshake)) => {
-                error!("history_plant: connection reset without closing handshake");
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    "WebSocket connection reset without closing handshake",
-                );
-                stop = true;
-            }
-            Err(Error::Protocol(ProtocolError::SendAfterClosing)) => {
-                error!("history_plant: attempted to send after closing");
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    "WebSocket attempted to send after closing",
-                );
-                stop = true;
-            }
-            Err(Error::Protocol(ProtocolError::ReceivedAfterClosing)) => {
-                error!("history_plant: received data after closing");
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    "WebSocket received data after closing",
-                );
-                stop = true;
-            }
-            _ => {
-                warn!("history_plant: Unhandled message {:?}", message);
-            }
-        }
-
-        stop
     }
 
     async fn handle_command(&mut self, command: HistoryPlantCommand) {
         match command {
             HistoryPlantCommand::Close => {
-                self.close_requested = true;
-                self.send_close_best_effort().await;
+                self.core.handle_close().await;
             }
             HistoryPlantCommand::ListSystemInfo { response_sender } => {
-                let (list_system_info_buf, id) =
-                    self.rithmic_sender_api.request_rithmic_system_info();
-
-                self.request_handler.register_request(RithmicRequest {
-                    request_id: id.clone(),
-                    responder: response_sender,
-                });
-
-                self.send_or_fail(Message::Binary(list_system_info_buf.into()), &id)
-                    .await;
+                self.core.handle_list_system_info(response_sender).await;
             }
             HistoryPlantCommand::Login {
                 config,
                 response_sender,
             } => {
-                let (login_buf, id) = self.rithmic_sender_api.request_login(
-                    &self.config.system_name,
-                    SysInfraType::HistoryPlant,
-                    &self.config.user,
-                    &self.config.password,
-                    &config,
-                );
-
-                info!("history_plant: sending login request {}", id);
-
-                self.request_handler.register_request(RithmicRequest {
-                    request_id: id.clone(),
-                    responder: response_sender,
-                });
-
-                self.send_or_fail(Message::Binary(login_buf.into()), &id)
+                self.core
+                    .handle_login(config, SysInfraType::HistoryPlant, response_sender)
                     .await;
             }
             HistoryPlantCommand::SetLogin => {
-                self.logged_in = true;
+                self.core.handle_set_login();
             }
             HistoryPlantCommand::Logout { response_sender } => {
-                let (logout_buf, id) = self.rithmic_sender_api.request_logout();
-
-                self.request_handler.register_request(RithmicRequest {
-                    request_id: id.clone(),
-                    responder: response_sender,
-                });
-
-                self.send_or_fail(Message::Binary(logout_buf.into()), &id)
-                    .await;
+                self.core.handle_logout(response_sender).await;
             }
             HistoryPlantCommand::UpdateHeartbeat { seconds } => {
-                self.interval = get_heartbeat_interval(Some(seconds));
+                self.core.handle_update_heartbeat(seconds);
             }
             HistoryPlantCommand::LoadTicks {
                 bar_type_specifier,
@@ -675,20 +333,22 @@ impl PlantActor for HistoryPlant {
                 end_time_sec,
                 response_sender,
             } => {
-                let (tick_bar_replay_buf, id) = self.rithmic_sender_api.request_tick_bar_replay(
-                    &symbol,
-                    &exchange,
-                    &bar_type_specifier,
-                    start_time_sec,
-                    end_time_sec,
-                );
+                let (tick_bar_replay_buf, id) =
+                    self.core.rithmic_sender_api.request_tick_bar_replay(
+                        &symbol,
+                        &exchange,
+                        &bar_type_specifier,
+                        start_time_sec,
+                        end_time_sec,
+                    );
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(tick_bar_replay_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(tick_bar_replay_buf.into()), &id)
                     .await;
             }
             HistoryPlantCommand::LoadTimeBars {
@@ -700,21 +360,23 @@ impl PlantActor for HistoryPlant {
                 start_time_sec,
                 symbol,
             } => {
-                let (time_bar_replay_buf, id) = self.rithmic_sender_api.request_time_bar_replay(
-                    &symbol,
-                    &exchange,
-                    bar_type,
-                    bar_type_period,
-                    start_time_sec,
-                    end_time_sec,
-                );
+                let (time_bar_replay_buf, id) =
+                    self.core.rithmic_sender_api.request_time_bar_replay(
+                        &symbol,
+                        &exchange,
+                        bar_type,
+                        bar_type_period,
+                        start_time_sec,
+                        end_time_sec,
+                    );
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(time_bar_replay_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(time_bar_replay_buf.into()), &id)
                     .await;
             }
             HistoryPlantCommand::LoadVolumeProfileMinuteBars {
@@ -727,35 +389,45 @@ impl PlantActor for HistoryPlant {
                 resume_bars,
                 response_sender,
             } => {
-                let (buf, id) = self.rithmic_sender_api.request_volume_profile_minute_bars(
-                    &symbol,
-                    &exchange,
-                    bar_type_period,
-                    start_time_sec,
-                    end_time_sec,
-                    user_max_count,
-                    resume_bars,
-                );
+                let (buf, id) = self
+                    .core
+                    .rithmic_sender_api
+                    .request_volume_profile_minute_bars(
+                        &symbol,
+                        &exchange,
+                        bar_type_period,
+                        start_time_sec,
+                        end_time_sec,
+                        user_max_count,
+                        resume_bars,
+                    );
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(buf.into()), &id).await;
+                self.core
+                    .send_or_fail(Message::Binary(buf.into()), &id)
+                    .await;
             }
             HistoryPlantCommand::ResumeBars {
                 request_key,
                 response_sender,
             } => {
-                let (buf, id) = self.rithmic_sender_api.request_resume_bars(&request_key);
+                let (buf, id) = self
+                    .core
+                    .rithmic_sender_api
+                    .request_resume_bars(&request_key);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(buf.into()), &id).await;
+                self.core
+                    .send_or_fail(Message::Binary(buf.into()), &id)
+                    .await;
             }
             HistoryPlantCommand::SubscribeTimeBarUpdates {
                 symbol,
@@ -765,7 +437,7 @@ impl PlantActor for HistoryPlant {
                 request,
                 response_sender,
             } => {
-                let (buf, id) = self.rithmic_sender_api.request_time_bar_update(
+                let (buf, id) = self.core.rithmic_sender_api.request_time_bar_update(
                     &symbol,
                     &exchange,
                     bar_type,
@@ -773,12 +445,14 @@ impl PlantActor for HistoryPlant {
                     request,
                 );
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(buf.into()), &id).await;
+                self.core
+                    .send_or_fail(Message::Binary(buf.into()), &id)
+                    .await;
             }
             HistoryPlantCommand::SubscribeTickBarUpdates {
                 symbol,
@@ -789,7 +463,7 @@ impl PlantActor for HistoryPlant {
                 request,
                 response_sender,
             } => {
-                let (buf, id) = self.rithmic_sender_api.request_tick_bar_update(
+                let (buf, id) = self.core.rithmic_sender_api.request_tick_bar_update(
                     &symbol,
                     &exchange,
                     bar_type,
@@ -798,12 +472,14 @@ impl PlantActor for HistoryPlant {
                     request,
                 );
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(buf.into()), &id).await;
+                self.core
+                    .send_or_fail(Message::Binary(buf.into()), &id)
+                    .await;
             }
             HistoryPlantCommand::Abort => {
                 unreachable!("Abort is handled in run() before handle_command");

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -439,7 +439,9 @@ impl PlantActor for OrderPlant {
                 SelectResult::PingTimeout => {
                     if self.core.ping_manager.check_timeout() {
                         if self.core.close_requested {
-                            warn!("order_plant: ping timed out while waiting for server close echo — terminating");
+                            warn!(
+                                "order_plant: ping timed out while waiting for server close echo — terminating"
+                            );
                             self.core.request_handler.drain_and_drop();
                         } else {
                             self.core.fail_connection_and_drain(

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -1,45 +1,35 @@
-use std::{sync::Arc, time::Duration};
-
+use std::sync::Arc;
 use tracing::{error, info, warn};
-
-use tokio_tungstenite::{
-    MaybeTlsStream,
-    tungstenite::{Error, Message, error::ProtocolError},
-};
 
 use crate::{
     ConnectStrategy,
     api::{
-        receiver_api::{RithmicReceiverApi, RithmicResponse},
+        receiver_api::RithmicResponse,
         rithmic_command_types::{
             LoginConfig, RithmicAdvancedBracketOrder, RithmicBracketOrder, RithmicCancelOrder,
             RithmicModifyOrder, RithmicOcoOrderLeg, RithmicOrder,
         },
-        sender_api::RithmicSenderApi,
     },
     config::{RithmicAccount, RithmicConfig},
     error::RithmicError,
-    ping_manager::PingManager,
-    plants::subscription::SubscriptionFilter,
-    request_handler::{RithmicRequest, RithmicRequestHandler},
-    rti::{messages::RithmicMessage, request_easy_to_borrow_list, request_login::SysInfraType},
-    ws::{
-        HEARTBEAT_SECS, PING_TIMEOUT_SECS, PlantActor, SEND_TIMEOUT_SECS, WebSocketSendError,
-        connect_with_strategy, get_heartbeat_interval, get_ping_interval, send_with_timeout,
+    plants::{
+        core::{PlantCore, SelectResult},
+        subscription::SubscriptionFilter,
     },
+    request_handler::RithmicRequest,
+    rti::{messages::RithmicMessage, request_easy_to_borrow_list, request_login::SysInfraType},
+    ws::{HEARTBEAT_SECS, PlantActor},
 };
 
-use futures_util::{
-    StreamExt,
-    stream::{SplitSink, SplitStream},
-};
+use futures_util::StreamExt;
 
 use tokio::{
-    net::TcpStream,
     sync::{broadcast, mpsc, oneshot},
     task::JoinHandle,
-    time::{Interval, sleep_until},
+    time::sleep_until,
 };
+
+use tokio_tungstenite::tungstenite::Message;
 
 pub(crate) enum OrderPlantCommand {
     Close,
@@ -392,24 +382,10 @@ impl RithmicOrderPlant {
     }
 }
 
+#[derive(Debug)]
 struct OrderPlant {
-    config: RithmicConfig,
-    // Distinguishes an intentional local shutdown from an unexpected peer close.
-    close_requested: bool,
-    interval: Interval,
-    logged_in: bool,
-    ping_interval: Interval,
-    ping_manager: PingManager,
-    request_handler: RithmicRequestHandler,
+    core: PlantCore,
     request_receiver: mpsc::Receiver<OrderPlantCommand>,
-    rithmic_reader: SplitStream<tokio_tungstenite::WebSocketStream<MaybeTlsStream<TcpStream>>>,
-    rithmic_receiver_api: RithmicReceiverApi,
-    rithmic_sender: SplitSink<
-        tokio_tungstenite::WebSocketStream<MaybeTlsStream<TcpStream>>,
-        tokio_tungstenite::tungstenite::Message,
-    >,
-    rithmic_sender_api: RithmicSenderApi,
-    subscription_sender: broadcast::Sender<RithmicResponse>,
 }
 
 impl OrderPlant {
@@ -419,175 +395,11 @@ impl OrderPlant {
         config: &RithmicConfig,
         strategy: ConnectStrategy,
     ) -> Result<OrderPlant, RithmicError> {
-        let ws_stream = connect_with_strategy(&config.url, &config.beta_url, strategy)
-            .await
-            .map_err(|e| RithmicError::ConnectionFailed(e.to_string()))?;
-
-        let (rithmic_sender, rithmic_reader) = ws_stream.split();
-
-        let rithmic_sender_api = RithmicSenderApi::new(config);
-        let rithmic_receiver_api = RithmicReceiverApi {
-            source: "order_plant".to_string(),
-        };
-
-        let interval = get_heartbeat_interval(None);
-        let ping_interval = get_ping_interval(None);
-        let ping_manager = PingManager::new(PING_TIMEOUT_SECS);
-
+        let core = PlantCore::new(subscription_sender, config, strategy, "order_plant").await?;
         Ok(OrderPlant {
-            config: config.clone(),
-            close_requested: false,
-            interval,
-            ping_interval,
-            logged_in: false,
-            ping_manager,
-            request_handler: RithmicRequestHandler::new(),
+            core,
             request_receiver,
-            rithmic_reader,
-            rithmic_receiver_api,
-            rithmic_sender_api,
-            rithmic_sender,
-            subscription_sender,
         })
-    }
-
-    fn emit_connection_health_event(
-        &self,
-        request_id: &str,
-        message: RithmicMessage,
-        error_message: impl Into<String>,
-    ) {
-        let error_response = RithmicResponse {
-            request_id: request_id.to_string(),
-            message,
-            is_update: true,
-            has_more: false,
-            multi_response: false,
-            error: Some(error_message.into()),
-            source: self.rithmic_receiver_api.source.clone(),
-        };
-
-        let _ = self.subscription_sender.send(error_response);
-    }
-
-    fn fail_connection_and_drain(
-        &mut self,
-        request_id: &str,
-        message: RithmicMessage,
-        error_message: impl Into<String>,
-    ) {
-        self.emit_connection_health_event(request_id, message, error_message);
-        self.request_handler.drain_and_drop();
-    }
-
-    async fn send_or_fail(&mut self, msg: Message, request_id: &str) {
-        match send_with_timeout(
-            &mut self.rithmic_sender,
-            msg,
-            Duration::from_secs(SEND_TIMEOUT_SECS),
-        )
-        .await
-        {
-            Ok(()) => {}
-            Err(WebSocketSendError::Transport(error)) => {
-                error!(
-                    "order_plant: WebSocket send failed for request {}: {}",
-                    request_id, error
-                );
-                self.request_handler
-                    .fail_request(request_id, RithmicError::SendFailed);
-            }
-            Err(WebSocketSendError::Timeout) => {
-                error!(
-                    "order_plant: WebSocket send timed out for request {}",
-                    request_id
-                );
-                self.request_handler
-                    .fail_request(request_id, RithmicError::SendFailed);
-            }
-        }
-    }
-
-    async fn send_ping(&mut self) -> bool {
-        self.ping_manager.sent();
-
-        match send_with_timeout(
-            &mut self.rithmic_sender,
-            Message::Ping(vec![].into()),
-            Duration::from_secs(SEND_TIMEOUT_SECS),
-        )
-        .await
-        {
-            Ok(()) => false,
-            Err(WebSocketSendError::Transport(error)) => {
-                error!("order_plant: WebSocket ping send failed: {}", error);
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    format!("WebSocket ping send failed: {error}"),
-                );
-                true
-            }
-            Err(WebSocketSendError::Timeout) => {
-                error!("order_plant: WebSocket ping send timed out");
-                self.fail_connection_and_drain(
-                    "websocket_ping_timeout",
-                    RithmicMessage::HeartbeatTimeout,
-                    "WebSocket ping send timed out - connection dead",
-                );
-                true
-            }
-        }
-    }
-
-    async fn send_heartbeat(&mut self) -> bool {
-        let (heartbeat_buf, _id) = self.rithmic_sender_api.request_heartbeat();
-
-        match send_with_timeout(
-            &mut self.rithmic_sender,
-            Message::Binary(heartbeat_buf.into()),
-            Duration::from_secs(SEND_TIMEOUT_SECS),
-        )
-        .await
-        {
-            Ok(()) => false,
-            Err(WebSocketSendError::Transport(error)) => {
-                error!("order_plant: heartbeat send failed: {}", error);
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    format!("Heartbeat send failed: {error}"),
-                );
-                true
-            }
-            Err(WebSocketSendError::Timeout) => {
-                error!("order_plant: heartbeat send timed out");
-                self.fail_connection_and_drain(
-                    "heartbeat_send_timeout",
-                    RithmicMessage::HeartbeatTimeout,
-                    "Heartbeat send timed out - connection dead",
-                );
-                true
-            }
-        }
-    }
-
-    async fn send_close_best_effort(&mut self) {
-        match send_with_timeout(
-            &mut self.rithmic_sender,
-            Message::Close(None),
-            Duration::from_secs(SEND_TIMEOUT_SECS),
-        )
-        .await
-        {
-            Ok(()) => {}
-            Err(WebSocketSendError::Transport(error)) => {
-                warn!("order_plant: close send failed: {}", error);
-            }
-            Err(WebSocketSendError::Timeout) => {
-                warn!("order_plant: close send timed out");
-            }
-        }
     }
 }
 
@@ -596,256 +408,109 @@ impl PlantActor for OrderPlant {
 
     async fn run(&mut self) {
         loop {
-            tokio::select! {
-                _ = self.interval.tick() => {
-                    if self.logged_in && !self.close_requested && self.send_heartbeat().await {
-                        break;
-                    }
-                }
-                _ = self.ping_interval.tick() => {
-                    if !self.close_requested && self.send_ping().await {
-                        break;
-                    }
-                }
-                _ = async {
-                    if let Some(timeout_at) = self.ping_manager.next_timeout_at() {
-                        sleep_until(timeout_at).await
-                    } else {
-                        std::future::pending::<()>().await
-                    }
-                } => {
-                    if self.ping_manager.check_timeout() {
-                        if self.close_requested {
-                            self.request_handler.drain_and_drop();
+            let result = {
+                let interval = &mut self.core.interval;
+                let ping_interval = &mut self.core.ping_interval;
+                let ping_manager = &mut self.core.ping_manager;
+                let reader = &mut self.core.rithmic_reader;
+                let receiver = &mut self.request_receiver;
+
+                tokio::select! {
+                    _ = interval.tick()      => SelectResult::HeartbeatFired,
+                    _ = ping_interval.tick() => SelectResult::PingFired,
+                    _ = async {
+                        if let Some(t) = ping_manager.next_timeout_at() {
+                            sleep_until(t).await
                         } else {
-                            error!("WebSocket ping timed out - connection appears dead");
-                            self.fail_connection_and_drain(
+                            std::future::pending::<()>().await
+                        }
+                    } => SelectResult::PingTimeout,
+                    Some(cmd) = receiver.recv() => SelectResult::Command(cmd),
+                    msg = reader.next() => match msg {
+                        Some(m) => SelectResult::RithmicMessage(m),
+                        None => SelectResult::StreamClosed,
+                    },
+                }
+            };
+
+            let stop = match result {
+                SelectResult::HeartbeatFired => self.core.send_heartbeat().await,
+                SelectResult::PingFired => self.core.send_ping().await,
+                SelectResult::PingTimeout => {
+                    if self.core.ping_manager.check_timeout() {
+                        if self.core.close_requested {
+                            warn!("order_plant: ping timed out while waiting for server close echo — terminating");
+                            self.core.request_handler.drain_and_drop();
+                        } else {
+                            self.core.fail_connection_and_drain(
                                 "websocket_ping_timeout",
                                 RithmicMessage::HeartbeatTimeout,
                                 "WebSocket ping timeout - connection dead",
                             );
                         }
-                        break;
+                        true
+                    } else {
+                        false
                     }
                 }
-                Some(message) = self.request_receiver.recv() => {
-                    if matches!(message, OrderPlantCommand::Abort) {
+                SelectResult::Command(cmd) => {
+                    if matches!(cmd, OrderPlantCommand::Abort) {
                         info!("order_plant: abort requested, shutting down immediately");
-                        self.fail_connection_and_drain(
+                        self.core.fail_connection_and_drain(
                             "",
                             RithmicMessage::ConnectionError,
                             "Plant aborted",
                         );
-                        break;
-                    }
-                    self.handle_command(message).await;
-                }
-                Some(message) = self.rithmic_reader.next() => {
-                    let stop = self.handle_rithmic_message(message).await;
-
-                    if stop {
-                        break;
+                        true
+                    } else {
+                        self.handle_command(cmd).await;
+                        false
                     }
                 }
-                else => { break; }
+                SelectResult::RithmicMessage(msg) => self.core.handle_rithmic_message(msg).await,
+                SelectResult::StreamClosed => self.core.handle_stream_closed(),
+            };
+            if stop {
+                break;
             }
         }
-    }
-
-    async fn handle_rithmic_message(&mut self, message: Result<Message, Error>) -> bool {
-        let mut stop = false;
-
-        match message {
-            Ok(Message::Close(frame)) => {
-                info!("order_plant: Received close frame: {:?}", frame);
-                if self.close_requested {
-                    self.request_handler.drain_and_drop();
-                } else {
-                    self.fail_connection_and_drain(
-                        "",
-                        RithmicMessage::ConnectionError,
-                        format!("WebSocket close frame received: {:?}", frame),
-                    );
-                }
-                stop = true;
-            }
-            Ok(Message::Pong(_)) => {
-                self.ping_manager.received();
-            }
-            Ok(Message::Binary(data)) => match self.rithmic_receiver_api.buf_to_message(data) {
-                Ok(response) => {
-                    // Handle heartbeat responses: only forward if they contain an error
-                    if matches!(response.message, RithmicMessage::ResponseHeartbeat(_)) {
-                        if let Some(error) = response.error {
-                            let error_response = RithmicResponse {
-                                request_id: response.request_id,
-                                message: RithmicMessage::HeartbeatTimeout,
-                                is_update: true,
-                                has_more: false,
-                                multi_response: false,
-                                error: Some(error),
-                                source: self.rithmic_receiver_api.source.clone(),
-                            };
-
-                            let _ = self.subscription_sender.send(error_response);
-                        }
-
-                        // Always drop heartbeat responses (successful or error)
-                        return false;
-                    }
-
-                    if response.is_update {
-                        match self.subscription_sender.send(response) {
-                            Ok(_) => {}
-                            Err(e) => {
-                                warn!("order_plant: no active subscribers: {:?}", e);
-                            }
-                        }
-                    } else {
-                        self.request_handler.handle_response(response);
-                    }
-                }
-                Err(err_response) => {
-                    error!(
-                        "order_plant: error response from server: {:?}",
-                        err_response
-                    );
-
-                    if err_response.is_update {
-                        let _ = self.subscription_sender.send(err_response);
-                    } else {
-                        self.request_handler.handle_response(err_response);
-                    }
-                }
-            },
-            Err(Error::ConnectionClosed) => {
-                error!("order_plant: connection closed");
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    "WebSocket connection closed",
-                );
-                stop = true;
-            }
-            Err(Error::AlreadyClosed) => {
-                error!("order_plant: connection already closed");
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    "WebSocket connection already closed",
-                );
-                stop = true;
-            }
-            Err(Error::Io(ref io_err)) => {
-                error!("order_plant: I/O error: {}", io_err);
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    format!("WebSocket I/O error: {}", io_err),
-                );
-                stop = true;
-            }
-            Err(Error::Protocol(ProtocolError::ResetWithoutClosingHandshake)) => {
-                error!("order_plant: connection reset without closing handshake");
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    "WebSocket connection reset without closing handshake",
-                );
-                stop = true;
-            }
-            Err(Error::Protocol(ProtocolError::SendAfterClosing)) => {
-                error!("order_plant: attempted to send after closing");
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    "WebSocket attempted to send after closing",
-                );
-                stop = true;
-            }
-            Err(Error::Protocol(ProtocolError::ReceivedAfterClosing)) => {
-                error!("order_plant: received data after closing");
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    "WebSocket received data after closing",
-                );
-                stop = true;
-            }
-            _ => {
-                warn!("order_plant: Unhandled message: {:?}", message);
-            }
-        }
-
-        stop
     }
 
     async fn handle_command(&mut self, command: OrderPlantCommand) {
         match command {
             OrderPlantCommand::Close => {
-                self.close_requested = true;
-                self.send_close_best_effort().await;
+                self.core.handle_close().await;
             }
             OrderPlantCommand::ListSystemInfo { response_sender } => {
-                let (list_system_info_buf, id) =
-                    self.rithmic_sender_api.request_rithmic_system_info();
-
-                self.request_handler.register_request(RithmicRequest {
-                    request_id: id.clone(),
-                    responder: response_sender,
-                });
-
-                self.send_or_fail(Message::Binary(list_system_info_buf.into()), &id)
-                    .await;
+                self.core.handle_list_system_info(response_sender).await;
             }
             OrderPlantCommand::Login {
                 config,
                 response_sender,
             } => {
-                let (login_buf, id) = self.rithmic_sender_api.request_login(
-                    &self.config.system_name,
-                    SysInfraType::OrderPlant,
-                    &self.config.user,
-                    &self.config.password,
-                    &config,
-                );
-
-                info!("order_plant: sending login request {}", id);
-
-                self.request_handler.register_request(RithmicRequest {
-                    request_id: id.clone(),
-                    responder: response_sender,
-                });
-
-                self.send_or_fail(Message::Binary(login_buf.into()), &id)
+                self.core
+                    .handle_login(config, SysInfraType::OrderPlant, response_sender)
                     .await;
             }
             OrderPlantCommand::SetLogin => {
-                self.logged_in = true;
+                self.core.handle_set_login();
             }
             OrderPlantCommand::Logout { response_sender } => {
-                let (logout_buf, id) = self.rithmic_sender_api.request_logout();
-
-                self.request_handler.register_request(RithmicRequest {
-                    request_id: id.clone(),
-                    responder: response_sender,
-                });
-
-                self.send_or_fail(Message::Binary(logout_buf.into()), &id)
-                    .await;
+                self.core.handle_logout(response_sender).await;
             }
             OrderPlantCommand::UpdateHeartbeat { seconds } => {
-                self.interval = get_heartbeat_interval(Some(seconds));
+                self.core.handle_update_heartbeat(seconds);
             }
             OrderPlantCommand::AccountList { response_sender } => {
-                let (req_buf, id) = self.rithmic_sender_api.request_account_list();
+                let (req_buf, id) = self.core.rithmic_sender_api.request_account_list();
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::SubscribeOrderUpdates {
@@ -853,15 +518,17 @@ impl PlantActor for OrderPlant {
                 response_sender,
             } => {
                 let (req_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_subscribe_for_order_updates(&account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::SubscribeBracketUpdates {
@@ -869,15 +536,17 @@ impl PlantActor for OrderPlant {
                 response_sender,
             } => {
                 let (req_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_subscribe_to_bracket_updates(&account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::PlaceBracketOrder {
@@ -886,15 +555,17 @@ impl PlantActor for OrderPlant {
                 response_sender,
             } => {
                 let (req_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_bracket_order(bracket_order, &account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::PlaceAdvancedBracketOrder {
@@ -903,15 +574,17 @@ impl PlantActor for OrderPlant {
                 response_sender,
             } => {
                 let (req_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_advanced_bracket_order(bracket_order, &account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::ModifyOrder {
@@ -919,7 +592,7 @@ impl PlantActor for OrderPlant {
                 account,
                 response_sender,
             } => {
-                let (req_buf, id) = self.rithmic_sender_api.request_modify_order(
+                let (req_buf, id) = self.core.rithmic_sender_api.request_modify_order(
                     &order.id,
                     &order.exchange,
                     &order.symbol,
@@ -929,12 +602,13 @@ impl PlantActor for OrderPlant {
                     &account,
                 );
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::CancelOrder {
@@ -943,15 +617,17 @@ impl PlantActor for OrderPlant {
                 response_sender,
             } => {
                 let (req_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_cancel_order(&order_id, &account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::ModifyStop {
@@ -961,15 +637,17 @@ impl PlantActor for OrderPlant {
                 response_sender,
             } => {
                 let (req_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_update_stop_bracket_level(&order_id, ticks, &account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::ModifyProfit {
@@ -979,71 +657,86 @@ impl PlantActor for OrderPlant {
                 response_sender,
             } => {
                 let (req_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_update_target_bracket_level(&order_id, ticks, &account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::ShowOrders {
                 account,
                 response_sender,
             } => {
-                let (req_buf, id) = self.rithmic_sender_api.request_show_orders(&account);
+                let (req_buf, id) = self.core.rithmic_sender_api.request_show_orders(&account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::CancelAllOrders {
                 account,
                 response_sender,
             } => {
-                let (req_buf, id) = self.rithmic_sender_api.request_cancel_all_orders(&account);
+                let (req_buf, id) = self
+                    .core
+                    .rithmic_sender_api
+                    .request_cancel_all_orders(&account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::GetAccountRmsInfo {
                 account,
                 response_sender,
             } => {
-                let (req_buf, id) = self.rithmic_sender_api.request_account_rms_info(&account);
+                let (req_buf, id) = self
+                    .core
+                    .rithmic_sender_api
+                    .request_account_rms_info(&account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::GetProductRmsInfo {
                 account,
                 response_sender,
             } => {
-                let (req_buf, id) = self.rithmic_sender_api.request_product_rms_info(&account);
+                let (req_buf, id) = self
+                    .core
+                    .rithmic_sender_api
+                    .request_product_rms_info(&account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::GetTradeRoutes {
@@ -1051,26 +744,32 @@ impl PlantActor for OrderPlant {
                 response_sender,
             } => {
                 let (req_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_trade_routes(subscribe_for_updates);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::ShowOrderHistoryDates { response_sender } => {
-                let (req_buf, id) = self.rithmic_sender_api.request_show_order_history_dates();
+                let (req_buf, id) = self
+                    .core
+                    .rithmic_sender_api
+                    .request_show_order_history_dates();
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::ShowOrderHistorySummary {
@@ -1079,15 +778,17 @@ impl PlantActor for OrderPlant {
                 response_sender,
             } => {
                 let (req_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_show_order_history_summary(&date, &account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::ShowOrderHistoryDetail {
@@ -1097,15 +798,17 @@ impl PlantActor for OrderPlant {
                 response_sender,
             } => {
                 let (req_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_show_order_history_detail(&basket_id, &date, &account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::ShowOrderHistory {
@@ -1114,15 +817,17 @@ impl PlantActor for OrderPlant {
                 response_sender,
             } => {
                 let (req_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_show_order_history(basket_id.as_deref(), &account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::PlaceOrder {
@@ -1130,14 +835,15 @@ impl PlantActor for OrderPlant {
                 account,
                 response_sender,
             } => {
-                let (req_buf, id) = self.rithmic_sender_api.request_order(&order, &account);
+                let (req_buf, id) = self.core.rithmic_sender_api.request_order(&order, &account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::PlaceOcoOrder {
@@ -1147,43 +853,50 @@ impl PlantActor for OrderPlant {
                 response_sender,
             } => {
                 let (req_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_oco_order(order1, order2, &account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::ShowBrackets {
                 account,
                 response_sender,
             } => {
-                let (req_buf, id) = self.rithmic_sender_api.request_show_brackets(&account);
+                let (req_buf, id) = self.core.rithmic_sender_api.request_show_brackets(&account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::ShowBracketStops {
                 account,
                 response_sender,
             } => {
-                let (req_buf, id) = self.rithmic_sender_api.request_show_bracket_stops(&account);
+                let (req_buf, id) = self
+                    .core
+                    .rithmic_sender_api
+                    .request_show_bracket_stops(&account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::ExitPosition {
@@ -1193,15 +906,17 @@ impl PlantActor for OrderPlant {
                 response_sender,
             } => {
                 let (req_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_exit_position(&symbol, &exchange, &account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::LinkOrders {
@@ -1210,15 +925,17 @@ impl PlantActor for OrderPlant {
                 response_sender,
             } => {
                 let (req_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_link_orders(basket_ids, &account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::GetEasyToBorrowList {
@@ -1226,15 +943,17 @@ impl PlantActor for OrderPlant {
                 response_sender,
             } => {
                 let (req_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_easy_to_borrow_list(request_type);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::ModifyOrderReferenceData {
@@ -1244,15 +963,17 @@ impl PlantActor for OrderPlant {
                 response_sender,
             } => {
                 let (req_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_modify_order_reference_data(&basket_id, &user_tag, &account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::GetOrderSessionConfig {
@@ -1260,15 +981,17 @@ impl PlantActor for OrderPlant {
                 response_sender,
             } => {
                 let (req_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_order_session_config(should_defer_request);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::ReplayExecutions {
@@ -1277,18 +1000,19 @@ impl PlantActor for OrderPlant {
                 account,
                 response_sender,
             } => {
-                let (req_buf, id) = self.rithmic_sender_api.request_replay_executions(
+                let (req_buf, id) = self.core.rithmic_sender_api.request_replay_executions(
                     start_index_sec,
                     finish_index_sec,
                     &account,
                 );
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::SubscribeAccountRmsUpdates {
@@ -1297,48 +1021,59 @@ impl PlantActor for OrderPlant {
                 response_sender,
             } => {
                 let (req_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_account_rms_updates(subscribe, &account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::GetLoginInfo { response_sender } => {
-                let (req_buf, id) = self.rithmic_sender_api.request_login_info();
+                let (req_buf, id) = self.core.rithmic_sender_api.request_login_info();
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::ListUnacceptedAgreements { response_sender } => {
-                let (req_buf, id) = self.rithmic_sender_api.request_list_unaccepted_agreements();
+                let (req_buf, id) = self
+                    .core
+                    .rithmic_sender_api
+                    .request_list_unaccepted_agreements();
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::ListAcceptedAgreements { response_sender } => {
-                let (req_buf, id) = self.rithmic_sender_api.request_list_accepted_agreements();
+                let (req_buf, id) = self
+                    .core
+                    .rithmic_sender_api
+                    .request_list_accepted_agreements();
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::AcceptAgreement {
@@ -1347,15 +1082,17 @@ impl PlantActor for OrderPlant {
                 response_sender,
             } => {
                 let (req_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_accept_agreement(&agreement_id, market_data_usage_capacity.as_deref());
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::ShowAgreement {
@@ -1363,15 +1100,17 @@ impl PlantActor for OrderPlant {
                 response_sender,
             } => {
                 let (req_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_show_agreement(&agreement_id);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::SetRithmicMrktDataSelfCertStatus {
@@ -1380,38 +1119,41 @@ impl PlantActor for OrderPlant {
                 response_sender,
             } => {
                 let (req_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_set_rithmic_mrkt_data_self_cert_status(
                         &agreement_id,
                         &market_data_usage_capacity,
                     );
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::ListExchangePermissions {
                 user,
                 response_sender,
             } => {
-                let (req_buf, id) = self.rithmic_sender_api.request_list_exchanges(&user);
+                let (req_buf, id) = self.core.rithmic_sender_api.request_list_exchanges(&user);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(req_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
             OrderPlantCommand::Abort => {
                 unreachable!("Abort is handled in run() before handle_command");
             }
-        };
+        }
     }
 }
 

--- a/src/plants/pnl_plant.rs
+++ b/src/plants/pnl_plant.rs
@@ -233,7 +233,9 @@ impl PlantActor for PnlPlant {
                 SelectResult::PingTimeout => {
                     if self.core.ping_manager.check_timeout() {
                         if self.core.close_requested {
-                            warn!("pnl_plant: ping timed out while waiting for server close echo — terminating");
+                            warn!(
+                                "pnl_plant: ping timed out while waiting for server close echo — terminating"
+                            );
                             self.core.request_handler.drain_and_drop();
                         } else {
                             self.core.fail_connection_and_drain(

--- a/src/plants/pnl_plant.rs
+++ b/src/plants/pnl_plant.rs
@@ -1,41 +1,28 @@
-use std::{sync::Arc, time::Duration};
-
+use std::sync::Arc;
 use tracing::{error, info, warn};
 
 use crate::{
     ConnectStrategy,
-    api::{
-        receiver_api::{RithmicReceiverApi, RithmicResponse},
-        rithmic_command_types::LoginConfig,
-        sender_api::RithmicSenderApi,
-    },
+    api::{receiver_api::RithmicResponse, rithmic_command_types::LoginConfig},
     config::{RithmicAccount, RithmicConfig},
     error::RithmicError,
-    ping_manager::PingManager,
-    plants::subscription::SubscriptionFilter,
-    request_handler::{RithmicRequest, RithmicRequestHandler},
-    rti::{messages::RithmicMessage, request_login::SysInfraType, request_pn_l_position_updates},
-    ws::{
-        HEARTBEAT_SECS, PING_TIMEOUT_SECS, PlantActor, SEND_TIMEOUT_SECS, WebSocketSendError,
-        connect_with_strategy, get_heartbeat_interval, get_ping_interval, send_with_timeout,
+    plants::{
+        core::{PlantCore, SelectResult},
+        subscription::SubscriptionFilter,
     },
+    request_handler::RithmicRequest,
+    rti::{messages::RithmicMessage, request_login::SysInfraType, request_pn_l_position_updates},
+    ws::{HEARTBEAT_SECS, PlantActor},
 };
 
-use futures_util::{
-    StreamExt,
-    stream::{SplitSink, SplitStream},
-};
+use futures_util::StreamExt;
 
 use tokio::{
-    net::TcpStream,
     sync::{broadcast, mpsc, oneshot},
-    time::{Interval, sleep_until},
+    time::sleep_until,
 };
 
-use tokio_tungstenite::{
-    MaybeTlsStream,
-    tungstenite::{Error, Message, error::ProtocolError},
-};
+use tokio_tungstenite::tungstenite::Message;
 
 pub(crate) enum PnlPlantCommand {
     Close,
@@ -193,23 +180,8 @@ impl RithmicPnlPlant {
 
 #[derive(Debug)]
 struct PnlPlant {
-    config: RithmicConfig,
-    // Distinguishes an intentional local shutdown from an unexpected peer close.
-    close_requested: bool,
-    interval: Interval,
-    logged_in: bool,
-    ping_interval: Interval,
-    ping_manager: PingManager,
-    request_handler: RithmicRequestHandler,
+    core: PlantCore,
     request_receiver: mpsc::Receiver<PnlPlantCommand>,
-    rithmic_reader: SplitStream<tokio_tungstenite::WebSocketStream<MaybeTlsStream<TcpStream>>>,
-    rithmic_receiver_api: RithmicReceiverApi,
-    rithmic_sender: SplitSink<
-        tokio_tungstenite::WebSocketStream<MaybeTlsStream<TcpStream>>,
-        tokio_tungstenite::tungstenite::Message,
-    >,
-    rithmic_sender_api: RithmicSenderApi,
-    subscription_sender: broadcast::Sender<RithmicResponse>,
 }
 
 impl PnlPlant {
@@ -219,177 +191,11 @@ impl PnlPlant {
         config: &RithmicConfig,
         strategy: ConnectStrategy,
     ) -> Result<PnlPlant, RithmicError> {
-        let ws_stream = connect_with_strategy(&config.url, &config.beta_url, strategy)
-            .await
-            .map_err(|e| RithmicError::ConnectionFailed(e.to_string()))?;
-
-        let (rithmic_sender, rithmic_reader) = ws_stream.split();
-
-        let rithmic_sender_api = RithmicSenderApi::new(config);
-        let rithmic_receiver_api = RithmicReceiverApi {
-            source: "pnl_plant".to_string(),
-        };
-
-        let interval = get_heartbeat_interval(None);
-        let ping_interval = get_ping_interval(None);
-        let ping_manager = PingManager::new(PING_TIMEOUT_SECS);
-
+        let core = PlantCore::new(subscription_sender, config, strategy, "pnl_plant").await?;
         Ok(PnlPlant {
-            config: config.clone(),
-            close_requested: false,
-            interval,
-            ping_interval,
-            logged_in: false,
-            ping_manager,
-            request_handler: RithmicRequestHandler::new(),
+            core,
             request_receiver,
-            rithmic_reader,
-            rithmic_receiver_api,
-            rithmic_sender_api,
-            rithmic_sender,
-            subscription_sender,
         })
-    }
-}
-
-impl PnlPlant {
-    fn emit_connection_health_event(
-        &self,
-        request_id: &str,
-        message: RithmicMessage,
-        error_message: impl Into<String>,
-    ) {
-        let error_response = RithmicResponse {
-            request_id: request_id.to_string(),
-            message,
-            is_update: true,
-            has_more: false,
-            multi_response: false,
-            error: Some(error_message.into()),
-            source: self.rithmic_receiver_api.source.clone(),
-        };
-
-        let _ = self.subscription_sender.send(error_response);
-    }
-
-    fn fail_connection_and_drain(
-        &mut self,
-        request_id: &str,
-        message: RithmicMessage,
-        error_message: impl Into<String>,
-    ) {
-        self.emit_connection_health_event(request_id, message, error_message);
-        self.request_handler.drain_and_drop();
-    }
-
-    async fn send_or_fail(&mut self, msg: Message, request_id: &str) {
-        match send_with_timeout(
-            &mut self.rithmic_sender,
-            msg,
-            Duration::from_secs(SEND_TIMEOUT_SECS),
-        )
-        .await
-        {
-            Ok(()) => {}
-            Err(WebSocketSendError::Transport(error)) => {
-                error!(
-                    "pnl_plant: WebSocket send failed for request {}: {}",
-                    request_id, error
-                );
-                self.request_handler
-                    .fail_request(request_id, RithmicError::SendFailed);
-            }
-            Err(WebSocketSendError::Timeout) => {
-                error!(
-                    "pnl_plant: WebSocket send timed out for request {}",
-                    request_id
-                );
-                self.request_handler
-                    .fail_request(request_id, RithmicError::SendFailed);
-            }
-        }
-    }
-
-    async fn send_ping(&mut self) -> bool {
-        self.ping_manager.sent();
-
-        match send_with_timeout(
-            &mut self.rithmic_sender,
-            Message::Ping(vec![].into()),
-            Duration::from_secs(SEND_TIMEOUT_SECS),
-        )
-        .await
-        {
-            Ok(()) => false,
-            Err(WebSocketSendError::Transport(error)) => {
-                error!("pnl_plant: WebSocket ping send failed: {}", error);
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    format!("WebSocket ping send failed: {error}"),
-                );
-                true
-            }
-            Err(WebSocketSendError::Timeout) => {
-                error!("pnl_plant: WebSocket ping send timed out");
-                self.fail_connection_and_drain(
-                    "websocket_ping_timeout",
-                    RithmicMessage::HeartbeatTimeout,
-                    "WebSocket ping send timed out - connection dead",
-                );
-                true
-            }
-        }
-    }
-
-    async fn send_heartbeat(&mut self) -> bool {
-        let (heartbeat_buf, _id) = self.rithmic_sender_api.request_heartbeat();
-
-        match send_with_timeout(
-            &mut self.rithmic_sender,
-            Message::Binary(heartbeat_buf.into()),
-            Duration::from_secs(SEND_TIMEOUT_SECS),
-        )
-        .await
-        {
-            Ok(()) => false,
-            Err(WebSocketSendError::Transport(error)) => {
-                error!("pnl_plant: heartbeat send failed: {}", error);
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    format!("Heartbeat send failed: {error}"),
-                );
-                true
-            }
-            Err(WebSocketSendError::Timeout) => {
-                error!("pnl_plant: heartbeat send timed out");
-                self.fail_connection_and_drain(
-                    "heartbeat_send_timeout",
-                    RithmicMessage::HeartbeatTimeout,
-                    "Heartbeat send timed out - connection dead",
-                );
-                true
-            }
-        }
-    }
-
-    async fn send_close_best_effort(&mut self) {
-        match send_with_timeout(
-            &mut self.rithmic_sender,
-            Message::Close(None),
-            Duration::from_secs(SEND_TIMEOUT_SECS),
-        )
-        .await
-        {
-            Ok(()) => {}
-            Err(WebSocketSendError::Transport(error)) => {
-                warn!("pnl_plant: close send failed: {}", error);
-            }
-            Err(WebSocketSendError::Timeout) => {
-                warn!("pnl_plant: close send timed out");
-            }
-        }
     }
 }
 
@@ -398,259 +204,114 @@ impl PlantActor for PnlPlant {
 
     async fn run(&mut self) {
         loop {
-            tokio::select! {
-                _ = self.interval.tick() => {
-                    if self.logged_in && !self.close_requested && self.send_heartbeat().await {
-                        break;
-                    }
-                }
-                _ = self.ping_interval.tick() => {
-                    if !self.close_requested && self.send_ping().await {
-                        break;
-                    }
-                }
-                _ = async {
-                    if let Some(timeout_at) = self.ping_manager.next_timeout_at() {
-                        sleep_until(timeout_at).await
-                    } else {
-                        std::future::pending::<()>().await
-                    }
-                } => {
-                    if self.ping_manager.check_timeout() {
-                        if self.close_requested {
-                            self.request_handler.drain_and_drop();
+            let result = {
+                let interval = &mut self.core.interval;
+                let ping_interval = &mut self.core.ping_interval;
+                let ping_manager = &mut self.core.ping_manager;
+                let reader = &mut self.core.rithmic_reader;
+                let receiver = &mut self.request_receiver;
+                tokio::select! {
+                    _ = interval.tick()      => SelectResult::HeartbeatFired,
+                    _ = ping_interval.tick() => SelectResult::PingFired,
+                    _ = async {
+                        if let Some(t) = ping_manager.next_timeout_at() {
+                            sleep_until(t).await
                         } else {
-                            error!("WebSocket ping timed out - connection appears dead");
-                            self.fail_connection_and_drain(
+                            std::future::pending::<()>().await
+                        }
+                    } => SelectResult::PingTimeout,
+                    Some(cmd) = receiver.recv() => SelectResult::Command(cmd),
+                    msg = reader.next() => match msg {
+                        Some(m) => SelectResult::RithmicMessage(m),
+                        None => SelectResult::StreamClosed,
+                    },
+                }
+            };
+            let stop = match result {
+                SelectResult::HeartbeatFired => self.core.send_heartbeat().await,
+                SelectResult::PingFired => self.core.send_ping().await,
+                SelectResult::PingTimeout => {
+                    if self.core.ping_manager.check_timeout() {
+                        if self.core.close_requested {
+                            warn!("pnl_plant: ping timed out while waiting for server close echo — terminating");
+                            self.core.request_handler.drain_and_drop();
+                        } else {
+                            self.core.fail_connection_and_drain(
                                 "websocket_ping_timeout",
                                 RithmicMessage::HeartbeatTimeout,
                                 "WebSocket ping timeout - connection dead",
                             );
                         }
-                        break;
+                        true
+                    } else {
+                        false
                     }
                 }
-                Some(message) = self.request_receiver.recv() => {
-                    if matches!(message, PnlPlantCommand::Abort) {
+                SelectResult::Command(cmd) => {
+                    if matches!(cmd, PnlPlantCommand::Abort) {
                         info!("pnl_plant: abort requested, shutting down immediately");
-                        self.fail_connection_and_drain(
+                        self.core.fail_connection_and_drain(
                             "",
                             RithmicMessage::ConnectionError,
                             "Plant aborted",
                         );
-                        break;
-                    }
-                    self.handle_command(message).await;
-                }
-                Some(message) = self.rithmic_reader.next() => {
-                    let stop = self.handle_rithmic_message(message).await;
-
-                    if stop {
-                        break;
+                        true
+                    } else {
+                        self.handle_command(cmd).await;
+                        false
                     }
                 }
-                else => { break; }
+                SelectResult::RithmicMessage(msg) => self.core.handle_rithmic_message(msg).await,
+                SelectResult::StreamClosed => self.core.handle_stream_closed(),
+            };
+            if stop {
+                break;
             }
         }
-    }
-
-    async fn handle_rithmic_message(&mut self, message: Result<Message, Error>) -> bool {
-        let mut stop = false;
-
-        match message {
-            Ok(Message::Close(frame)) => {
-                info!("pnl_plant: Received close frame: {:?}", frame);
-                if self.close_requested {
-                    self.request_handler.drain_and_drop();
-                } else {
-                    self.fail_connection_and_drain(
-                        "",
-                        RithmicMessage::ConnectionError,
-                        format!("WebSocket close frame received: {:?}", frame),
-                    );
-                }
-                stop = true;
-            }
-            Ok(Message::Pong(_)) => {
-                self.ping_manager.received();
-            }
-            Ok(Message::Binary(data)) => match self.rithmic_receiver_api.buf_to_message(data) {
-                Ok(response) => {
-                    // Handle heartbeat responses: only forward if they contain an error
-                    if matches!(response.message, RithmicMessage::ResponseHeartbeat(_)) {
-                        if let Some(error) = response.error {
-                            let error_response = RithmicResponse {
-                                request_id: response.request_id,
-                                message: RithmicMessage::HeartbeatTimeout,
-                                is_update: true,
-                                has_more: false,
-                                multi_response: false,
-                                error: Some(error),
-                                source: self.rithmic_receiver_api.source.clone(),
-                            };
-
-                            let _ = self.subscription_sender.send(error_response);
-                        }
-
-                        // Always drop heartbeat responses (successful or error)
-                        return false;
-                    }
-
-                    if response.is_update {
-                        match self.subscription_sender.send(response) {
-                            Ok(_) => {}
-                            Err(e) => {
-                                warn!("pnl_plant: no active subscribers: {:?}", e);
-                            }
-                        }
-                    } else {
-                        self.request_handler.handle_response(response);
-                    }
-                }
-                Err(err_response) => {
-                    error!("pnl_plant: error response from server: {:?}", err_response);
-
-                    if err_response.is_update {
-                        let _ = self.subscription_sender.send(err_response);
-                    } else {
-                        self.request_handler.handle_response(err_response);
-                    }
-                }
-            },
-            Err(Error::ConnectionClosed) => {
-                error!("pnl_plant: connection closed");
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    "WebSocket connection closed",
-                );
-                stop = true;
-            }
-            Err(Error::AlreadyClosed) => {
-                error!("pnl_plant: connection already closed");
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    "WebSocket connection already closed",
-                );
-                stop = true;
-            }
-            Err(Error::Io(ref io_err)) => {
-                error!("pnl_plant: I/O error: {}", io_err);
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    format!("WebSocket I/O error: {}", io_err),
-                );
-                stop = true;
-            }
-            Err(Error::Protocol(ProtocolError::ResetWithoutClosingHandshake)) => {
-                error!("pnl_plant: connection reset without closing handshake");
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    "WebSocket connection reset without closing handshake",
-                );
-                stop = true;
-            }
-            Err(Error::Protocol(ProtocolError::SendAfterClosing)) => {
-                error!("pnl_plant: attempted to send after closing");
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    "WebSocket attempted to send after closing",
-                );
-                stop = true;
-            }
-            Err(Error::Protocol(ProtocolError::ReceivedAfterClosing)) => {
-                error!("pnl_plant: received data after closing");
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    "WebSocket received data after closing",
-                );
-                stop = true;
-            }
-            _ => {
-                warn!("pnl_plant: Unhandled message: {:?}", message);
-            }
-        }
-
-        stop
     }
 
     async fn handle_command(&mut self, command: PnlPlantCommand) {
         match command {
             PnlPlantCommand::Close => {
-                self.close_requested = true;
-                self.send_close_best_effort().await;
+                self.core.handle_close().await;
             }
             PnlPlantCommand::ListSystemInfo { response_sender } => {
-                let (list_system_info_buf, id) =
-                    self.rithmic_sender_api.request_rithmic_system_info();
-
-                self.request_handler.register_request(RithmicRequest {
-                    request_id: id.clone(),
-                    responder: response_sender,
-                });
-
-                self.send_or_fail(Message::Binary(list_system_info_buf.into()), &id)
-                    .await;
+                self.core.handle_list_system_info(response_sender).await;
             }
             PnlPlantCommand::Login {
                 config,
                 response_sender,
             } => {
-                let (login_buf, id) = self.rithmic_sender_api.request_login(
-                    &self.config.system_name,
-                    SysInfraType::PnlPlant,
-                    &self.config.user,
-                    &self.config.password,
-                    &config,
-                );
-
-                info!("pnl_plant: sending login request {}", id);
-
-                self.request_handler.register_request(RithmicRequest {
-                    request_id: id.clone(),
-                    responder: response_sender,
-                });
-
-                self.send_or_fail(Message::Binary(login_buf.into()), &id)
+                self.core
+                    .handle_login(config, SysInfraType::PnlPlant, response_sender)
                     .await;
             }
             PnlPlantCommand::SetLogin => {
-                self.logged_in = true;
+                self.core.handle_set_login();
             }
             PnlPlantCommand::Logout { response_sender } => {
-                let (logout_buf, id) = self.rithmic_sender_api.request_logout();
-
-                self.request_handler.register_request(RithmicRequest {
-                    request_id: id.clone(),
-                    responder: response_sender,
-                });
-
-                self.send_or_fail(Message::Binary(logout_buf.into()), &id)
-                    .await;
+                self.core.handle_logout(response_sender).await;
             }
             PnlPlantCommand::UpdateHeartbeat { seconds } => {
-                self.interval = get_heartbeat_interval(Some(seconds));
+                self.core.handle_update_heartbeat(seconds);
             }
             PnlPlantCommand::SubscribePnlUpdates {
                 account,
                 response_sender,
             } => {
-                let (subscribe_buf, id) = self.rithmic_sender_api.request_pnl_position_updates(
-                    request_pn_l_position_updates::Request::Subscribe,
-                    &account,
-                );
+                let (subscribe_buf, id) =
+                    self.core.rithmic_sender_api.request_pnl_position_updates(
+                        request_pn_l_position_updates::Request::Subscribe,
+                        &account,
+                    );
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(subscribe_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(subscribe_buf.into()), &id)
                     .await;
             }
             PnlPlantCommand::PnlPositionSnapshots {
@@ -658,32 +319,36 @@ impl PlantActor for PnlPlant {
                 response_sender,
             } => {
                 let (snapshot_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_pnl_position_snapshot(&account);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(snapshot_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(snapshot_buf.into()), &id)
                     .await;
             }
             PnlPlantCommand::UnsubscribePnlUpdates {
                 account,
                 response_sender,
             } => {
-                let (unsubscribe_buf, id) = self.rithmic_sender_api.request_pnl_position_updates(
-                    request_pn_l_position_updates::Request::Unsubscribe,
-                    &account,
-                );
+                let (unsubscribe_buf, id) =
+                    self.core.rithmic_sender_api.request_pnl_position_updates(
+                        request_pn_l_position_updates::Request::Unsubscribe,
+                        &account,
+                    );
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(unsubscribe_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(unsubscribe_buf.into()), &id)
                     .await;
             }
             PnlPlantCommand::Abort => {

--- a/src/plants/ticker_plant.rs
+++ b/src/plants/ticker_plant.rs
@@ -1,18 +1,12 @@
-use std::time::Duration;
-
 use tracing::{error, info, warn};
 
 use crate::{
     ConnectStrategy,
-    api::{
-        receiver_api::{RithmicReceiverApi, RithmicResponse},
-        rithmic_command_types::LoginConfig,
-        sender_api::RithmicSenderApi,
-    },
+    api::{receiver_api::RithmicResponse, rithmic_command_types::LoginConfig},
     config::RithmicConfig,
     error::RithmicError,
-    ping_manager::PingManager,
-    request_handler::{RithmicRequest, RithmicRequestHandler},
+    plants::core::{PlantCore, SelectResult},
+    request_handler::RithmicRequest,
     rti::{
         messages::RithmicMessage,
         request_depth_by_order_updates,
@@ -20,26 +14,16 @@ use crate::{
         request_market_data_update::{Request, UpdateBits},
         request_market_data_update_by_underlying, request_search_symbols,
     },
-    ws::{
-        HEARTBEAT_SECS, PING_TIMEOUT_SECS, PlantActor, SEND_TIMEOUT_SECS, WebSocketSendError,
-        connect_with_strategy, get_heartbeat_interval, get_ping_interval, send_with_timeout,
-    },
+    ws::{HEARTBEAT_SECS, PlantActor},
 };
 
-use futures_util::{
-    StreamExt,
-    stream::{SplitSink, SplitStream},
-};
+use tokio_tungstenite::tungstenite::Message;
 
-use tokio_tungstenite::{
-    MaybeTlsStream,
-    tungstenite::{Error, Message, error::ProtocolError},
-};
+use futures_util::StreamExt;
 
 use tokio::{
-    net::TcpStream,
     sync::{broadcast, mpsc, oneshot},
-    time::{Interval, sleep_until},
+    time::sleep_until,
 };
 
 pub(crate) enum TickerPlantCommand {
@@ -301,24 +285,8 @@ impl RithmicTickerPlant {
 
 #[derive(Debug)]
 struct TickerPlant {
-    config: RithmicConfig,
-    // Distinguishes an intentional local shutdown from an unexpected peer close.
-    close_requested: bool,
-    interval: Interval,
-    logged_in: bool,
-    ping_interval: Interval,
-    ping_manager: PingManager,
-    request_handler: RithmicRequestHandler,
+    core: PlantCore,
     request_receiver: mpsc::Receiver<TickerPlantCommand>,
-    rithmic_reader: SplitStream<tokio_tungstenite::WebSocketStream<MaybeTlsStream<TcpStream>>>,
-    rithmic_receiver_api: RithmicReceiverApi,
-    rithmic_sender: SplitSink<
-        tokio_tungstenite::WebSocketStream<MaybeTlsStream<TcpStream>>,
-        tokio_tungstenite::tungstenite::Message,
-    >,
-
-    rithmic_sender_api: RithmicSenderApi,
-    subscription_sender: broadcast::Sender<RithmicResponse>,
 }
 
 impl TickerPlant {
@@ -328,429 +296,110 @@ impl TickerPlant {
         config: &RithmicConfig,
         strategy: ConnectStrategy,
     ) -> Result<TickerPlant, RithmicError> {
-        let ws_stream = connect_with_strategy(&config.url, &config.beta_url, strategy)
-            .await
-            .map_err(|e| RithmicError::ConnectionFailed(e.to_string()))?;
-
-        let (rithmic_sender, rithmic_reader) = ws_stream.split();
-
-        let rithmic_sender_api = RithmicSenderApi::new(config);
-        let rithmic_receiver_api = RithmicReceiverApi {
-            source: "ticker_plant".to_string(),
-        };
-
-        let interval = get_heartbeat_interval(None);
-        let ping_interval = get_ping_interval(None);
-        let ping_manager = PingManager::new(PING_TIMEOUT_SECS);
-
+        let core = PlantCore::new(subscription_sender, config, strategy, "ticker_plant").await?;
         Ok(TickerPlant {
-            config: config.clone(),
-            close_requested: false,
-            interval,
-            ping_interval,
-            logged_in: false,
-            ping_manager,
-            request_handler: RithmicRequestHandler::new(),
+            core,
             request_receiver,
-            rithmic_reader,
-            rithmic_receiver_api,
-            rithmic_sender_api,
-            rithmic_sender,
-            subscription_sender,
         })
-    }
-}
-
-impl TickerPlant {
-    fn emit_connection_health_event(
-        &self,
-        request_id: &str,
-        message: RithmicMessage,
-        error_message: impl Into<String>,
-    ) {
-        let error_response = RithmicResponse {
-            request_id: request_id.to_string(),
-            message,
-            is_update: true,
-            has_more: false,
-            multi_response: false,
-            error: Some(error_message.into()),
-            source: self.rithmic_receiver_api.source.clone(),
-        };
-
-        let _ = self.subscription_sender.send(error_response);
-    }
-
-    fn fail_connection_and_drain(
-        &mut self,
-        request_id: &str,
-        message: RithmicMessage,
-        error_message: impl Into<String>,
-    ) {
-        self.emit_connection_health_event(request_id, message, error_message);
-        self.request_handler.drain_and_drop();
-    }
-
-    async fn send_or_fail(&mut self, msg: Message, request_id: &str) {
-        match send_with_timeout(
-            &mut self.rithmic_sender,
-            msg,
-            Duration::from_secs(SEND_TIMEOUT_SECS),
-        )
-        .await
-        {
-            Ok(()) => {}
-            Err(WebSocketSendError::Transport(error)) => {
-                error!(
-                    "ticker_plant: WebSocket send failed for request {}: {}",
-                    request_id, error
-                );
-                self.request_handler
-                    .fail_request(request_id, RithmicError::SendFailed);
-            }
-            Err(WebSocketSendError::Timeout) => {
-                error!(
-                    "ticker_plant: WebSocket send timed out for request {}",
-                    request_id
-                );
-                self.request_handler
-                    .fail_request(request_id, RithmicError::SendFailed);
-            }
-        }
-    }
-
-    async fn send_ping(&mut self) -> bool {
-        self.ping_manager.sent();
-
-        match send_with_timeout(
-            &mut self.rithmic_sender,
-            Message::Ping(vec![].into()),
-            Duration::from_secs(SEND_TIMEOUT_SECS),
-        )
-        .await
-        {
-            Ok(()) => false,
-            Err(WebSocketSendError::Transport(error)) => {
-                error!("ticker_plant: WebSocket ping send failed: {}", error);
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    format!("WebSocket ping send failed: {error}"),
-                );
-                true
-            }
-            Err(WebSocketSendError::Timeout) => {
-                error!("ticker_plant: WebSocket ping send timed out");
-                self.fail_connection_and_drain(
-                    "websocket_ping_timeout",
-                    RithmicMessage::HeartbeatTimeout,
-                    "WebSocket ping send timed out - connection dead",
-                );
-                true
-            }
-        }
-    }
-
-    async fn send_heartbeat(&mut self) -> bool {
-        let (heartbeat_buf, _id) = self.rithmic_sender_api.request_heartbeat();
-
-        match send_with_timeout(
-            &mut self.rithmic_sender,
-            Message::Binary(heartbeat_buf.into()),
-            Duration::from_secs(SEND_TIMEOUT_SECS),
-        )
-        .await
-        {
-            Ok(()) => false,
-            Err(WebSocketSendError::Transport(error)) => {
-                error!("ticker_plant: heartbeat send failed: {}", error);
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    format!("Heartbeat send failed: {error}"),
-                );
-                true
-            }
-            Err(WebSocketSendError::Timeout) => {
-                error!("ticker_plant: heartbeat send timed out");
-                self.fail_connection_and_drain(
-                    "heartbeat_send_timeout",
-                    RithmicMessage::HeartbeatTimeout,
-                    "Heartbeat send timed out - connection dead",
-                );
-                true
-            }
-        }
-    }
-
-    async fn send_close_best_effort(&mut self) {
-        match send_with_timeout(
-            &mut self.rithmic_sender,
-            Message::Close(None),
-            Duration::from_secs(SEND_TIMEOUT_SECS),
-        )
-        .await
-        {
-            Ok(()) => {}
-            Err(WebSocketSendError::Transport(error)) => {
-                warn!("ticker_plant: close send failed: {}", error);
-            }
-            Err(WebSocketSendError::Timeout) => {
-                warn!("ticker_plant: close send timed out");
-            }
-        }
     }
 }
 
 impl PlantActor for TickerPlant {
     type Command = TickerPlantCommand;
 
-    /// Execute the ticker plant in its own thread
-    /// We will listen for messages from request_receiver and forward them to Rithmic
-    /// while also listening for messages from Rithmic and forwarding them to subscription_sender
-    /// or request handler
+    /// Execute the ticker plant actor loop.
     async fn run(&mut self) {
         loop {
-            tokio::select! {
-                _ = self.interval.tick() => {
-                    if self.logged_in && !self.close_requested && self.send_heartbeat().await {
-                        break;
-                    }
-                }
-                _ = self.ping_interval.tick() => {
-                    if !self.close_requested && self.send_ping().await {
-                        break;
-                    }
-                }
-                _ = async {
-                    if let Some(timeout_at) = self.ping_manager.next_timeout_at() {
-                        sleep_until(timeout_at).await
-                    } else {
-                        std::future::pending::<()>().await
-                    }
-                } => {
-                    if self.ping_manager.check_timeout() {
-                        if self.close_requested {
-                            self.request_handler.drain_and_drop();
+            let result = {
+                let interval = &mut self.core.interval;
+                let ping_interval = &mut self.core.ping_interval;
+                let ping_manager = &mut self.core.ping_manager;
+                let reader = &mut self.core.rithmic_reader;
+                let receiver = &mut self.request_receiver;
+                tokio::select! {
+                    _ = interval.tick()      => SelectResult::HeartbeatFired,
+                    _ = ping_interval.tick() => SelectResult::PingFired,
+                    _ = async {
+                        if let Some(t) = ping_manager.next_timeout_at() {
+                            sleep_until(t).await
                         } else {
-                            error!("WebSocket ping timed out - connection appears dead");
-                            self.fail_connection_and_drain(
+                            std::future::pending::<()>().await
+                        }
+                    } => SelectResult::PingTimeout,
+                    Some(cmd) = receiver.recv() => SelectResult::Command(cmd),
+                    msg = reader.next() => match msg {
+                        Some(m) => SelectResult::RithmicMessage(m),
+                        None => SelectResult::StreamClosed,
+                    },
+                }
+            };
+            let stop = match result {
+                SelectResult::HeartbeatFired => self.core.send_heartbeat().await,
+                SelectResult::PingFired => self.core.send_ping().await,
+                SelectResult::PingTimeout => {
+                    if self.core.ping_manager.check_timeout() {
+                        if self.core.close_requested {
+                            warn!("ticker_plant: ping timed out while waiting for server close echo — terminating");
+                            self.core.request_handler.drain_and_drop();
+                        } else {
+                            self.core.fail_connection_and_drain(
                                 "websocket_ping_timeout",
                                 RithmicMessage::HeartbeatTimeout,
                                 "WebSocket ping timeout - connection dead",
                             );
                         }
-                        break;
+                        true
+                    } else {
+                        false
                     }
                 }
-                Some(message) = self.request_receiver.recv() => {
-                    if matches!(message, TickerPlantCommand::Abort) {
+                SelectResult::Command(cmd) => {
+                    if matches!(cmd, TickerPlantCommand::Abort) {
                         info!("ticker_plant: abort requested, shutting down immediately");
-                        self.fail_connection_and_drain(
+                        self.core.fail_connection_and_drain(
                             "",
                             RithmicMessage::ConnectionError,
                             "Plant aborted",
                         );
-                        break;
-                    }
-                    self.handle_command(message).await;
-                }
-                Some(message) = self.rithmic_reader.next() => {
-                    let stop = self.handle_rithmic_message(message).await;
-
-                    if stop {
-                        break;
+                        true
+                    } else {
+                        self.handle_command(cmd).await;
+                        false
                     }
                 }
-                else => { break }
+                SelectResult::RithmicMessage(msg) => self.core.handle_rithmic_message(msg).await,
+                SelectResult::StreamClosed => self.core.handle_stream_closed(),
+            };
+            if stop {
+                break;
             }
         }
-    }
-
-    async fn handle_rithmic_message(&mut self, message: Result<Message, Error>) -> bool {
-        let mut stop = false;
-
-        match message {
-            Ok(Message::Close(frame)) => {
-                info!("ticker_plant received close frame: {:?}", frame);
-                if self.close_requested {
-                    self.request_handler.drain_and_drop();
-                } else {
-                    self.fail_connection_and_drain(
-                        "",
-                        RithmicMessage::ConnectionError,
-                        format!("WebSocket close frame received: {:?}", frame),
-                    );
-                }
-                stop = true;
-            }
-            Ok(Message::Pong(_)) => {
-                self.ping_manager.received();
-            }
-            Ok(Message::Binary(data)) => match self.rithmic_receiver_api.buf_to_message(data) {
-                Ok(response) => {
-                    // Handle heartbeat responses: only forward if they contain an error
-                    if matches!(response.message, RithmicMessage::ResponseHeartbeat(_)) {
-                        if let Some(error) = response.error {
-                            let error_response = RithmicResponse {
-                                request_id: response.request_id,
-                                message: RithmicMessage::HeartbeatTimeout,
-                                is_update: true,
-                                has_more: false,
-                                multi_response: false,
-                                error: Some(error),
-                                source: self.rithmic_receiver_api.source.clone(),
-                            };
-
-                            let _ = self.subscription_sender.send(error_response);
-                        }
-
-                        // Always drop heartbeat responses (successful or error)
-                        return false;
-                    }
-
-                    if response.is_update {
-                        match self.subscription_sender.send(response) {
-                            Ok(_) => {}
-                            Err(e) => {
-                                warn!("ticker_plant: no active subscribers: {:?}", e);
-                            }
-                        }
-                    } else {
-                        self.request_handler.handle_response(response);
-                    }
-                }
-                Err(err_response) => {
-                    error!(
-                        "ticker_plant: error response from server: {:?}",
-                        err_response
-                    );
-
-                    if err_response.is_update {
-                        let _ = self.subscription_sender.send(err_response);
-                    } else {
-                        self.request_handler.handle_response(err_response);
-                    }
-                }
-            },
-            Err(Error::ConnectionClosed) => {
-                error!("ticker_plant: connection closed");
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    "WebSocket connection closed",
-                );
-                stop = true;
-            }
-            Err(Error::AlreadyClosed) => {
-                error!("ticker_plant: connection already closed");
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    "WebSocket connection already closed",
-                );
-                stop = true;
-            }
-            Err(Error::Io(ref io_err)) => {
-                error!("ticker_plant: I/O error: {}", io_err);
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    format!("WebSocket I/O error: {}", io_err),
-                );
-                stop = true;
-            }
-            Err(Error::Protocol(ProtocolError::ResetWithoutClosingHandshake)) => {
-                error!("ticker_plant: connection reset without closing handshake");
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    "WebSocket connection reset without closing handshake",
-                );
-                stop = true;
-            }
-            Err(Error::Protocol(ProtocolError::SendAfterClosing)) => {
-                error!("ticker_plant: attempted to send after closing");
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    "WebSocket attempted to send after closing",
-                );
-                stop = true;
-            }
-            Err(Error::Protocol(ProtocolError::ReceivedAfterClosing)) => {
-                error!("ticker_plant: received data after closing");
-                self.fail_connection_and_drain(
-                    "",
-                    RithmicMessage::ConnectionError,
-                    "WebSocket received data after closing",
-                );
-                stop = true;
-            }
-            _ => {
-                warn!("ticker_plant received unknown message {:?}", message);
-            }
-        }
-
-        stop
     }
 
     async fn handle_command(&mut self, command: TickerPlantCommand) {
         match command {
             TickerPlantCommand::Close => {
-                self.close_requested = true;
-                self.send_close_best_effort().await;
+                self.core.handle_close().await;
             }
             TickerPlantCommand::ListSystemInfo { response_sender } => {
-                let (list_system_info_buf, id) =
-                    self.rithmic_sender_api.request_rithmic_system_info();
-
-                self.request_handler.register_request(RithmicRequest {
-                    request_id: id.clone(),
-                    responder: response_sender,
-                });
-
-                self.send_or_fail(Message::Binary(list_system_info_buf.into()), &id)
-                    .await;
+                self.core.handle_list_system_info(response_sender).await;
             }
             TickerPlantCommand::Login {
                 config,
                 response_sender,
             } => {
-                let (login_buf, id) = self.rithmic_sender_api.request_login(
-                    &self.config.system_name,
-                    SysInfraType::TickerPlant,
-                    &self.config.user,
-                    &self.config.password,
-                    &config,
-                );
-
-                info!("ticker_plant: sending login request {}", id);
-
-                self.request_handler.register_request(RithmicRequest {
-                    request_id: id.clone(),
-                    responder: response_sender,
-                });
-
-                self.send_or_fail(Message::Binary(login_buf.into()), &id)
+                self.core
+                    .handle_login(config, SysInfraType::TickerPlant, response_sender)
                     .await;
             }
             TickerPlantCommand::SetLogin => {
-                self.logged_in = true;
+                self.core.handle_set_login();
             }
             TickerPlantCommand::Logout { response_sender } => {
-                let (logout_buf, id) = self.rithmic_sender_api.request_logout();
-
-                self.request_handler.register_request(RithmicRequest {
-                    request_id: id.clone(),
-                    responder: response_sender,
-                });
-
-                self.send_or_fail(Message::Binary(logout_buf.into()), &id)
-                    .await;
+                self.core.handle_logout(response_sender).await;
             }
             TickerPlantCommand::UpdateHeartbeat { seconds } => {
-                self.interval = get_heartbeat_interval(Some(seconds));
+                self.core.handle_update_heartbeat(seconds);
             }
             TickerPlantCommand::Subscribe {
                 symbol,
@@ -759,19 +408,20 @@ impl PlantActor for TickerPlant {
                 request_type,
                 response_sender,
             } => {
-                let (sub_buf, id) = self.rithmic_sender_api.request_market_data_update(
+                let (sub_buf, id) = self.core.rithmic_sender_api.request_market_data_update(
                     &symbol,
                     &exchange,
                     fields,
                     request_type,
                 );
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(sub_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(sub_buf.into()), &id)
                     .await;
             }
             TickerPlantCommand::SubscribeOrderBook {
@@ -780,18 +430,19 @@ impl PlantActor for TickerPlant {
                 request_type,
                 response_sender,
             } => {
-                let (sub_buf, id) = self.rithmic_sender_api.request_depth_by_order_update(
+                let (sub_buf, id) = self.core.rithmic_sender_api.request_depth_by_order_update(
                     &symbol,
                     &exchange,
                     request_type,
                 );
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(sub_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(sub_buf.into()), &id)
                     .await;
             }
             TickerPlantCommand::RequestDepthByOrderSnapshot {
@@ -800,15 +451,17 @@ impl PlantActor for TickerPlant {
                 response_sender,
             } => {
                 let (snapshot_buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_depth_by_order_snapshot(&symbol, &exchange);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(snapshot_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(snapshot_buf.into()), &id)
                     .await;
             }
             TickerPlantCommand::SearchSymbols {
@@ -819,7 +472,7 @@ impl PlantActor for TickerPlant {
                 pattern,
                 response_sender,
             } => {
-                let (search_buf, id) = self.rithmic_sender_api.request_search_symbols(
+                let (search_buf, id) = self.core.rithmic_sender_api.request_search_symbols(
                     &search_text,
                     exchange.as_deref(),
                     product_code.as_deref(),
@@ -827,26 +480,28 @@ impl PlantActor for TickerPlant {
                     pattern,
                 );
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(search_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(search_buf.into()), &id)
                     .await;
             }
             TickerPlantCommand::ListExchanges {
                 user,
                 response_sender,
             } => {
-                let (list_buf, id) = self.rithmic_sender_api.request_list_exchanges(&user);
+                let (list_buf, id) = self.core.rithmic_sender_api.request_list_exchanges(&user);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(list_buf.into()), &id)
+                self.core
+                    .send_or_fail(Message::Binary(list_buf.into()), &id)
                     .await;
             }
             TickerPlantCommand::GetInstrumentByUnderlying {
@@ -856,6 +511,7 @@ impl PlantActor for TickerPlant {
                 response_sender,
             } => {
                 let (buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_get_instrument_by_underlying(
                         &underlying_symbol,
@@ -863,12 +519,14 @@ impl PlantActor for TickerPlant {
                         expiration_date.as_deref(),
                     );
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(buf.into()), &id).await;
+                self.core
+                    .send_or_fail(Message::Binary(buf.into()), &id)
+                    .await;
             }
             TickerPlantCommand::SubscribeByUnderlying {
                 underlying_symbol,
@@ -879,6 +537,7 @@ impl PlantActor for TickerPlant {
                 response_sender,
             } => {
                 let (buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_market_data_update_by_underlying(
                         &underlying_symbol,
@@ -888,27 +547,32 @@ impl PlantActor for TickerPlant {
                         request_type,
                     );
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(buf.into()), &id).await;
+                self.core
+                    .send_or_fail(Message::Binary(buf.into()), &id)
+                    .await;
             }
             TickerPlantCommand::GetTickSizeTypeTable {
                 tick_size_type,
                 response_sender,
             } => {
                 let (buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_give_tick_size_type_table(&tick_size_type);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(buf.into()), &id).await;
+                self.core
+                    .send_or_fail(Message::Binary(buf.into()), &id)
+                    .await;
             }
             TickerPlantCommand::GetProductCodes {
                 exchange,
@@ -916,15 +580,18 @@ impl PlantActor for TickerPlant {
                 response_sender,
             } => {
                 let (buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_product_codes(exchange.as_deref(), give_toi_products_only);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(buf.into()), &id).await;
+                self.core
+                    .send_or_fail(Message::Binary(buf.into()), &id)
+                    .await;
             }
             TickerPlantCommand::GetVolumeAtPrice {
                 symbol,
@@ -932,15 +599,18 @@ impl PlantActor for TickerPlant {
                 response_sender,
             } => {
                 let (buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_get_volume_at_price(&symbol, &exchange);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(buf.into()), &id).await;
+                self.core
+                    .send_or_fail(Message::Binary(buf.into()), &id)
+                    .await;
             }
             TickerPlantCommand::GetAuxilliaryReferenceData {
                 symbol,
@@ -948,15 +618,18 @@ impl PlantActor for TickerPlant {
                 response_sender,
             } => {
                 let (buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_auxilliary_reference_data(&symbol, &exchange);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(buf.into()), &id).await;
+                self.core
+                    .send_or_fail(Message::Binary(buf.into()), &id)
+                    .await;
             }
             TickerPlantCommand::GetReferenceData {
                 symbol,
@@ -964,15 +637,18 @@ impl PlantActor for TickerPlant {
                 response_sender,
             } => {
                 let (buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_reference_data(&symbol, &exchange);
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(buf.into()), &id).await;
+                self.core
+                    .send_or_fail(Message::Binary(buf.into()), &id)
+                    .await;
             }
             TickerPlantCommand::GetFrontMonthContract {
                 symbol,
@@ -980,33 +656,38 @@ impl PlantActor for TickerPlant {
                 need_updates,
                 response_sender,
             } => {
-                let (buf, id) = self.rithmic_sender_api.request_front_month_contract(
+                let (buf, id) = self.core.rithmic_sender_api.request_front_month_contract(
                     &symbol,
                     &exchange,
                     need_updates,
                 );
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(buf.into()), &id).await;
+                self.core
+                    .send_or_fail(Message::Binary(buf.into()), &id)
+                    .await;
             }
             TickerPlantCommand::GetSystemGatewayInfo {
                 system_name,
                 response_sender,
             } => {
                 let (buf, id) = self
+                    .core
                     .rithmic_sender_api
                     .request_rithmic_system_gateway_info(system_name.as_deref());
 
-                self.request_handler.register_request(RithmicRequest {
+                self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
                     responder: response_sender,
                 });
 
-                self.send_or_fail(Message::Binary(buf.into()), &id).await;
+                self.core
+                    .send_or_fail(Message::Binary(buf.into()), &id)
+                    .await;
             }
             TickerPlantCommand::Abort => {
                 unreachable!("Abort is handled in run() before handle_command");

--- a/src/plants/ticker_plant.rs
+++ b/src/plants/ticker_plant.rs
@@ -339,7 +339,9 @@ impl PlantActor for TickerPlant {
                 SelectResult::PingTimeout => {
                     if self.core.ping_manager.check_timeout() {
                         if self.core.close_requested {
-                            warn!("ticker_plant: ping timed out while waiting for server close echo — terminating");
+                            warn!(
+                                "ticker_plant: ping timed out while waiting for server close echo — terminating"
+                            );
                             self.core.request_handler.drain_and_drop();
                         } else {
                             self.core.fail_connection_and_drain(

--- a/src/request_handler.rs
+++ b/src/request_handler.rs
@@ -47,8 +47,12 @@ impl RithmicRequestHandler {
 
     /// Remove a pending request and send an error through its oneshot channel.
     ///
+    /// Also removes any partially-accumulated multi-part responses for the same
+    /// request ID so that `response_vec_map` does not retain stale data.
+    ///
     /// Returns `true` if the request was found and the error was sent.
     pub fn fail_request(&mut self, request_id: &str, error: RithmicError) -> bool {
+        self.response_vec_map.remove(request_id);
         if let Some(responder) = self.handle_map.remove(request_id) {
             let _ = responder.send(Err(error));
             true

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -51,7 +51,6 @@ pub(crate) trait PlantActor {
 
     async fn run(&mut self);
     async fn handle_command(&mut self, command: Self::Command);
-    async fn handle_rithmic_message(&mut self, message: Result<Message, Error>) -> bool;
 }
 
 /// Error returned when a bounded WebSocket send does not complete.


### PR DESCRIPTION
## Summary

Each of the four plants (history/order/pnl/ticker) had its own near-identical copy of the connect/login/heartbeat/ping/send loop. This extracts that into a single `PlantCore<S = WsSink>` in `src/plants/core.rs`. The plant files shrink by roughly half and now mostly contain plant-specific command handling.

The sink is generic so tests can drive the core with a `MockMessageSink` instead of a live WebSocket. While doing that I also dropped the `connection_health_emitted` latch: `send_or_fail` now only fails the in-flight request, and a dead sink gets surfaced by the reader task or the next ping/heartbeat, which is what we actually want.

No public API changes, no behavior changes intended.

## Tests

Added coverage for the pieces that used to be hard to reach:

- `plants/core.rs`: `fail_connection_and_drain`, `send_or_fail`, `send_ping`/`send_heartbeat`, `handle_rithmic_message`, `handle_stream_closed`
- `ping_manager.rs`: the sent/received/timeout/clear cycles of the state machine
- `receiver_api.rs`: `get_error` / `has_multiple` rp_code parsing

`tokio` gets the `test-util` feature so tests can use `time::pause`/`advance`.

## Verified

- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` and `cargo test -- --ignored`
