### PR TITLE
Harden rp_code handling without disconnecting actors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Create a `RithmicAccount` with `RithmicAccount::from_env(env)` or build one directly
   - For multi-account workflows, create one `RithmicAccount` per account and call `get_handle(&account)` for each
 - **`subscription_receiver` on order and PnL handles is now `SubscriptionFilter`** instead of `broadcast::Receiver<RithmicResponse>`
+- **Request-path `rp_code` failures now surface as `RithmicError::RequestRejected(RithmicRequestError)`**
+  instead of `RithmicError::ServerError(String)`, preserving the raw server code
+  plus message
 
 ### Added
 
@@ -25,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fetches historical N-tick bars (e.g., 5-tick, 10-tick) for a symbol
   - `bar_length` controls the number of ticks aggregated into each bar
   - Returns `RithmicError::InvalidArgument` when `bar_length` is 0
+- **`RithmicRequestError`** — structured non-transport request rejection carrying
+  the full raw `rp_code` payload plus derived first/second elements
+- **`RithmicResponse` helpers** for protocol-aware request handling:
+  - `rp_code()`, `rp_code_text()`, `rp_code_raw()`
+  - `request_rejection()` / `request_error()`
+- **`RithmicError::ProtocolError(String)`** — non-transport response failure without an `rp_code` rejection
 - **`RithmicError::InvalidArgument(String)`** variant for rejecting invalid caller-supplied arguments before a request is sent
 - **`RithmicAdvancedBracketOrder`** — full raw bracket order request exposing all venue-native fields
   - Supports triggered entry, break-even, trailing-stop, timed release/cancel, and if-touched entry conditions
@@ -48,6 +57,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`RithmicError::SendFailed`** now also covers send timeouts — all plant WebSocket sends are bounded to 10 seconds; a hung sink surfaces as `SendFailed` rather than blocking the actor indefinitely
 - **`load_ticks`** now delegates to `load_tick_bars` with `bar_length = 1` — no behavioral change for existing callers
 - **`request_tick_bar_replay`** on `RithmicSenderApi` now accepts a `bar_type_specifier` parameter instead of hard-coding `"1"`
+- **Request-level non-zero `rp_code` responses** now stay on the normal response
+  path with `response.error` populated instead of being treated as receiver
+  decode failures
+- **Non-zero request-level `rp_code` failures** now surface uniformly as
+  `RithmicError::RequestRejected(RithmicRequestError)` without implying a
+  disconnect
+- **Generic non-transport response failures without `rp_code`** now surface as
+  `RithmicError::ProtocolError(String)` instead of being conflated with request rejections
+- **Heartbeat response `rp_code` failures** now stay on the connection-health
+  path and surface as `HeartbeatTimeout`
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -175,11 +175,37 @@ match handle.subscribe("ESM6", "CME").await {
         handle.abort();
         // reconnect — see examples/reconnect.rs
     }
-    Err(RithmicError::InvalidArgument(msg)) => eprintln!("Bad argument: {}", msg),
-    Err(RithmicError::ServerError(msg)) => eprintln!("Server rejected: {}", msg),
+    Err(RithmicError::RequestRejected(err)) => {
+        eprintln!(
+            "Request rejected {}: {}",
+            err.code.as_deref().unwrap_or("?"),
+            err.message
+        );
+    }
+    Err(RithmicError::ProtocolError(msg)) => eprintln!("Protocol error: {}", msg),
+    Err(RithmicError::InvalidArgument(msg)) => eprintln!("Bad local input: {}", msg),
     Err(e) => eprintln!("{}", e),
 }
 ```
+
+`RithmicError::RequestRejected` is the generic non-transport rejection returned
+for explicit non-zero `rp_code` responses and preserves the full raw `rp_code`
+payload plus derived first/second elements. `RithmicError::ProtocolError`
+covers non-transport response failures that were not carried in `rp_code`.
+`RithmicError::InvalidArgument` is reserved for local validation before a
+request is sent. The one proven benign non-zero case is
+`rp_code = ["7", "no data"]`, which is treated as an empty successful result.
+Reconnect only for transport failures or subscription updates where
+[`RithmicResponse::is_connection_issue()`](src/api/receiver_api.rs) returns `true`.
+
+For methods that return [`RithmicResponse`](src/api/receiver_api.rs) directly, inspect
+the raw server outcome with:
+
+- `response.rp_code()`
+- `response.rp_code_text()`
+- `response.rp_code_raw()`
+- `response.request_rejection()`
+- `response.request_error()`
 
 `RithmicError` implements `std::error::Error`, so `?` works in functions returning `Box<dyn Error>`.
 

--- a/examples/reconnect.rs
+++ b/examples/reconnect.rs
@@ -46,8 +46,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 RithmicError::ConnectionClosed | RithmicError::SendFailed => {
                     error!("Login failed (connection issue): {}", e);
                 }
-                RithmicError::ServerError(msg) => {
-                    error!("Login rejected by server: {}", msg);
+                RithmicError::RequestRejected(err) => {
+                    error!(
+                        "Login rejected by server [{}]: {}",
+                        err.code.as_deref().unwrap_or("?"),
+                        err.message
+                    );
                 }
                 _ => {
                     error!("Login failed: {}", e);

--- a/src/api/receiver_api.rs
+++ b/src/api/receiver_api.rs
@@ -30,6 +30,7 @@ use crate::rti::{
     TradeRoute, TradeStatistics, UpdateEasyToBorrowList, UserAccountUpdate,
     messages::RithmicMessage,
 };
+use crate::{RithmicError, RithmicRequestError};
 
 /// Response from a Rithmic plant, either from a request or a subscription update.
 ///
@@ -54,6 +55,12 @@ use crate::rti::{
 /// When Rithmic rejects a request or encounters an error, the response will have:
 /// - `error: Some("error description from Rithmic")`
 /// - `message`: Usually [`RithmicMessage::Reject`]
+///
+/// These are request/response outcomes, not transport failures. A populated
+/// `error` field by itself does not mean the plant disconnected or needs to
+/// reconnect. Use [`RithmicResponse::request_rejection`] together with
+/// [`RithmicResponse::rp_code`] / [`RithmicResponse::rp_code_text`] to inspect
+/// the raw upstream outcome without treating it as a transport failure.
 ///
 /// ### 2. Connection Errors
 /// When a plant's WebSocket connection fails, you'll receive:
@@ -113,7 +120,7 @@ impl RithmicResponse {
     /// Returns true if this response represents an error condition.
     ///
     /// This checks both:
-    /// - The `error` field being set (Rithmic protocol errors)
+    /// - The `error` field being set (Rithmic protocol or business-level errors)
     /// - Connection issues (WebSocket errors, heartbeat timeouts, forced logout)
     ///
     /// # Example
@@ -126,6 +133,61 @@ impl RithmicResponse {
         self.error.is_some() || self.is_connection_issue()
     }
 
+    /// Returns the raw `rp_code` payload for responses that carry it.
+    ///
+    /// Most request/response templates expose `rp_code`; update-only messages do not.
+    pub fn rp_code_raw(&self) -> Option<&[String]> {
+        response_rp_code_info(&self.message).map(|(_, rp_code)| rp_code)
+    }
+
+    /// Returns the first `rp_code` element, if present.
+    pub fn rp_code(&self) -> Option<&str> {
+        self.rp_code_raw()
+            .and_then(|rp_code| rp_code.first().map(String::as_str))
+    }
+
+    /// Returns the second `rp_code` element, if present.
+    pub fn rp_code_text(&self) -> Option<&str> {
+        self.rp_code_raw()
+            .and_then(|rp_code| rp_code.get(1).map(String::as_str))
+    }
+
+    /// Returns the typed non-transport `rp_code` rejection attached to this response.
+    ///
+    /// This only reflects rejections carried explicitly by `rp_code` and
+    /// preserves the full raw payload for downstream handling. It does not treat
+    /// transport-health events or generic non-`rp_code` errors as request
+    /// rejections.
+    pub fn request_rejection(&self) -> Option<RithmicRequestError> {
+        if self.is_connection_issue() {
+            return None;
+        }
+
+        match self.rp_code_raw().map(classify_rp_code) {
+            Some(RpCodeClassification::Success | RpCodeClassification::KnownBenignEmpty) => None,
+            Some(RpCodeClassification::RequestRejected(err)) => Some(err),
+            None => None,
+        }
+    }
+
+    /// Maps non-transport response failures into typed [`RithmicError`] values.
+    ///
+    /// `rp_code` rejections surface as [`RithmicError::RequestRejected`].
+    /// Generic non-transport response failures without `rp_code` surface as
+    /// [`RithmicError::ProtocolError`]. This does not treat transport-health
+    /// events as request errors.
+    pub fn request_error(&self) -> Option<RithmicError> {
+        if let Some(err) = self.request_rejection() {
+            return Some(RithmicError::RequestRejected(err));
+        }
+
+        if self.is_connection_issue() {
+            return None;
+        }
+
+        self.error.clone().map(RithmicError::ProtocolError)
+    }
+
     /// Returns true if this response indicates a connection health issue.
     ///
     /// Connection issues include:
@@ -133,7 +195,8 @@ impl RithmicResponse {
     /// - `HeartbeatTimeout`: Connection appears dead
     /// - `ForcedLogout`: Server forcibly logged out the client
     ///
-    /// These conditions typically require reconnection logic.
+    /// These conditions typically require reconnection logic. Generic request
+    /// failures encoded in `rp_code` do not.
     ///
     /// # Example
     /// ```ignore
@@ -1623,44 +1686,149 @@ impl RithmicReceiverApi {
             }
         };
 
-        // Handle errors
-        if let Some(error) = check_message_error(&response) {
-            error!("receiver_api: error {:#?} {:?}", response, error);
-
-            return Err(response);
-        }
-
         Ok(response)
     }
 }
 
 fn has_multiple(rq_handler_rp_code: &[String]) -> bool {
-    !rq_handler_rp_code.is_empty() && rq_handler_rp_code[0] == "0"
+    // Per the Rithmic guide, the presence of `rq_handler_rp_code` means more
+    // response messages follow. `rp_code` marks the terminal frame.
+    !rq_handler_rp_code.is_empty()
 }
 
-fn get_error(rp_code: &[String]) -> Option<String> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RpCodeClassification {
+    Success,
+    KnownBenignEmpty,
+    RequestRejected(RithmicRequestError),
+}
+
+impl RpCodeClassification {
+    fn error_message(&self) -> Option<String> {
+        match self {
+            Self::Success | Self::KnownBenignEmpty => None,
+            Self::RequestRejected(err) => Some(err.message.clone()),
+        }
+    }
+}
+
+macro_rules! rp_code_response_variants {
+    ($macro:ident) => {
+        $macro! {
+            Reject,
+            ResponseAcceptAgreement,
+            ResponseAccountList,
+            ResponseAccountRmsInfo,
+            ResponseAccountRmsUpdates,
+            ResponseAuxilliaryReferenceData,
+            ResponseBracketOrder,
+            ResponseCancelAllOrders,
+            ResponseCancelOrder,
+            ResponseDepthByOrderSnapshot,
+            ResponseDepthByOrderUpdates,
+            ResponseEasyToBorrowList,
+            ResponseExitPosition,
+            ResponseFrontMonthContract,
+            ResponseGetInstrumentByUnderlying,
+            ResponseGetInstrumentByUnderlyingKeys,
+            ResponseGetVolumeAtPrice,
+            ResponseGiveTickSizeTypeTable,
+            ResponseHeartbeat,
+            ResponseLinkOrders,
+            ResponseListAcceptedAgreements,
+            ResponseListExchangePermissions,
+            ResponseListUnacceptedAgreements,
+            ResponseLogin,
+            ResponseLoginInfo,
+            ResponseLogout,
+            ResponseMarketDataUpdate,
+            ResponseMarketDataUpdateByUnderlying,
+            ResponseModifyOrder,
+            ResponseModifyOrderReferenceData,
+            ResponseNewOrder,
+            ResponseOcoOrder,
+            ResponseOrderSessionConfig,
+            ResponsePnLPositionSnapshot,
+            ResponsePnLPositionUpdates,
+            ResponseProductCodes,
+            ResponseProductRmsInfo,
+            ResponseReferenceData,
+            ResponseReplayExecutions,
+            ResponseResumeBars,
+            ResponseRithmicSystemGatewayInfo,
+            ResponseRithmicSystemInfo,
+            ResponseSearchSymbols,
+            ResponseSetRithmicMrktDataSelfCertStatus,
+            ResponseShowAgreement,
+            ResponseShowBracketStops,
+            ResponseShowBrackets,
+            ResponseShowOrderHistory,
+            ResponseShowOrderHistoryDates,
+            ResponseShowOrderHistoryDetail,
+            ResponseShowOrderHistorySummary,
+            ResponseShowOrders,
+            ResponseSubscribeForOrderUpdates,
+            ResponseSubscribeToBracketUpdates,
+            ResponseTickBarReplay,
+            ResponseTickBarUpdate,
+            ResponseTimeBarReplay,
+            ResponseTimeBarUpdate,
+            ResponseTradeRoutes,
+            ResponseUpdateStopBracketLevel,
+            ResponseUpdateTargetBracketLevel,
+            ResponseVolumeProfileMinuteBars,
+        }
+    };
+}
+
+macro_rules! define_response_rp_code_info {
+    ($($variant:ident),* $(,)?) => {
+        fn response_rp_code_info(message: &RithmicMessage) -> Option<(&'static str, &[String])> {
+            match message {
+                $(RithmicMessage::$variant(resp) => Some((stringify!($variant), resp.rp_code.as_slice())),)*
+                _ => None,
+            }
+        }
+    };
+}
+
+rp_code_response_variants!(define_response_rp_code_info);
+
+fn classify_rp_code(rp_code: &[String]) -> RpCodeClassification {
     if (rp_code.len() == 1 && rp_code[0] == "0") || rp_code.is_empty() {
-        return None;
+        return RpCodeClassification::Success;
     }
 
-    // Rithmic uses rp_code = ["7", "no data"] to signal "successful query, zero results"
-    // across all list/replay/search responses. Treat it as a normal empty outcome, not an error.
-    if let (Some(code), Some(msg)) = (rp_code.first(), rp_code.get(1)) {
-        if code == "7" && msg.eq_ignore_ascii_case("no data") {
-            return None;
+    if let Some(code) = rp_code.first() {
+        if let Some(message) = rp_code.get(1) {
+            // Rithmic uses `["7", "no data"]` across query/list/search-style
+            // responses to mean "successful request, zero rows returned".
+            if code == "7" && message.eq_ignore_ascii_case("no data") {
+                return RpCodeClassification::KnownBenignEmpty;
+            }
         }
     }
 
-    let msg = rp_code
+    let code = rp_code.first().cloned();
+    let message = rp_code
         .get(1)
         .cloned()
-        .unwrap_or_else(|| rp_code[0].clone());
+        .or_else(|| code.clone())
+        .unwrap_or_default();
 
-    Some(msg)
+    RpCodeClassification::RequestRejected(RithmicRequestError {
+        rp_code: rp_code.to_vec(),
+        code,
+        message,
+    })
 }
 
-fn check_message_error(message: &RithmicResponse) -> Option<String> {
-    message.error.as_ref().map(|e| e.to_string())
+fn rp_code_error(rp_code: &[String]) -> Option<String> {
+    classify_rp_code(rp_code).error_message()
+}
+
+fn get_error(rp_code: &[String]) -> Option<String> {
+    rp_code_error(rp_code)
 }
 
 fn decode_error(source: &str, e: prost::DecodeError, is_update: bool) -> RithmicResponse {
@@ -1891,59 +2059,158 @@ mod tests {
     }
 
     // =========================================================================
-    // get_error() / has_multiple() unit tests
+    // rp_code classification / has_multiple() unit tests
     // =========================================================================
 
     #[test]
+    fn response_rp_code_info_returns_variant_name_and_payload() {
+        let message = RithmicMessage::ResponseSearchSymbols(ResponseSearchSymbols {
+            rp_code: vec!["5".to_string(), "permission denied".to_string()],
+            ..ResponseSearchSymbols::default()
+        });
+
+        let (template_name, rp_code) =
+            super::response_rp_code_info(&message).expect("response should expose rp_code");
+
+        assert_eq!(template_name, "ResponseSearchSymbols");
+        assert_eq!(rp_code, &["5".to_string(), "permission denied".to_string()]);
+    }
+
+    #[test]
     fn get_error_returns_none_for_empty_rp_code() {
-        assert_eq!(super::get_error(&[]), None);
+        assert_eq!(super::classify_rp_code(&[]), RpCodeClassification::Success);
     }
 
     #[test]
-    fn get_error_returns_none_for_zero_rp_code() {
-        assert_eq!(super::get_error(&["0".to_string()]), None);
-    }
-
-    #[test]
-    fn get_error_returns_none_for_no_data_rp_code() {
-        // rp_code = ["7", "no data"] means "successful query, zero results" across all
-        // Rithmic list/replay/search responses — must not be treated as an error.
-        let rp_code = vec!["7".to_string(), "no data".to_string()];
-        assert_eq!(get_error(&rp_code), None);
-    }
-
-    #[test]
-    fn get_error_returns_none_for_no_data_case_insensitive() {
-        let rp_code = vec!["7".to_string(), "No Data".to_string()];
-        assert_eq!(get_error(&rp_code), None);
-    }
-
-    #[test]
-    fn get_error_returns_some_for_other_code_7_messages() {
-        // code "7" with a different message is still an error
-        let rp_code = vec!["7".to_string(), "permission denied".to_string()];
-        assert!(get_error(&rp_code).is_some());
-    }
-
-    #[test]
-    fn get_error_returns_some_for_code_7_with_error() {
+    fn classify_rp_code_returns_success_for_zero_rp_code() {
         assert_eq!(
-            super::get_error(&["7".to_string(), "permission denied".to_string()]),
-            Some("permission denied".to_string())
+            super::classify_rp_code(&["0".to_string()]),
+            RpCodeClassification::Success
         );
     }
 
     #[test]
-    fn get_error_returns_second_element_for_non_zero_non_7_code() {
+    fn classify_rp_code_returns_benign_empty_for_code_7() {
+        let rp_code = vec!["7".to_string(), "no data".to_string()];
         assert_eq!(
-            super::get_error(&["3".to_string(), "bad request".to_string()]),
+            classify_rp_code(&rp_code),
+            RpCodeClassification::KnownBenignEmpty
+        );
+    }
+
+    #[test]
+    fn classify_rp_code_returns_benign_empty_for_code_7_case_insensitive_text() {
+        let rp_code = vec!["7".to_string(), "No Data".to_string()];
+        assert_eq!(
+            classify_rp_code(&rp_code),
+            RpCodeClassification::KnownBenignEmpty
+        );
+    }
+
+    #[test]
+    fn classify_rp_code_returns_request_rejected_for_other_code_7_text() {
+        let rp_code = vec!["7".to_string(), "permission denied".to_string()];
+        assert_eq!(
+            classify_rp_code(&rp_code),
+            RpCodeClassification::RequestRejected(RithmicRequestError {
+                rp_code: rp_code.clone(),
+                code: Some("7".to_string()),
+                message: "permission denied".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn classify_rp_code_returns_request_rejected_for_code_6() {
+        let rp_code = vec!["6".to_string(), "missing symbol".to_string()];
+        assert_eq!(
+            classify_rp_code(&rp_code),
+            RpCodeClassification::RequestRejected(RithmicRequestError {
+                rp_code: rp_code.clone(),
+                code: Some("6".to_string()),
+                message: "missing symbol".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn classify_rp_code_returns_request_rejected_for_missing_field_text() {
+        let rp_code = vec![
+            "1039".to_string(),
+            "FCM Id field is not received.".to_string(),
+        ];
+        assert_eq!(
+            classify_rp_code(&rp_code),
+            RpCodeClassification::RequestRejected(RithmicRequestError {
+                rp_code: rp_code.clone(),
+                code: Some("1039".to_string()),
+                message: "FCM Id field is not received.".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn classify_rp_code_returns_request_rejected_for_search_pattern_text() {
+        let rp_code = vec![
+            "1062".to_string(),
+            "Search pattern field is not received.".to_string(),
+        ];
+        assert_eq!(
+            classify_rp_code(&rp_code),
+            RpCodeClassification::RequestRejected(RithmicRequestError {
+                rp_code: rp_code.clone(),
+                code: Some("1062".to_string()),
+                message: "Search pattern field is not received.".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn classify_rp_code_keeps_parse_failure_as_request_rejected() {
+        let rp_code = vec![
+            "13".to_string(),
+            "an error occurred while parsing data.".to_string(),
+        ];
+        assert_eq!(
+            classify_rp_code(&rp_code),
+            RpCodeClassification::RequestRejected(RithmicRequestError {
+                rp_code: rp_code.clone(),
+                code: Some("13".to_string()),
+                message: "an error occurred while parsing data.".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn rp_code_error_returns_none_for_code_7_no_data() {
+        assert_eq!(
+            super::rp_code_error(&["7".to_string(), "no data".to_string()]),
+            None
+        );
+    }
+
+    #[test]
+    fn rp_code_error_returns_some_for_other_code_7_text() {
+        assert_eq!(
+            super::rp_code_error(&["7".to_string(), "parse failure".to_string()]),
+            Some("parse failure".to_string())
+        );
+    }
+
+    #[test]
+    fn rp_code_error_returns_second_element_for_non_zero_code() {
+        assert_eq!(
+            super::rp_code_error(&["3".to_string(), "bad request".to_string()]),
             Some("bad request".to_string())
         );
     }
 
     #[test]
-    fn get_error_returns_first_element_when_no_second() {
-        assert_eq!(super::get_error(&["5".to_string()]), Some("5".to_string()));
+    fn rp_code_error_returns_first_element_when_no_second() {
+        assert_eq!(
+            super::rp_code_error(&["5".to_string()]),
+            Some("5".to_string())
+        );
     }
 
     #[test]
@@ -1957,13 +2224,13 @@ mod tests {
     }
 
     #[test]
-    fn has_multiple_returns_false_for_non_zero_code() {
-        assert!(!super::has_multiple(&["7".to_string()]));
+    fn has_multiple_returns_true_for_non_zero_code_when_field_present() {
+        assert!(super::has_multiple(&["7".to_string()]));
     }
 
     #[test]
-    fn has_multiple_returns_false_for_zero_as_second_element() {
-        assert!(!super::has_multiple(&["1".to_string(), "0".to_string()]));
+    fn has_multiple_returns_true_for_any_present_payload() {
+        assert!(super::has_multiple(&["1".to_string(), "0".to_string()]));
     }
 
     #[test]
@@ -1985,6 +2252,235 @@ mod tests {
             result.err()
         );
         assert_eq!(result.unwrap().error, None);
+    }
+
+    #[test]
+    fn replay_no_data_decodes_as_ok_case_insensitive() {
+        use crate::rti::ResponseReplayExecutions;
+        let api = RithmicReceiverApi {
+            source: "test".to_string(),
+        };
+        let result = api.buf_to_message(encode_with_header(&ResponseReplayExecutions {
+            template_id: 3507,
+            user_msg: vec!["req-1b".to_string()],
+            rp_code: vec!["7".to_string(), "NO DATA".to_string()],
+        }));
+        let response = result.expect("case-insensitive no-data should decode as success");
+        assert_eq!(response.error, None);
+        assert!(response.request_error().is_none());
+    }
+
+    #[test]
+    fn search_symbols_decode_sets_multi_response_flags_from_field_presence() {
+        let api = RithmicReceiverApi {
+            source: "test".to_string(),
+        };
+
+        let partial = api
+            .buf_to_message(encode_with_header(&ResponseSearchSymbols {
+                template_id: 110,
+                user_msg: vec!["req-multi".to_string()],
+                rq_handler_rp_code: vec!["7".to_string()],
+                ..ResponseSearchSymbols::default()
+            }))
+            .expect("intermediate multi-response frame should decode");
+
+        assert!(matches!(
+            partial.message,
+            RithmicMessage::ResponseSearchSymbols(_)
+        ));
+        assert!(partial.multi_response);
+        assert!(partial.has_more);
+        assert!(partial.error.is_none());
+
+        let terminal = api
+            .buf_to_message(encode_with_header(&ResponseSearchSymbols {
+                template_id: 110,
+                user_msg: vec!["req-multi".to_string()],
+                rp_code: vec!["0".to_string()],
+                ..ResponseSearchSymbols::default()
+            }))
+            .expect("terminal multi-response frame should decode");
+
+        assert!(terminal.multi_response);
+        assert!(!terminal.has_more);
+        assert!(terminal.error.is_none());
+    }
+
+    #[test]
+    fn reject_with_non_zero_rp_code_decodes_as_ok_with_error() {
+        let api = RithmicReceiverApi {
+            source: "test".to_string(),
+        };
+        let result = api.buf_to_message(encode_with_header(&Reject {
+            template_id: 75,
+            user_msg: vec!["req-2".to_string()],
+            rp_code: vec!["5".to_string(), "permission denied".to_string()],
+        }));
+
+        let response = result.expect("reject with rp_code error should still decode");
+        assert!(matches!(response.message, RithmicMessage::Reject(_)));
+        assert_eq!(response.error.as_deref(), Some("permission denied"));
+        assert!(!response.is_connection_issue());
+    }
+
+    #[test]
+    fn accepted_agreements_bad_input_decodes_as_ok_with_error() {
+        let api = RithmicReceiverApi {
+            source: "test".to_string(),
+        };
+        let result = api.buf_to_message(encode_with_header(&ResponseListAcceptedAgreements {
+            template_id: 503,
+            user_msg: vec!["req-3".to_string()],
+            rp_code: vec!["6".to_string(), "bad input".to_string()],
+            ..ResponseListAcceptedAgreements::default()
+        }));
+
+        let response = result.expect("known request/business errors should stay on response path");
+        assert!(matches!(
+            response.message,
+            RithmicMessage::ResponseListAcceptedAgreements(_)
+        ));
+        assert_eq!(response.error.as_deref(), Some("bad input"));
+        assert!(!response.is_connection_issue());
+    }
+
+    #[test]
+    fn response_request_error_maps_code_6_to_request_rejected_with_full_text() {
+        let response = decode_with_api(&ResponseListAcceptedAgreements {
+            template_id: 503,
+            user_msg: vec!["req-4".to_string()],
+            rp_code: vec!["6".to_string(), "agreement already signed".to_string()],
+            ..ResponseListAcceptedAgreements::default()
+        });
+
+        assert_eq!(response.rp_code(), Some("6"));
+        assert_eq!(response.rp_code_text(), Some("agreement already signed"));
+        assert!(matches!(
+            response.request_error(),
+            Some(RithmicError::RequestRejected(RithmicRequestError { rp_code, code, message }))
+                if rp_code == vec!["6".to_string(), "agreement already signed".to_string()]
+                    && code.as_deref() == Some("6")
+                    && message == "agreement already signed"
+        ));
+    }
+
+    #[test]
+    fn response_request_error_maps_missing_field_server_text_to_request_rejected() {
+        let response = decode_with_api(&ResponseShowOrders {
+            template_id: 321,
+            user_msg: vec!["req-4b".to_string()],
+            rp_code: vec![
+                "1039".to_string(),
+                "FCM Id field is not received.".to_string(),
+            ],
+        });
+
+        assert_eq!(response.rp_code(), Some("1039"));
+        assert_eq!(
+            response.rp_code_text(),
+            Some("FCM Id field is not received.")
+        );
+        assert!(matches!(
+            response.request_error(),
+            Some(RithmicError::RequestRejected(RithmicRequestError { rp_code, code, message }))
+                if rp_code
+                    == vec![
+                        "1039".to_string(),
+                        "FCM Id field is not received.".to_string()
+                    ]
+                    && code.as_deref() == Some("1039")
+                    && message == "FCM Id field is not received."
+        ));
+    }
+
+    #[test]
+    fn response_request_error_maps_search_pattern_server_text_to_request_rejected() {
+        let response = decode_with_api(&ResponseSearchSymbols {
+            template_id: 110,
+            user_msg: vec!["req-4c".to_string()],
+            rp_code: vec![
+                "1062".to_string(),
+                "Search pattern field is not received.".to_string(),
+            ],
+            ..ResponseSearchSymbols::default()
+        });
+
+        assert_eq!(response.rp_code(), Some("1062"));
+        assert_eq!(
+            response.rp_code_text(),
+            Some("Search pattern field is not received.")
+        );
+        assert!(matches!(
+            response.request_error(),
+            Some(RithmicError::RequestRejected(RithmicRequestError { rp_code, code, message }))
+                if rp_code
+                    == vec![
+                        "1062".to_string(),
+                        "Search pattern field is not received.".to_string()
+                    ]
+                    && code.as_deref() == Some("1062")
+                    && message == "Search pattern field is not received."
+        ));
+    }
+
+    #[test]
+    fn response_request_error_preserves_raw_text_for_code_7_no_data() {
+        let response = decode_with_api(&ResponseReplayExecutions {
+            template_id: 3507,
+            user_msg: vec!["req-5".to_string()],
+            rp_code: vec!["7".to_string(), "no data".to_string()],
+        });
+
+        assert_eq!(response.rp_code(), Some("7"));
+        assert_eq!(response.rp_code_text(), Some("no data"));
+        assert!(response.request_error().is_none());
+        assert!(response.request_rejection().is_none());
+    }
+
+    #[test]
+    fn response_request_error_keeps_non_no_data_code_7_as_request_rejected() {
+        use crate::rti::ResponseOrderSessionConfig;
+
+        let response = decode_with_api(&ResponseOrderSessionConfig {
+            template_id: 3503,
+            user_msg: vec!["req-6".to_string()],
+            rp_code: vec![
+                "7".to_string(),
+                "an error occurred while parsing data.".to_string(),
+            ],
+        });
+
+        assert_eq!(
+            response.rp_code_text(),
+            Some("an error occurred while parsing data.")
+        );
+        assert!(matches!(
+            response.request_error(),
+            Some(RithmicError::RequestRejected(RithmicRequestError { rp_code, code, message }))
+                if rp_code
+                    == vec![
+                        "7".to_string(),
+                        "an error occurred while parsing data.".to_string()
+                    ]
+                    && code.as_deref() == Some("7")
+                    && message == "an error occurred while parsing data."
+        ));
+
+        assert_eq!(
+            make_response_with_error(RithmicMessage::Unknown, "decode failed").request_rejection(),
+            None
+        );
+    }
+
+    #[test]
+    fn response_request_error_maps_non_rp_error_to_protocol_error() {
+        let response = make_response_with_error(RithmicMessage::Unknown, "decode failed");
+
+        assert!(matches!(
+            response.request_error(),
+            Some(RithmicError::ProtocolError(message)) if message == "decode failed"
+        ));
     }
 
     // =========================================================================

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,26 @@
 use std::fmt;
 
+/// A non-transport request rejection reported by Rithmic via `rp_code`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RithmicRequestError {
+    /// The raw `rp_code` payload exactly as received from Rithmic.
+    pub rp_code: Vec<String>,
+    /// The first `rp_code` element, when present.
+    pub code: Option<String>,
+    /// The second `rp_code` element when present, otherwise the first element.
+    pub message: String,
+}
+
+impl fmt::Display for RithmicRequestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.code.as_deref() {
+            Some(code) if !code.is_empty() => write!(f, "[{code}] {}", self.message),
+            _ => write!(f, "{}", self.message),
+        }
+    }
+}
+
 /// Typed errors returned by all plant handle methods.
 ///
 /// ```ignore
@@ -9,8 +30,11 @@ use std::fmt;
 ///         handle.abort();
 ///         // reconnect — see examples/reconnect.rs
 ///     }
-///     Err(RithmicError::InvalidArgument(msg)) => eprintln!("bad input: {msg}"),
-///     Err(RithmicError::ServerError(msg)) => eprintln!("rejected: {msg}"),
+///     Err(RithmicError::RequestRejected(err)) => {
+///         eprintln!("request rejected {}: {}", err.code.as_deref().unwrap_or("?"), err.message);
+///     }
+///     Err(RithmicError::ProtocolError(msg)) => eprintln!("protocol error: {msg}"),
+///     Err(RithmicError::InvalidArgument(msg)) => eprintln!("bad local input: {msg}"),
 ///     Err(e) => eprintln!("{e}"),
 /// }
 /// ```
@@ -34,10 +58,21 @@ pub enum RithmicError {
     SendFailed,
     /// Server returned an empty response where at least one was expected.
     EmptyResponse,
-    /// Protocol-level rejection from Rithmic (the `rp_code` text).
-    ServerError(String),
-    /// A caller-supplied argument is invalid (the message describes which argument
-    /// and why).
+    /// Non-transport request rejection from Rithmic.
+    ///
+    /// This preserves the server rejection text and the raw `rp_code` when one
+    /// is supplied. It is a request/business outcome, not a transport failure.
+    /// Do not treat this alone as evidence that the plant disconnected or
+    /// should be reconnected.
+    RequestRejected(RithmicRequestError),
+    /// Non-transport protocol/receiver failure without an `rp_code` rejection.
+    ///
+    /// This covers malformed or unexpected responses that should fail the
+    /// current request path but do not indicate a dead connection.
+    ProtocolError(String),
+    /// Invalid request input.
+    ///
+    /// This is reserved for local argument validation before a request is sent.
     InvalidArgument(String),
 }
 
@@ -48,7 +83,8 @@ impl fmt::Display for RithmicError {
             RithmicError::ConnectionClosed => write!(f, "connection closed"),
             RithmicError::SendFailed => write!(f, "WebSocket send failed or timed out"),
             RithmicError::EmptyResponse => write!(f, "empty response"),
-            RithmicError::ServerError(msg) => write!(f, "server error: {msg}"),
+            RithmicError::RequestRejected(err) => write!(f, "request rejected: {err}"),
+            RithmicError::ProtocolError(msg) => write!(f, "protocol error: {msg}"),
             RithmicError::InvalidArgument(msg) => write!(f, "invalid argument: {msg}"),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,10 +119,35 @@
 //!         handle.abort();
 //!         // reconnect — see examples/reconnect.rs
 //!     }
-//!     Err(RithmicError::ServerError(msg)) => eprintln!("Server rejected: {msg}"),
+//!     Err(RithmicError::RequestRejected(err)) => {
+//!         eprintln!(
+//!             "Request rejected {}: {}",
+//!             err.code.as_deref().unwrap_or("?"),
+//!             err.message
+//!         );
+//!     }
+//!     Err(RithmicError::ProtocolError(msg)) => eprintln!("Protocol error: {msg}"),
+//!     Err(RithmicError::InvalidArgument(msg)) => eprintln!("Bad local input: {msg}"),
 //!     Err(e) => eprintln!("{e}"),
 //! }
 //! ```
+//!
+//! `RithmicError::RequestRejected` reflects explicit non-zero `rp_code`
+//! outcomes and preserves the full raw `rp_code` payload plus derived
+//! first/second elements. `RithmicError::ProtocolError` covers non-transport
+//! response failures that were not carried in `rp_code`. `RithmicError::InvalidArgument`
+//! is reserved for local validation before a request is sent. The one proven benign non-zero case is
+//! `rp_code = ["7", "no data"]`, which is treated as an empty success.
+//! Reconnect only for
+//! connection-health errors or subscription updates where
+//! [`api::receiver_api::RithmicResponse::is_connection_issue`] is true.
+//!
+//! For methods that return [`api::receiver_api::RithmicResponse`] directly, use
+//! [`api::receiver_api::RithmicResponse::rp_code`],
+//! [`api::receiver_api::RithmicResponse::rp_code_text`],
+//! [`api::receiver_api::RithmicResponse::request_rejection`] /
+//! [`api::receiver_api::RithmicResponse::request_error`] to inspect the full
+//! server outcome without pattern-matching individual response templates.
 //!
 //! A graceful `disconnect().await` is separate from that reconnect path: it
 //! shuts the plant down without sending synthetic `HeartbeatTimeout` or
@@ -211,7 +236,7 @@ pub use plants::ticker_plant::{RithmicTickerPlant, RithmicTickerPlantHandle};
 pub use config::{ConfigError, RithmicAccount, RithmicConfig, RithmicConfigBuilder, RithmicEnv};
 
 // Re-export error types
-pub use error::RithmicError;
+pub use error::{RithmicError, RithmicRequestError};
 
 // Re-export connection strategy
 pub use ws::ConnectStrategy;

--- a/src/plants/core.rs
+++ b/src/plants/core.rs
@@ -291,6 +291,44 @@ where
         }
     }
 
+    fn heartbeat_timeout_response(&self, response: RithmicResponse) -> Option<RithmicResponse> {
+        if !matches!(response.message, RithmicMessage::ResponseHeartbeat(_)) {
+            return None;
+        }
+
+        response.error.map(|error| RithmicResponse {
+            request_id: response.request_id,
+            message: RithmicMessage::HeartbeatTimeout,
+            is_update: true,
+            has_more: false,
+            multi_response: false,
+            error: Some(error),
+            source: self.rithmic_receiver_api.source.clone(),
+        })
+    }
+
+    fn forward_response(&mut self, source: &str, response: RithmicResponse) {
+        if let Some(heartbeat_timeout) = self.heartbeat_timeout_response(response.clone()) {
+            let _ = self.subscription_sender.send(heartbeat_timeout);
+            return;
+        }
+
+        if matches!(response.message, RithmicMessage::ResponseHeartbeat(_)) {
+            return;
+        }
+
+        if response.is_update {
+            match self.subscription_sender.send(response) {
+                Ok(_) => {}
+                Err(e) => {
+                    warn!("{}: no active subscribers: {:?}", source, e);
+                }
+            }
+        } else {
+            self.request_handler.handle_response(response);
+        }
+    }
+
     /// Handle a raw WebSocket message. Returns `true` if the actor should stop.
     pub(crate) async fn handle_rithmic_message(&mut self, message: Result<Message, Error>) -> bool {
         let mut stop = false;
@@ -316,46 +354,10 @@ where
             Ok(Message::Binary(data)) => {
                 let source = self.rithmic_receiver_api.source.clone();
                 match self.rithmic_receiver_api.buf_to_message(data) {
-                    Ok(response) => {
-                        // Handle heartbeat responses: only forward if they contain an error
-                        if matches!(response.message, RithmicMessage::ResponseHeartbeat(_)) {
-                            if let Some(error) = response.error {
-                                let error_response = RithmicResponse {
-                                    request_id: response.request_id,
-                                    message: RithmicMessage::HeartbeatTimeout,
-                                    is_update: true,
-                                    has_more: false,
-                                    multi_response: false,
-                                    error: Some(error),
-                                    source: self.rithmic_receiver_api.source.clone(),
-                                };
-
-                                let _ = self.subscription_sender.send(error_response);
-                            }
-
-                            // Always drop heartbeat responses (successful or error)
-                            return false;
-                        }
-
-                        if response.is_update {
-                            match self.subscription_sender.send(response) {
-                                Ok(_) => {}
-                                Err(e) => {
-                                    warn!("{}: no active subscribers: {:?}", source, e);
-                                }
-                            }
-                        } else {
-                            self.request_handler.handle_response(response);
-                        }
-                    }
+                    Ok(response) => self.forward_response(&source, response),
                     Err(err_response) => {
                         error!("{}: error response from server: {:?}", source, err_response);
-
-                        if err_response.is_update {
-                            let _ = self.subscription_sender.send(err_response);
-                        } else {
-                            self.request_handler.handle_response(err_response);
-                        }
+                        self.forward_response(&source, err_response);
                     }
                 }
             }
@@ -568,6 +570,7 @@ mod tests {
     };
 
     use futures_util::StreamExt;
+    use prost::{Message as ProstMessage, bytes::Bytes};
     use tokio::sync::{broadcast, oneshot};
     use tokio_tungstenite::tungstenite::{Error, Message, error::ProtocolError};
 
@@ -704,6 +707,16 @@ mod tests {
         drop(client_tcp);
         let (_, reader) = server_ws.split();
         reader
+    }
+
+    fn encode_with_header<T: ProstMessage>(message: &T) -> Bytes {
+        let mut payload = Vec::new();
+        message.encode(&mut payload).unwrap();
+
+        let mut framed = (payload.len() as u32).to_be_bytes().to_vec();
+        framed.extend(payload);
+
+        Bytes::from(framed)
     }
 
     fn make_test_core(
@@ -1053,6 +1066,141 @@ mod tests {
             broadcast_msg.message,
             RithmicMessage::ConnectionError
         ));
+    }
+
+    #[tokio::test]
+    async fn handle_rithmic_message_request_rp_code_error_does_not_emit_connection_issue() {
+        use crate::rti::Reject;
+
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, mut sub_rx) = make_test_core(MockMessageSink::ready(), reader);
+        let mut rx = register_request(&mut core, "req-1");
+
+        let message = encode_with_header(&Reject {
+            template_id: 75,
+            user_msg: vec!["req-1".to_string()],
+            rp_code: vec!["5".to_string(), "permission denied".to_string()],
+        });
+
+        let stop = core
+            .handle_rithmic_message(Ok(Message::Binary(message)))
+            .await;
+
+        assert!(!stop, "protocol request errors must not stop the actor");
+        assert!(
+            sub_rx.try_recv().is_err(),
+            "generic rp_code errors must not emit connection-health updates"
+        );
+
+        let result = rx.try_recv().unwrap().unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(matches!(result[0].message, RithmicMessage::Reject(_)));
+        assert_eq!(result[0].error.as_deref(), Some("permission denied"));
+    }
+
+    #[tokio::test]
+    async fn handle_rithmic_message_heartbeat_rp_code_error_maps_to_heartbeat_timeout() {
+        use crate::rti::ResponseHeartbeat;
+
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, mut sub_rx) = make_test_core(MockMessageSink::ready(), reader);
+
+        let message = encode_with_header(&ResponseHeartbeat {
+            template_id: 19,
+            user_msg: vec!["hb-1".to_string()],
+            rp_code: vec!["5".to_string(), "heartbeat rejected".to_string()],
+            ..ResponseHeartbeat::default()
+        });
+
+        let stop = core
+            .handle_rithmic_message(Ok(Message::Binary(message)))
+            .await;
+
+        assert!(!stop, "heartbeat rp_code errors should not stop the actor");
+        let update = sub_rx.try_recv().unwrap();
+        assert!(matches!(update.message, RithmicMessage::HeartbeatTimeout));
+        assert_eq!(update.request_id, "hb-1");
+        assert_eq!(update.error.as_deref(), Some("heartbeat rejected"));
+    }
+
+    #[tokio::test]
+    async fn handle_rithmic_message_successful_heartbeat_is_silent() {
+        use crate::rti::ResponseHeartbeat;
+
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, mut sub_rx) = make_test_core(MockMessageSink::ready(), reader);
+
+        let message = encode_with_header(&ResponseHeartbeat {
+            template_id: 19,
+            user_msg: vec!["hb-ok".to_string()],
+            rp_code: vec!["0".to_string()],
+            ..ResponseHeartbeat::default()
+        });
+
+        let stop = core
+            .handle_rithmic_message(Ok(Message::Binary(message)))
+            .await;
+
+        assert!(!stop, "successful heartbeat should not stop the actor");
+        assert!(
+            sub_rx.try_recv().is_err(),
+            "successful heartbeat should not emit a synthetic update"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_rithmic_message_multi_response_uses_rq_handler_rp_code_presence() {
+        use crate::rti::ResponseSearchSymbols;
+
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, mut sub_rx) = make_test_core(MockMessageSink::ready(), reader);
+        let mut rx = register_request(&mut core, "req-multi");
+
+        let intermediate = encode_with_header(&ResponseSearchSymbols {
+            template_id: 110,
+            user_msg: vec!["req-multi".to_string()],
+            rq_handler_rp_code: vec!["7".to_string()],
+            ..ResponseSearchSymbols::default()
+        });
+
+        let stop = core
+            .handle_rithmic_message(Ok(Message::Binary(intermediate)))
+            .await;
+
+        assert!(
+            !stop,
+            "intermediate multi-response frame should not stop the actor"
+        );
+        assert!(
+            matches!(rx.try_recv(), Err(oneshot::error::TryRecvError::Empty)),
+            "intermediate frame should remain buffered until terminal rp_code arrives"
+        );
+        assert!(
+            sub_rx.try_recv().is_err(),
+            "request multipart frames must not emit subscription updates"
+        );
+
+        let terminal = encode_with_header(&ResponseSearchSymbols {
+            template_id: 110,
+            user_msg: vec!["req-multi".to_string()],
+            rp_code: vec!["0".to_string()],
+            ..ResponseSearchSymbols::default()
+        });
+
+        let stop = core
+            .handle_rithmic_message(Ok(Message::Binary(terminal)))
+            .await;
+
+        assert!(
+            !stop,
+            "terminal multi-response frame should not stop the actor"
+        );
+        let result = rx.try_recv().unwrap().unwrap();
+        assert_eq!(result.len(), 2);
+        assert!(result[0].multi_response);
+        assert!(result[0].has_more);
+        assert!(result[1].multi_response);
+        assert!(!result[1].has_more);
     }
 
     #[tokio::test]

--- a/src/plants/history_plant.rs
+++ b/src/plants/history_plant.rs
@@ -576,9 +576,9 @@ impl RithmicHistoryPlantHandle {
             .next()
             .ok_or(RithmicError::EmptyResponse)?;
 
-        if let Some(err) = response.error {
+        if let Some(err) = response.request_error() {
             error!("history_plant: login failed {:?}", err);
-            Err(RithmicError::ServerError(err))
+            Err(err)
         } else {
             let _ = self.sender.send(HistoryPlantCommand::SetLogin).await;
 

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -1244,9 +1244,9 @@ impl RithmicOrderPlantHandle {
             .next()
             .ok_or(RithmicError::EmptyResponse)?;
 
-        if let Some(err) = response.error {
+        if let Some(err) = response.request_error() {
             error!("order_plant: login failed {:?}", err);
-            Err(RithmicError::ServerError(err))
+            Err(err)
         } else {
             let _ = self.sender.send(OrderPlantCommand::SetLogin).await;
 

--- a/src/plants/pnl_plant.rs
+++ b/src/plants/pnl_plant.rs
@@ -445,9 +445,9 @@ impl RithmicPnlPlantHandle {
             .next()
             .ok_or(RithmicError::EmptyResponse)?;
 
-        if let Some(err) = response.error {
+        if let Some(err) = response.request_error() {
             error!("pnl_plant: login failed {:?}", err);
-            Err(RithmicError::ServerError(err))
+            Err(err)
         } else {
             let _ = self.sender.send(PnlPlantCommand::SetLogin).await;
 

--- a/src/plants/ticker_plant.rs
+++ b/src/plants/ticker_plant.rs
@@ -792,9 +792,9 @@ impl RithmicTickerPlantHandle {
             .next()
             .ok_or(RithmicError::EmptyResponse)?;
 
-        if let Some(err) = response.error {
+        if let Some(err) = response.request_error() {
             error!("ticker_plant: login failed {:?}", err);
-            Err(RithmicError::ServerError(err))
+            Err(err)
         } else {
             let _ = self.sender.send(TickerPlantCommand::SetLogin).await;
 


### PR DESCRIPTION
Refs #59

## Summary
- keep request-level non-zero `rp_code` outcomes on the normal response path instead of treating them as connection failures
- preserve the full raw `rp_code` payload for downstream handling while only normalizing the proven benign `["7", "no data"]` case
- treat only explicit transport and heartbeat health failures as actor-fatal
- follow the guide's multipart rule by using `rq_handler_rp_code` field presence to indicate more response frames

## API Changes
- add `RithmicError::RequestRejected(RithmicRequestError)` with the full raw `rp_code` payload plus derived fields
- add `RithmicError::ProtocolError(String)` for non-transport response failures without `rp_code`
- expose `RithmicResponse::rp_code_raw()` alongside `rp_code()` and `rp_code_text()`
- keep `request_rejection()` limited to explicit `rp_code` rejections

## Validation
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -q`
- `cargo +1.85 test --all-targets`
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps`
