### PR TITLE
feat(orders)!: multi-leg OCO, per-leg trailing stops, modify trigger price, RMS auto-liq streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Additive: no public API is removed or changed, so this lands in a 2.x minor release.
+Public struct fields and a method signature change, so this lands in a major release.
+
+### Breaking Changes
+
+- **`RithmicOcoOrderLeg` gains a required `trailing_stop: Option<TrailingStop>` field.** Add
+  `trailing_stop: None` to existing literals to preserve prior behavior.
+- **`TrailingStop` gains a required `trail_by_price_id: i32` field.** It is mandatory for Rithmic to
+  accept a trailing stop.
+- **`RithmicModifyOrder` gains a required `trigger_price: Option<f64>` field.** Add `trigger_price: None`
+  to preserve the prior stop-type default behavior.
+- **`RithmicOrderPlantHandle::subscribe_account_rms_updates` gains a required `update_bits` parameter.**
+  Pass `vec![]` for the prior behavior, or `vec![RmsUpdateBits::AutoLiqThresholdCurrentValue]` to
+  stream auto-liq threshold updates.
 
 ### Added
 
@@ -15,6 +27,21 @@ Additive: no public API is removed or changed, so this lands in a 2.x minor rele
 - **`UnknownTemplateMessage::decode_as<M>()`** — decode the payload into a caller-supplied `prost` type, so an unmapped template can be handled downstream without a change here. `Ok` is not proof the type was guessed right: protobuf skips undeclared fields, so an unrelated payload usually decodes into a mostly-empty value.
 - **`UnknownTemplateMessage::payload_hex()` / `from_payload_hex()`** — the untruncated payload as hex and its inverse. `Display` elides; `payload_hex` doesn't, so a frame captured in production can be attached to a bug report and replayed in a test.
 - **`rithmic_rs::prost`** — the `prost` this crate's types are generated against, re-exported so downstream types are compatible with `decode_as` and with `UnknownTemplateMessage::payload`. prost is a public dependency, so a major bump of it remains a breaking change of this crate.
+- **Multi-leg OCO orders**: `RithmicOrderPlantHandle::place_oco_order_multi(Vec<RithmicOcoOrderLeg>)`
+  for N-leg OCO groups (minimum two legs; fewer returns `RithmicError::InvalidArgument`).
+- **Per-leg OCO trailing stops** via the new `RithmicOcoOrderLeg::trailing_stop` field, which reuses
+  the existing `TrailingStop`. `trail_by_price_id` is mandatory — Rithmic rejects a trailing stop
+  with rp_code 1112 when it is omitted. The three repeated trailing-stop fields are
+  index-aligned with the other per-leg fields, so they are sent for every leg or for none; an OCO
+  where no leg trails is unchanged on the wire.
+- **RMS auto-liquidation streaming**: `subscribe_account_rms_updates` now accepts a `Vec` of update
+  selectors; pass `AutoLiqThresholdCurrentValue` to receive `auto_liq_threshold_current_value`. An
+  empty `Vec` omits `update_bits` rather than sending `0`.
+- **`rithmic_rs::RmsUpdateBits`** — `request_account_rms_updates::UpdateBits` re-exported at the
+  crate root, so the selector passed to `subscribe_account_rms_updates` is nameable without reaching
+  into `rithmic_rs::rti`.
+- `RithmicModifyOrder::trigger_price` — StopLimit/StopMarket modifies can set a trigger price
+  distinct from the limit price. When `None`, the trigger still defaults to `price` for stop types.
 
 ### Changed
 
@@ -30,6 +57,10 @@ Additive: no public API is removed or changed, so this lands in a 2.x minor rele
 
 - **`examples/bracket_order.rs` no longer exits its listener on a recoverable error.** It broke out of the loop on any populated `update.error`, which a per-message decode failure also sets. Breaking there was redundant for the fatal cases — transport failure, forced logout and heartbeat timeout each arrive as their own `RithmicMessage` variant, which the listener already matches — so its only effect was that a single undecodable frame silently stopped order updates on a live bracket.
 - **Samples that handled a turned-down `subscribe` in an `Err` arm.** That arm can never match, so a `subscribe` the server turned down was reported as a success. Affects the crate-root docs, the `RithmicError` rustdoc, the README, `examples/reconnect.rs` and the 2.0.0 migration guide below. All now check `resp.error`, and show `Err(RequestRejected)` on `login`, which is the one call that returns it.
+- **Single-order trailing stops now populate `trail_by_price_id`** (previously omitted, causing
+  Rithmic to reject the trailing stop with rp_code 1112).
+- **`request_account_rms_updates` sent `update_bits: None`**, so `auto_liq_threshold_current_value`
+  never streamed even when subscribed.
 
 ## [2.0.0]
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -53,3 +53,6 @@ pub use crate::rti::request_modify_order::PriceType as ModifyPriceType;
 
 // Re-export easy-to-borrow list request type
 pub use crate::rti::request_easy_to_borrow_list::Request as EasyToBorrowRequest;
+
+// Re-export account RMS update selector
+pub use crate::rti::request_account_rms_updates::UpdateBits as RmsUpdateBits;

--- a/src/api/rithmic_command_types.rs
+++ b/src/api/rithmic_command_types.rs
@@ -48,6 +48,7 @@ pub struct LoginConfig {
 ///     duration: OcoDuration::Day,
 ///     price_type: OcoPriceType::Limit,
 ///     user_tag: "take-profit".to_string(),
+///     trailing_stop: None,
 /// };
 ///
 /// let stop_loss = RithmicOcoOrderLeg {
@@ -60,6 +61,7 @@ pub struct LoginConfig {
 ///     duration: OcoDuration::Day,
 ///     price_type: OcoPriceType::StopMarket,
 ///     user_tag: "stop-loss".to_string(),
+///     trailing_stop: None,
 /// };
 ///
 /// handle.place_oco_order(take_profit, stop_loss).await?;
@@ -84,6 +86,8 @@ pub struct RithmicOcoOrderLeg {
     pub price_type: request_oco_order::PriceType,
     /// Your identifier for this order
     pub user_tag: String,
+    /// Optional trailing stop configuration for this leg
+    pub trailing_stop: Option<TrailingStop>,
 }
 
 /// Entry order with linked profit target and stop loss orders.
@@ -379,6 +383,7 @@ impl From<RithmicBracketOrder> for RithmicAdvancedBracketOrder {
 ///     qty: 2,
 ///     price: 5005.0,
 ///     price_type: ModifyPriceType::Limit,
+///     trigger_price: None,
 /// };
 /// handle.modify_order(modification).await?;
 /// ```
@@ -396,6 +401,8 @@ pub struct RithmicModifyOrder {
     pub price: f64,
     /// Order type
     pub price_type: request_modify_order::PriceType,
+    /// Separate trigger price for StopLimit/StopMarket modifies. When `None`, the trigger defaults to `price` for stop order types.
+    pub trigger_price: Option<f64>,
 }
 
 /// Cancel an existing order.
@@ -416,17 +423,23 @@ pub struct RithmicCancelOrder {
 
 /// Configuration for trailing stop orders.
 ///
+/// Used both by [`RithmicOrder::trailing_stop`] for a standalone order and by
+/// [`RithmicOcoOrderLeg::trailing_stop`] for a single leg of an OCO group.
+///
 /// # Example
 ///
 /// ```ignore
 /// use rithmic_rs::TrailingStop;
 ///
-/// let trailing = TrailingStop { trail_by_ticks: 20 };
+/// let trailing = TrailingStop { trail_by_ticks: 20, trail_by_price_id: 1 };
 /// ```
 #[derive(Debug, Clone, Default)]
 pub struct TrailingStop {
     /// Number of ticks to trail behind the market price
     pub trail_by_ticks: i32,
+    /// Rithmic price-id to trail against. Rithmic rejects a trailing stop with
+    /// rp_code 1112 when this is unset.
+    pub trail_by_price_id: i32,
 }
 
 /// A standalone order (not a bracket order).
@@ -485,7 +498,7 @@ pub struct TrailingStop {
 ///     price: 0.0,  // Not used for trailing stops
 ///     transaction_type: NewOrderTransactionType::Sell,
 ///     price_type: NewOrderPriceType::StopMarket,
-///     trailing_stop: Some(TrailingStop { trail_by_ticks: 20 }),
+///     trailing_stop: Some(TrailingStop { trail_by_ticks: 20, trail_by_price_id: 1 }),
 ///     user_tag: "trailing-stop".to_string(),
 ///     ..Default::default()
 /// };

--- a/src/api/sender_api.rs
+++ b/src/api/sender_api.rs
@@ -28,7 +28,8 @@ use crate::{
         RequestUpdateStopBracketLevel, RequestUpdateTargetBracketLevel,
         RequestVolumeProfileMinuteBars,
         request_account_list::UserType,
-        request_cancel_all_orders, request_depth_by_order_updates, request_easy_to_borrow_list,
+        request_account_rms_updates, request_cancel_all_orders, request_depth_by_order_updates,
+        request_easy_to_borrow_list,
         request_login::SysInfraType,
         request_market_data_update::{Request, UpdateBits},
         request_market_data_update_by_underlying, request_modify_order, request_oco_order,
@@ -476,6 +477,7 @@ impl RithmicSenderApi {
             trigger_price: order.trigger_price,
             trailing_stop: order.trailing_stop.as_ref().map(|_| true),
             trail_by_ticks: order.trailing_stop.as_ref().map(|ts| ts.trail_by_ticks),
+            trail_by_price_id: order.trailing_stop.as_ref().map(|ts| ts.trail_by_price_id),
             ..RequestNewOrder::default()
         };
 
@@ -576,6 +578,7 @@ impl RithmicSenderApi {
         qty: i32,
         price: f64,
         price_type: request_modify_order::PriceType,
+        trigger_price: Option<f64>,
         account: &RithmicAccount,
     ) -> (Vec<u8>, String) {
         let id = self.get_next_message_id();
@@ -593,11 +596,11 @@ impl RithmicSenderApi {
             quantity: Some(qty),
             price: Some(price),
             user_msg: vec![id.clone()],
-            trigger_price: match price_type {
+            trigger_price: trigger_price.or(match price_type {
                 request_modify_order::PriceType::StopLimit
                 | request_modify_order::PriceType::StopMarket => Some(price),
                 _ => None,
-            },
+            }),
             ..RequestModifyOrder::default()
         };
 
@@ -1352,15 +1355,27 @@ impl RithmicSenderApi {
     ///
     /// # Arguments
     /// * `subscribe` - true to subscribe, false to unsubscribe
+    /// * `update_bits` - which RMS fields to stream, folded into the `update_bits`
+    ///   bitmask. An empty `Vec` leaves the field off the request.
+    /// * `account` - The account to subscribe for
     ///
     /// # Returns
     /// A tuple of (serialized request buffer, request ID)
     pub fn request_account_rms_updates(
         &mut self,
         subscribe: bool,
+        update_bits: Vec<request_account_rms_updates::UpdateBits>,
         account: &RithmicAccount,
     ) -> (Vec<u8>, String) {
         let id = self.get_next_message_id();
+
+        // An empty selection leaves the field off the wire entirely; sending an
+        // explicit 0 is a different message from omitting the field.
+        let bits = if update_bits.is_empty() {
+            None
+        } else {
+            Some(update_bits.into_iter().fold(0i32, |acc, f| acc | f as i32))
+        };
 
         let req = RequestAccountRmsUpdates {
             template_id: 3508,
@@ -1376,7 +1391,7 @@ impl RithmicSenderApi {
                 }
                 .to_string(),
             ),
-            update_bits: None,
+            update_bits: bits,
         };
 
         self.request_to_buf(req, id)
@@ -1398,6 +1413,26 @@ impl RithmicSenderApi {
         order2: RithmicOcoOrderLeg,
         account: &RithmicAccount,
     ) -> (Vec<u8>, String) {
+        self.request_oco_order_multi(vec![order1, order2], account)
+    }
+
+    /// Request an OCO (One Cancels Other) order with an arbitrary number of legs
+    ///
+    /// Builds a single `RequestOcoOrder` (template 328) with every repeated field
+    /// populated in a single pass over `legs`. When one leg is filled, the others
+    /// are automatically cancelled.
+    ///
+    /// # Arguments
+    /// * `legs` - The order legs
+    /// * `account` - The account to place the order for
+    ///
+    /// # Returns
+    /// A tuple of (serialized request buffer, request ID)
+    pub fn request_oco_order_multi(
+        &mut self,
+        legs: Vec<RithmicOcoOrderLeg>,
+        account: &RithmicAccount,
+    ) -> (Vec<u8>, String) {
         let id = self.get_next_message_id();
 
         let trade_route = match self.env {
@@ -1405,36 +1440,73 @@ impl RithmicSenderApi {
             RithmicEnv::Demo | RithmicEnv::Test => TRADE_ROUTE_DEMO,
         };
 
+        let mut user_tag = Vec::new();
+        let mut symbol = Vec::new();
+        let mut exchange = Vec::new();
+        let mut quantity = Vec::new();
+        let mut price = Vec::new();
+        let mut trigger_price = Vec::new();
+        let mut transaction_type = Vec::new();
+        let mut duration = Vec::new();
+        let mut price_type = Vec::new();
+        let mut trade_routes = Vec::new();
+        let mut manual_or_auto = Vec::new();
+        let mut trailing_stop = Vec::new();
+        let mut trail_by_ticks = Vec::new();
+        let mut trail_by_price_id = Vec::new();
+
+        for leg in legs {
+            user_tag.push(leg.user_tag);
+            symbol.push(leg.symbol);
+            exchange.push(leg.exchange);
+            quantity.push(leg.quantity);
+            price.push(leg.price);
+            trigger_price.push(leg.trigger_price.unwrap_or(0.0));
+            transaction_type.push(leg.transaction_type.into());
+            duration.push(leg.duration.into());
+            price_type.push(leg.price_type.into());
+            trade_routes.push(trade_route.to_string());
+            manual_or_auto.push(request_oco_order::OrderPlacement::Auto.into());
+            trailing_stop.push(leg.trailing_stop.is_some());
+            trail_by_ticks.push(leg.trailing_stop.as_ref().map_or(0, |ts| ts.trail_by_ticks));
+            trail_by_price_id.push(
+                leg.trailing_stop
+                    .as_ref()
+                    .map_or(0, |ts| ts.trail_by_price_id),
+            );
+        }
+
+        // The three trailing-stop fields are index-aligned with the other repeated
+        // fields, so they are populated for every leg or for none. A leg without a
+        // trailing stop has no price id to trail against, and Rithmic rejects
+        // trail_by_price_id 0 with rp_code 1112.
+        let (trailing_stop, trail_by_ticks, trail_by_price_id) = if trailing_stop.contains(&true) {
+            (trailing_stop, trail_by_ticks, trail_by_price_id)
+        } else {
+            (vec![], vec![], vec![])
+        };
+
         let req = RequestOcoOrder {
             template_id: 328,
             user_msg: vec![id.clone()],
-            user_tag: vec![order1.user_tag, order2.user_tag],
+            user_tag,
             window_name: vec![],
             fcm_id: Some(account.fcm_id.clone()),
             ib_id: Some(account.ib_id.clone()),
             account_id: Some(account.account_id.clone()),
-            symbol: vec![order1.symbol, order2.symbol],
-            exchange: vec![order1.exchange, order2.exchange],
-            quantity: vec![order1.quantity, order2.quantity],
-            price: vec![order1.price, order2.price],
-            trigger_price: vec![
-                order1.trigger_price.unwrap_or(0.0),
-                order2.trigger_price.unwrap_or(0.0),
-            ],
-            transaction_type: vec![
-                order1.transaction_type.into(),
-                order2.transaction_type.into(),
-            ],
-            duration: vec![order1.duration.into(), order2.duration.into()],
-            price_type: vec![order1.price_type.into(), order2.price_type.into()],
-            trade_route: vec![trade_route.to_string(), trade_route.to_string()],
-            manual_or_auto: vec![
-                request_oco_order::OrderPlacement::Auto.into(),
-                request_oco_order::OrderPlacement::Auto.into(),
-            ],
-            trailing_stop: vec![],
-            trail_by_ticks: vec![],
-            trail_by_price_id: vec![],
+            symbol,
+            exchange,
+            quantity,
+            price,
+            trigger_price,
+            transaction_type,
+            duration,
+            price_type,
+            trade_route: trade_routes,
+            manual_or_auto,
+            trailing_stop,
+            trail_by_ticks,
+            trail_by_price_id,
             cancel_at_ssboe: None,
             cancel_at_usecs: None,
             cancel_after_secs: None,
@@ -1695,6 +1767,7 @@ impl RithmicSenderApi {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::rithmic_command_types::TrailingStop;
 
     fn test_config() -> RithmicConfig {
         RithmicConfig::builder(RithmicEnv::Demo)
@@ -1933,6 +2006,7 @@ mod tests {
             duration: crate::rti::request_oco_order::Duration::Day,
             price_type: crate::rti::request_oco_order::PriceType::Limit,
             user_tag: "oco-1".to_string(),
+            trailing_stop: None,
         };
         let leg2 = RithmicOcoOrderLeg {
             symbol: "ESM6".to_string(),
@@ -1944,6 +2018,7 @@ mod tests {
             duration: crate::rti::request_oco_order::Duration::Day,
             price_type: crate::rti::request_oco_order::PriceType::StopMarket,
             user_tag: "oco-2".to_string(),
+            trailing_stop: None,
         };
 
         let (buf, _) = api.request_oco_order(leg1, leg2, &override_account());
@@ -1952,6 +2027,12 @@ mod tests {
         assert_eq!(request.fcm_id.as_deref(), Some("FCM_B"));
         assert_eq!(request.ib_id.as_deref(), Some("IB_B"));
         assert_eq!(request.account_id.as_deref(), Some("ACCOUNT_B"));
+
+        // No leg trails, so the trailing-stop fields stay off the wire rather than
+        // carrying a trail_by_price_id of 0.
+        assert!(request.trailing_stop.is_empty());
+        assert!(request.trail_by_ticks.is_empty());
+        assert!(request.trail_by_price_id.is_empty());
     }
 
     #[test]
@@ -2004,11 +2085,208 @@ mod tests {
     fn account_rms_updates_override_uses_supplied_account() {
         let mut api = RithmicSenderApi::new(&test_config());
 
-        let (buf, _) = api.request_account_rms_updates(true, &override_account());
+        let (buf, _) = api.request_account_rms_updates(true, vec![], &override_account());
         let request: RequestAccountRmsUpdates = decode_request(&buf);
 
         assert_eq!(request.fcm_id.as_deref(), Some("FCM_B"));
         assert_eq!(request.ib_id.as_deref(), Some("IB_B"));
         assert_eq!(request.account_id.as_deref(), Some("ACCOUNT_B"));
+    }
+
+    #[test]
+    fn account_rms_updates_omits_update_bits_when_empty() {
+        let mut api = RithmicSenderApi::new(&test_config());
+
+        let (buf, _) = api.request_account_rms_updates(true, vec![], &default_account());
+        let request: RequestAccountRmsUpdates = decode_request(&buf);
+        assert_eq!(request.update_bits, None);
+
+        let (buf, _) = api.request_account_rms_updates(false, vec![], &default_account());
+        let request: RequestAccountRmsUpdates = decode_request(&buf);
+        assert_eq!(request.update_bits, None);
+        assert_eq!(request.request.as_deref(), Some("unsubscribe"));
+    }
+
+    #[test]
+    fn account_rms_updates_sets_update_bits() {
+        let mut api = RithmicSenderApi::new(&test_config());
+
+        let (buf, _) = api.request_account_rms_updates(
+            true,
+            vec![request_account_rms_updates::UpdateBits::AutoLiqThresholdCurrentValue],
+            &default_account(),
+        );
+        let request: RequestAccountRmsUpdates = decode_request(&buf);
+
+        assert_eq!(request.update_bits, Some(1));
+        assert_eq!(request.request.as_deref(), Some("subscribe"));
+    }
+
+    #[test]
+    fn oco_multi_request_populates_repeated_fields_and_trailing_stops() {
+        let mut api = RithmicSenderApi::new(&test_config());
+
+        let leg0 = RithmicOcoOrderLeg {
+            symbol: "ESM6".to_string(),
+            exchange: "CME".to_string(),
+            quantity: 1,
+            price: 5000.0,
+            trigger_price: None,
+            transaction_type: crate::rti::request_oco_order::TransactionType::Buy,
+            duration: crate::rti::request_oco_order::Duration::Day,
+            price_type: crate::rti::request_oco_order::PriceType::Limit,
+            user_tag: "leg-0".to_string(),
+            trailing_stop: None,
+        };
+        let leg1 = RithmicOcoOrderLeg {
+            symbol: "NQM6".to_string(),
+            exchange: "CME".to_string(),
+            quantity: 2,
+            price: 18000.0,
+            trigger_price: Some(17990.0),
+            transaction_type: crate::rti::request_oco_order::TransactionType::Sell,
+            duration: crate::rti::request_oco_order::Duration::Gtc,
+            price_type: crate::rti::request_oco_order::PriceType::StopMarket,
+            user_tag: "leg-1".to_string(),
+            trailing_stop: Some(TrailingStop {
+                trail_by_ticks: 15,
+                trail_by_price_id: 7,
+            }),
+        };
+        let leg2 = RithmicOcoOrderLeg {
+            symbol: "CLM6".to_string(),
+            exchange: "NYMEX".to_string(),
+            quantity: 3,
+            price: 75.0,
+            trigger_price: Some(74.5),
+            transaction_type: crate::rti::request_oco_order::TransactionType::Sell,
+            duration: crate::rti::request_oco_order::Duration::Day,
+            price_type: crate::rti::request_oco_order::PriceType::StopMarket,
+            user_tag: "leg-2".to_string(),
+            trailing_stop: Some(TrailingStop {
+                trail_by_ticks: 25,
+                trail_by_price_id: 9,
+            }),
+        };
+
+        let (buf, _) = api.request_oco_order_multi(vec![leg0, leg1, leg2], &default_account());
+        let request: RequestOcoOrder = decode_request(&buf);
+
+        assert_eq!(request.symbol.len(), 3);
+        assert_eq!(
+            request.symbol,
+            vec!["ESM6".to_string(), "NQM6".to_string(), "CLM6".to_string()]
+        );
+        assert_eq!(
+            request.exchange,
+            vec!["CME".to_string(), "CME".to_string(), "NYMEX".to_string()]
+        );
+        assert_eq!(request.quantity, vec![1, 2, 3]);
+        assert_eq!(request.price, vec![5000.0, 18000.0, 75.0]);
+        assert_eq!(request.trigger_price, vec![0.0, 17990.0, 74.5]);
+        assert_eq!(
+            request.user_tag,
+            vec![
+                "leg-0".to_string(),
+                "leg-1".to_string(),
+                "leg-2".to_string()
+            ]
+        );
+
+        // Every remaining repeated field is asserted too: the two-leg builder was
+        // rewritten into this loop, so a per-field slip would otherwise go unseen.
+        assert_eq!(
+            request.transaction_type,
+            vec![
+                crate::rti::request_oco_order::TransactionType::Buy as i32,
+                crate::rti::request_oco_order::TransactionType::Sell as i32,
+                crate::rti::request_oco_order::TransactionType::Sell as i32,
+            ]
+        );
+        assert_eq!(
+            request.price_type,
+            vec![
+                crate::rti::request_oco_order::PriceType::Limit as i32,
+                crate::rti::request_oco_order::PriceType::StopMarket as i32,
+                crate::rti::request_oco_order::PriceType::StopMarket as i32,
+            ]
+        );
+        assert_eq!(
+            request.duration,
+            vec![
+                crate::rti::request_oco_order::Duration::Day as i32,
+                crate::rti::request_oco_order::Duration::Gtc as i32,
+                crate::rti::request_oco_order::Duration::Day as i32,
+            ]
+        );
+        assert_eq!(
+            request.manual_or_auto,
+            vec![request_oco_order::OrderPlacement::Auto as i32; 3]
+        );
+        assert_eq!(request.trade_route, vec![TRADE_ROUTE_DEMO.to_string(); 3]);
+        assert_eq!(request.trailing_stop, vec![false, true, true]);
+        assert_eq!(request.trail_by_ticks, vec![0, 15, 25]);
+        assert_eq!(request.trail_by_price_id, vec![0, 7, 9]);
+    }
+
+    #[test]
+    fn order_request_sets_trail_by_price_id() {
+        let mut api = RithmicSenderApi::new(&test_config());
+        let order = RithmicOrder {
+            symbol: "ESM6".to_string(),
+            exchange: "CME".to_string(),
+            quantity: 1,
+            price: 0.0,
+            transaction_type: crate::rti::request_new_order::TransactionType::Sell,
+            price_type: crate::rti::request_new_order::PriceType::StopMarket,
+            user_tag: "trailing-stop".to_string(),
+            duration: None,
+            trigger_price: None,
+            trailing_stop: Some(TrailingStop {
+                trail_by_ticks: 20,
+                trail_by_price_id: 3,
+            }),
+        };
+
+        let (buf, _) = api.request_order(&order, &default_account());
+        let request: RequestNewOrder = decode_request(&buf);
+
+        assert_eq!(request.trailing_stop, Some(true));
+        assert_eq!(request.trail_by_ticks, Some(20));
+        assert_eq!(request.trail_by_price_id, Some(3));
+    }
+
+    #[test]
+    fn modify_order_uses_explicit_trigger_price() {
+        let mut api = RithmicSenderApi::new(&test_config());
+
+        let (buf, _) = api.request_modify_order(
+            "b",
+            "CME",
+            "ESM6",
+            2,
+            5005.0,
+            request_modify_order::PriceType::StopLimit,
+            Some(4999.0),
+            &default_account(),
+        );
+        let request: RequestModifyOrder = decode_request(&buf);
+
+        assert_eq!(request.price, Some(5005.0));
+        assert_eq!(request.trigger_price, Some(4999.0));
+
+        let (buf, _) = api.request_modify_order(
+            "b",
+            "CME",
+            "ESM6",
+            2,
+            5005.0,
+            request_modify_order::PriceType::StopLimit,
+            None,
+            &default_account(),
+        );
+        let request: RequestModifyOrder = decode_request(&buf);
+
+        assert_eq!(request.trigger_price, Some(5005.0));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,8 @@ pub use api::{
     BracketType, EasyToBorrowRequest, LoginConfig, ModifyPriceType, NewOrderDuration,
     NewOrderPriceType, NewOrderTransactionType, OcoDuration, OcoPriceType, OcoTransactionType,
     RithmicAdvancedBracketOrder, RithmicBracketOrder, RithmicCancelOrder, RithmicIfTouchedTrigger,
-    RithmicModifyOrder, RithmicOcoOrderLeg, RithmicOrder, RithmicResponse, TrailingStop,
+    RithmicModifyOrder, RithmicOcoOrderLeg, RithmicOrder, RithmicResponse, RmsUpdateBits,
+    TrailingStop,
 };
 
 // Re-export utility types for convenience

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -20,7 +20,10 @@ use crate::{
         subscription::SubscriptionFilter,
     },
     request_handler::RithmicRequest,
-    rti::{messages::RithmicMessage, request_easy_to_borrow_list, request_login::SysInfraType},
+    rti::{
+        messages::RithmicMessage, request_account_rms_updates, request_easy_to_borrow_list,
+        request_login::SysInfraType,
+    },
     ws::{HEARTBEAT_SECS, PlantActor},
 };
 
@@ -140,6 +143,11 @@ pub(crate) enum OrderPlantCommand {
         account: Arc<RithmicAccount>,
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
     },
+    PlaceOcoOrderMulti {
+        legs: Vec<RithmicOcoOrderLeg>,
+        account: Arc<RithmicAccount>,
+        response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
+    },
     ShowBrackets {
         account: Arc<RithmicAccount>,
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
@@ -181,6 +189,7 @@ pub(crate) enum OrderPlantCommand {
     },
     SubscribeAccountRmsUpdates {
         subscribe: bool,
+        update_bits: Vec<request_account_rms_updates::UpdateBits>,
         account: Arc<RithmicAccount>,
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
     },
@@ -595,6 +604,7 @@ impl PlantActor for OrderPlant {
                     order.qty,
                     order.price,
                     order.price_type,
+                    order.trigger_price,
                     &account,
                 );
 
@@ -862,6 +872,25 @@ impl PlantActor for OrderPlant {
                     .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
+            OrderPlantCommand::PlaceOcoOrderMulti {
+                legs,
+                account,
+                response_sender,
+            } => {
+                let (req_buf, id) = self
+                    .core
+                    .rithmic_sender_api
+                    .request_oco_order_multi(legs, &account);
+
+                self.core.request_handler.register_request(RithmicRequest {
+                    request_id: id.clone(),
+                    responder: response_sender,
+                });
+
+                self.core
+                    .send_or_fail(Message::Binary(req_buf.into()), &id)
+                    .await;
+            }
             OrderPlantCommand::ShowBrackets {
                 account,
                 response_sender,
@@ -1013,13 +1042,15 @@ impl PlantActor for OrderPlant {
             }
             OrderPlantCommand::SubscribeAccountRmsUpdates {
                 subscribe,
+                update_bits,
                 account,
                 response_sender,
             } => {
-                let (req_buf, id) = self
-                    .core
-                    .rithmic_sender_api
-                    .request_account_rms_updates(subscribe, &account);
+                let (req_buf, id) = self.core.rithmic_sender_api.request_account_rms_updates(
+                    subscribe,
+                    update_bits,
+                    &account,
+                );
 
                 self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
@@ -1791,6 +1822,42 @@ impl RithmicOrderPlantHandle {
         rx.await.map_err(|_| RithmicError::ConnectionClosed)?
     }
 
+    /// Place a multi-leg OCO (One Cancels Other) order
+    ///
+    /// When one leg is filled, the others are automatically cancelled. Requires
+    /// at least two legs.
+    ///
+    /// # Arguments
+    /// * `legs` - The order legs (at least two)
+    ///
+    /// # Returns
+    /// A vector of order placement responses or an error message
+    ///
+    /// # Errors
+    /// Returns [`RithmicError::InvalidArgument`] if fewer than two legs are supplied.
+    pub async fn place_oco_order_multi(
+        &self,
+        legs: Vec<RithmicOcoOrderLeg>,
+    ) -> Result<Vec<RithmicResponse>, RithmicError> {
+        if legs.len() < 2 {
+            return Err(RithmicError::InvalidArgument(
+                "OCO order requires at least 2 legs".to_string(),
+            ));
+        }
+
+        let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, RithmicError>>();
+
+        let command = OrderPlantCommand::PlaceOcoOrderMulti {
+            legs,
+            account: self.account.clone(),
+            response_sender: tx,
+        };
+
+        let _ = self.sender.send(command).await;
+
+        rx.await.map_err(|_| RithmicError::ConnectionClosed)?
+    }
+
     /// Show all active bracket orders
     ///
     /// # Returns
@@ -1997,17 +2064,23 @@ impl RithmicOrderPlantHandle {
     ///
     /// # Arguments
     /// * `subscribe` - true to subscribe, false to unsubscribe
+    /// * `update_bits` - which RMS fields to stream. Passing
+    ///   `vec![RmsUpdateBits::AutoLiqThresholdCurrentValue]` streams
+    ///   `auto_liq_threshold_current_value`; an empty `Vec` leaves the field
+    ///   off the request.
     ///
     /// # Returns
     /// The subscription response or an error message
     pub async fn subscribe_account_rms_updates(
         &self,
         subscribe: bool,
+        update_bits: Vec<request_account_rms_updates::UpdateBits>,
     ) -> Result<RithmicResponse, RithmicError> {
         let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, RithmicError>>();
 
         let command = OrderPlantCommand::SubscribeAccountRmsUpdates {
             subscribe,
+            update_bits,
             account: self.account.clone(),
             response_sender: tx,
         };
@@ -2184,5 +2257,89 @@ impl RithmicOrderPlantHandle {
         let _ = self.sender.send(command).await;
 
         rx.await.map_err(|_| RithmicError::ConnectionClosed)?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::rithmic_command_types::RithmicOcoOrderLeg;
+
+    fn test_handle() -> (RithmicOrderPlantHandle, mpsc::Receiver<OrderPlantCommand>) {
+        let account = Arc::new(RithmicAccount::new("FCM_A", "IB_A", "ACCOUNT_A"));
+        let (sender, command_receiver) = mpsc::channel(4);
+        let (_, subscription_receiver) = broadcast::channel(4);
+
+        let handle = RithmicOrderPlantHandle {
+            account: account.clone(),
+            sender,
+            subscription_receiver: SubscriptionFilter::new(account, subscription_receiver),
+        };
+
+        (handle, command_receiver)
+    }
+
+    fn leg(tag: &str) -> RithmicOcoOrderLeg {
+        RithmicOcoOrderLeg {
+            symbol: "ESM6".to_string(),
+            exchange: "CME".to_string(),
+            quantity: 1,
+            price: 5000.0,
+            trigger_price: None,
+            transaction_type: crate::rti::request_oco_order::TransactionType::Buy,
+            duration: crate::rti::request_oco_order::Duration::Day,
+            price_type: crate::rti::request_oco_order::PriceType::Limit,
+            user_tag: tag.to_string(),
+            trailing_stop: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn place_oco_order_multi_rejects_fewer_than_two_legs() {
+        for legs in [vec![], vec![leg("only")]] {
+            let (handle, mut command_receiver) = test_handle();
+
+            // Without the guard the command reaches the actor, which is not
+            // running here, and the call parks on its response channel. The
+            // timeout turns that into a failure instead of a hung suite.
+            let err = tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                handle.place_oco_order_multi(legs),
+            )
+            .await
+            .expect("must be rejected without reaching the actor")
+            .expect_err("fewer than two legs must be rejected");
+
+            assert!(matches!(err, RithmicError::InvalidArgument(_)));
+            // Rejected before reaching the actor, so nothing was queued.
+            assert!(command_receiver.try_recv().is_err());
+        }
+    }
+
+    #[tokio::test]
+    async fn place_oco_order_multi_forwards_two_or_more_legs() {
+        let (handle, mut command_receiver) = test_handle();
+
+        // The call parks on its response channel until the actor answers, so it
+        // has to run alongside the receive below rather than before it.
+        let call = tokio::spawn(async move {
+            handle
+                .place_oco_order_multi(vec![leg("a"), leg("b"), leg("c")])
+                .await
+        });
+
+        match command_receiver.recv().await {
+            Some(OrderPlantCommand::PlaceOcoOrderMulti { legs, .. }) => {
+                assert_eq!(legs.len(), 3);
+                assert_eq!(legs[2].user_tag, "c");
+                // Dropping the command drops the responder, which unparks the call.
+            }
+            _ => panic!("expected PlaceOcoOrderMulti to be queued"),
+        }
+
+        assert!(matches!(
+            call.await.expect("call task panicked"),
+            Err(RithmicError::ConnectionClosed)
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Ports order-entry features from community forks onto `main` (the deferred gateway/proxy feature is **not** included). Two logical changes, both confined to order entry.

### Multi-leg OCO + trailing stops + StopLimit modify (from `niroam/rithmic-rs`)

- `place_oco_order_multi(Vec<RithmicOcoOrderLeg>)` — N-leg OCO groups (min 2 legs; fewer → `RithmicError::InvalidArgument`). The existing two-leg `place_oco_order` now delegates to it.
- Per-leg trailing stops via the new `RithmicOcoOrderLeg::trailing_stop`, carrying the existing `TrailingStop`. `trail_by_price_id` is mandatory (Rithmic rejects with rp_code 1112 otherwise).
- `RithmicModifyOrder::trigger_price` — StopLimit/StopMarket modifies can set a trigger distinct from the limit price. `None` keeps the prior behaviour of defaulting the trigger to `price` for stop types.
- **Bug fixes, not inherited from the fork:** single-order trailing stops now populate `trail_by_price_id` (the same rp_code 1112 rejection the fork left broken on the single-order path); the two doc examples that omitted it are corrected.

### RMS auto-liquidation streaming (from `awyl/rithmic-rs`)

- `subscribe_account_rms_updates` / `request_account_rms_updates` now take the update selectors to stream, folded into the `update_bits` bitmask, so `auto_liq_threshold_current_value` arrives (was hardcoded `update_bits: None`).
- The selector enum is re-exported at the crate root as `RmsUpdateBits`, so it is nameable without reaching into `rithmic_rs::rti` — matching how `EasyToBorrowRequest`, `ModifyPriceType` and the bracket/OCO/new-order enums are already surfaced.

## Wire compatibility

Both new fields are absent-by-default rather than zero-filled, so code that does not opt in produces byte-identical requests to `main`:

- The three OCO trailing-stop fields (`trailing_stop`, `trail_by_ticks`, `trail_by_price_id`) are index-aligned with the other repeated per-leg fields, so they are populated for every leg or for none. An OCO where no leg trails sends all three empty, rather than shipping `trail_by_price_id: 0` — the value that draws rp_code 1112.
- An empty `update_bits` selection omits the field entirely. A proto2 optional that is absent and one present with value `0` are distinct messages, so `vec![]` genuinely reproduces the prior `None`, on both the subscribe and unsubscribe paths.

## Breaking changes

New required fields on `RithmicOcoOrderLeg` (`trailing_stop`), `TrailingStop` (`trail_by_price_id`), and `RithmicModifyOrder` (`trigger_price`); `subscribe_account_rms_updates` gains an `update_bits` parameter. None of these structs are `#[non_exhaustive]`, so downstream struct literals need updating. Migration notes are in `CHANGELOG.md` under `[Unreleased]`. This is a semver-major change — intended for the next major release.

## Testing

`cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, and `cargo doc --no-deps` under `RUSTDOCFLAGS=-D warnings` all green locally (197 passed, 21 `ignore` doctests), matching what CI runs.

New tests cover:

- every one of the thirteen repeated fields on a three-leg OCO, including index alignment of the trailing-stop fields;
- a plain two-leg OCO leaving all three trailing-stop fields empty;
- the single-order `trail_by_price_id` fix;
- explicit-vs-fallback modify trigger price;
- the RMS `update_bits` bitmask, and its omission on both subscribe and unsubscribe when the selection is empty;
- the `place_oco_order_multi` leg-count guard, on both the rejection and forwarding paths.

These were checked by mutation testing rather than by coverage: each change was reverted or corrupted in turn to confirm a test actually fails. That found two gaps, since closed — seven of the thirteen repeated OCO fields (`quantity`, `exchange`, `transaction_type`, `price_type`, `duration`, `manual_or_auto`, `trade_route`) had no assertion despite being exactly what the rewrite from a hand-written two-element `vec![]` into a loop touched, and the documented `InvalidArgument` guard had no test at all.

Two caveats worth stating plainly. Nothing here has been exercised against a live Rithmic gateway, so the rp_code 1112 premise is inherited from the fork rather than independently confirmed. And the touched rustdoc examples are `ignore` blocks, so their added `trailing_stop: None` / `trigger_price: None` lines are verified by inspection rather than by `cargo test`.

## Not in this PR

An earlier revision of this branch also raised `ws::CONNECT_TIMEOUT_SECS` from 2s to 10s. That commit has been dropped — it was unrelated to order entry and unsupported by any measurement, so `src/ws.rs` is untouched here. Worth revisiting separately: in an unbounded retry loop a too-short connect timeout is a permanent failure rather than a slowdown, and separately `ConnectStrategy::Simple` bypasses the constant entirely, so the strategy documented as "fast-fail" is the only one with no deadline at all.

The larger order-API redesign (collapsing to `#[non_exhaustive]` evolvable structs so new proto fields stop being breaking) is being iterated separately.

Rebased onto `main` at `422a01a` and squashed to a single commit. No conflicts; `CHANGELOG.md`'s `[Unreleased]` section merges cleanly with the entries from #66/#67/#68 into single `Breaking Changes` / `Added` / `Changed` / `Fixed` sections.
