### PR TITLE
Surface unmapped template ids instead of failing to decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Additive: no public API is removed or changed, so this lands in a 2.x minor release.
+
+### Added
+
+- **`RithmicMessage::UnknownTemplate(UnknownTemplateMessage)`** — a frame whose `template_id` has no message definition in this crate. Delivered with `error: None` and the message body kept as received. `RithmicMessage` is `#[non_exhaustive]`, so the new variant does not break existing matches.
+- **`UnknownTemplateMessage::decode_as<M>()`** — decode the payload into a caller-supplied `prost` type, so an unmapped template can be handled downstream without a change here. `Ok` is not proof the type was guessed right: protobuf skips undeclared fields, so an unrelated payload usually decodes into a mostly-empty value.
+- **`UnknownTemplateMessage::payload_hex()` / `from_payload_hex()`** — the untruncated payload as hex and its inverse. `Display` elides; `payload_hex` doesn't, so a frame captured in production can be attached to a bug report and replayed in a test.
+- **`rithmic_rs::prost`** — the `prost` this crate's types are generated against, re-exported so downstream types are compatible with `decode_as` and with `UnknownTemplateMessage::payload`. prost is a public dependency, so a major bump of it remains a breaking change of this crate.
+
+### Changed
+
+- **An unrecognized `template_id` is no longer reported as a decode failure.** It previously produced `Err(RithmicResponse)` with `RithmicError::ProtocolError("Unknown message type: template_id=…")`, logged at `error` level with the payload discarded. It now returns `Ok` with `RithmicMessage::UnknownTemplate`, `error: None`, and a `warn` carrying the template id and size. Routing is unchanged — it was, and remains, delivered on the subscription channel as an update.
+
+  This is a behavioural change, not a source-breaking one: code matching `RithmicMessage::Unknown` still compiles, but will no longer see unrecognized templates. Match `UnknownTemplate` for those; `Unknown` now means only that a frame failed to decode.
+- A frame carrying no `template_id` is still an error: prost does not enforce proto2 `required` on decode, so the missing field arrives as `0`, leaving no template to route it to.
+
 ## [2.0.0]
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -133,6 +133,25 @@ handle.exit_position("ESM6", "CME").await?;
 For multi-account workflows, create one [`RithmicAccount`] per account and call
 `get_handle(&account)` for each handle you need.
 
+### Unrecognized message templates
+
+A `template_id` this crate has no definition for arrives as
+`RithmicMessage::UnknownTemplate` with `error: None`, carrying the message body
+as received:
+
+```rust
+if let RithmicMessage::UnknownTemplate(frame) = &update.message {
+    // template_id=358 (84 bytes) a2e135054d45535536aae13503434d45e2ed3506393231342d32faed35096361…+52B
+    tracing::warn!(payload = %frame.payload_hex(), "unmapped template: {frame}");
+
+    // Once you know what it maps to, generate the type from the .proto in your
+    // own crate; `rithmic_rs::prost` is re-exported so versions can't drift.
+    if let Ok(decoded) = frame.decode_as::<my_crate::Template358>() {
+        handle_it_yourself(decoded);
+    }
+}
+```
+
 ### History Plant
 
 ```rust

--- a/src/api/receiver_api.rs
+++ b/src/api/receiver_api.rs
@@ -1,5 +1,5 @@
 use prost::{Message, bytes::Bytes};
-use tracing::error;
+use tracing::{error, warn};
 
 use crate::rti::{
     AccountListUpdates, AccountPnLPositionUpdate, AccountRmsUpdates, BestBidOffer, BracketUpdates,
@@ -34,6 +34,7 @@ use crate::rti::{
 pub use super::response::RithmicResponse;
 use super::rp_code::classify_rp_code_error;
 use crate::error::RithmicError;
+use crate::util::unknown_message::UnknownTemplateMessage;
 
 #[derive(Debug)]
 pub(crate) struct RithmicReceiverApi {
@@ -1426,27 +1427,52 @@ impl RithmicReceiverApi {
                     source: self.source.clone(),
                 }
             }
-            _ => {
-                error!(
-                    "Unknown message type received - template_id: {}, data_size: {} bytes",
-                    parsed_message.template_id,
-                    data.len()
-                );
+            // prost doesn't enforce proto2 `required`, so a body with no
+            // template_id decodes as 0. Keep it an error — there is no
+            // template to route it to.
+            id if id <= 0 => {
+                error!("{}: frame carries no template_id", self.source);
 
-                // Unknown templates are unsolicited; route as an update so we
-                // don't spam "no responder found" via the request handler.
                 return Err(RithmicResponse {
                     request_id: "".to_string(),
                     message: RithmicMessage::Unknown,
+                    is_update: false,
+                    has_more: false,
+                    multi_response: false,
+                    error: Some(RithmicError::ProtocolError(
+                        "Frame carries no template_id".to_string(),
+                    )),
+                    source: self.source.clone(),
+                });
+            }
+            _ => {
+                // Not a recognized message template.
+                let unknown = UnknownTemplateMessage {
+                    template_id: parsed_message.template_id,
+                    payload: data.slice(4..),
+                };
+
+                // Payload stays out of the log: it may carry account and order
+                // ids, and the caller receives the frame to log as it sees fit.
+                warn!(
+                    "{}: unmapped Rithmic template {} ({} bytes)",
+                    self.source,
+                    unknown.template_id,
+                    unknown.payload.len()
+                );
+
+                // No request_id can be extracted without a schema, so route as
+                // an update rather than letting the request handler log
+                // "no responder found".
+                RithmicResponse {
+                    request_id: "".to_string(),
+                    message: RithmicMessage::UnknownTemplate(unknown),
                     is_update: true,
                     has_more: false,
                     multi_response: false,
-                    error: Some(RithmicError::ProtocolError(format!(
-                        "Unknown message type: template_id={}",
-                        parsed_message.template_id
-                    ))),
+                    error: None,
                     source: self.source.clone(),
-                });
+                }
             }
         };
 
@@ -1491,11 +1517,10 @@ mod tests {
     use crate::error::{RithmicError, RithmicRequestError};
     use crate::rti::{
         Reject, ResponseAccountList, ResponseListAcceptedAgreements, ResponseLogin,
-        ResponseOrderSessionConfig, ResponseReplayExecutions, ResponseSearchSymbols, TradeRoute,
-        UpdateEasyToBorrowList, messages::RithmicMessage,
+        ResponseOrderSessionConfig, ResponseReplayExecutions, ResponseSearchSymbols,
+        RithmicOrderNotification, TradeRoute, UpdateEasyToBorrowList, messages::RithmicMessage,
     };
-    use prost::Message;
-    use prost::bytes::Bytes;
+    use prost::{Message, bytes::Bytes};
 
     fn encode_with_header<T: Message>(message: &T) -> Bytes {
         let mut payload = Vec::new();
@@ -1551,6 +1576,60 @@ mod tests {
             RithmicMessage::UpdateEasyToBorrowList(_)
         ));
         assert!(response.is_update);
+    }
+
+    #[test]
+    fn unmapped_template_decodes_as_update_without_error() {
+        // 358 has no decoder here, so the frame must survive as an update
+        // rather than an error.
+        let api = RithmicReceiverApi {
+            source: "order_plant".to_string(),
+        };
+        let notification = RithmicOrderNotification {
+            template_id: 358,
+            basket_id: Some("9214-2".to_string()),
+            symbol: Some("MESU6".to_string()),
+            ..RithmicOrderNotification::default()
+        };
+        let result = api.buf_to_message(encode_with_header(&notification));
+
+        let response = result.expect("unmapped templates are not decode failures");
+
+        assert!(response.error.is_none());
+        assert!(response.is_update);
+        assert_eq!(response.request_id, "");
+
+        let RithmicMessage::UnknownTemplate(frame) = &response.message else {
+            panic!("expected UnknownTemplate, got {:?}", response.message);
+        };
+
+        assert_eq!(frame.template_id, 358);
+
+        // Byte-identical to what was framed, length prefix aside.
+        assert_eq!(frame.payload, Bytes::from(notification.encode_to_vec()));
+    }
+
+    #[test]
+    fn frame_without_a_template_id_stays_an_error() {
+        // prost decodes a missing proto2 `required` int32 as 0, so this must
+        // not be mistaken for a template we simply don't map.
+        let api = RithmicReceiverApi {
+            source: "order_plant".to_string(),
+        };
+
+        let mut framed = 2u32.to_be_bytes().to_vec();
+        framed.extend_from_slice(&[0x08, 0x01]); // field 1 — not in MessageType
+
+        let response = api
+            .buf_to_message(Bytes::from(framed))
+            .expect_err("a frame with no template_id is malformed");
+
+        assert!(matches!(response.message, RithmicMessage::Unknown));
+        assert!(matches!(
+            response.error,
+            Some(RithmicError::ProtocolError(_))
+        ));
+        assert!(!response.is_update);
     }
 
     // =========================================================================

--- a/src/error.rs
+++ b/src/error.rs
@@ -96,6 +96,9 @@ pub enum RithmicError {
     /// Non-transport, non-rp_code response failure (e.g. decode failures or
     /// other protocol-level outcomes that don't carry `rp_code`). Not a
     /// reconnect signal.
+    ///
+    /// An unrecognized `template_id` does not produce this error; it arrives as
+    /// [`RithmicMessage::UnknownTemplate`](crate::rti::messages::RithmicMessage::UnknownTemplate).
     ProtocolError(String),
     /// A caller-supplied argument is invalid (the message describes which argument
     /// and why).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,6 +218,12 @@ pub mod util;
 /// WebSocket connectivity layer
 pub mod ws;
 
+/// The `prost` this crate's protobuf types are generated against, re-exported so
+/// downstream code can decode an [`UnknownTemplateMessage`] payload without
+/// risking a version mismatch. prost is a public dependency, so a major bump of
+/// it is a breaking change of this crate.
+pub use prost;
+
 // Re-export plant types for easier access
 pub use plants::history_plant::{RithmicHistoryPlant, RithmicHistoryPlantHandle};
 pub use plants::order_plant::{RithmicOrderPlant, RithmicOrderPlantHandle};
@@ -244,8 +250,8 @@ pub use api::{
 
 // Re-export utility types for convenience
 pub use util::{
-    InstrumentInfo, InstrumentInfoError, OrderStatus, rithmic_to_unix_nanos,
-    rithmic_to_unix_nanos_precise,
+    InstrumentInfo, InstrumentInfoError, OrderStatus, UnknownTemplateMessage,
+    rithmic_to_unix_nanos, rithmic_to_unix_nanos_precise,
 };
 
 // Re-export high-level trading types

--- a/src/rti/messages.rs
+++ b/src/rti/messages.rs
@@ -25,6 +25,7 @@ use super::{
     ResponseVolumeProfileMinuteBars, RithmicOrderNotification, SymbolMarginRate, TickBar, TimeBar,
     TradeRoute, TradeStatistics, UpdateEasyToBorrowList, UserAccountUpdate,
 };
+use crate::util::unknown_message::UnknownTemplateMessage;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
@@ -166,11 +167,22 @@ pub enum RithmicMessage {
     /// ```
     HeartbeatTimeout,
 
-    /// A message type that this library doesn't recognize.
+    /// A frame whose `template_id` has no message definition in this crate.
+    ///
+    /// The header parsed and carried a `template_id`, but no decoder is
+    /// registered for it, so the body is delivered as received with
+    /// `error: None` rather than as a decode failure. It can be logged,
+    /// archived, or decoded by the caller.
+    ///
+    /// The library logs only the template id and size; the payload may carry
+    /// account and order ids, so what to log is left to the caller.
+    UnknownTemplate(UnknownTemplateMessage),
+
+    /// A frame that could not be decoded.
     ///
     /// *Note: This is a synthetic message from rithmic-rs, not from Rithmic servers.*
     ///
-    /// This shouldn't happen in normal usage. If you see this, it may indicate
-    /// a newer Rithmic protocol version with message types not yet supported.
+    /// Always accompanied by a `ProtocolError`. A `template_id` this crate
+    /// doesn't map arrives as [`UnknownTemplate`](Self::UnknownTemplate).
     Unknown,
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,9 @@
 pub mod instrument;
 pub mod order_status;
 pub mod time;
+pub mod unknown_message;
 
 pub use instrument::{InstrumentInfo, InstrumentInfoError};
 pub use order_status::OrderStatus;
 pub use time::{rithmic_to_unix_nanos, rithmic_to_unix_nanos_precise};
+pub use unknown_message::UnknownTemplateMessage;

--- a/src/util/unknown_message.rs
+++ b/src/util/unknown_message.rs
@@ -1,0 +1,273 @@
+//! Frames whose `template_id` this crate doesn't map.
+
+use std::fmt;
+
+use prost::bytes::Bytes;
+
+/// Payload bytes rendered by the [`fmt::Display`] and [`fmt::Debug`] impls
+/// before eliding. [`UnknownTemplateMessage::payload_hex`] is the full form.
+const MAX_RENDERED_BYTES: usize = 32;
+
+/// A frame whose `template_id` this crate has no message definition for.
+///
+/// The payload is kept as received, so a template this crate doesn't map can
+/// still be handled downstream: [`decode_as`](Self::decode_as) decodes it into a
+/// type you generate yourself, and [`payload_hex`](Self::payload_hex) dumps it
+/// for later.
+#[derive(Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UnknownTemplateMessage {
+    /// The `template_id` read from the frame header.
+    pub template_id: i32,
+    /// The complete message body, exactly as received.
+    ///
+    /// Only the 4-byte big-endian length prefix is stripped, as every other
+    /// decoder here does; it carries nothing beyond `payload.len()`.
+    pub payload: Bytes,
+}
+
+impl UnknownTemplateMessage {
+    /// Build a frame from its `template_id` and body.
+    pub fn new(template_id: i32, payload: Bytes) -> Self {
+        Self {
+            template_id,
+            payload,
+        }
+    }
+
+    /// Decode the payload into a caller-supplied protobuf type.
+    ///
+    /// Generate the type from the `.proto` in your own crate and decode into it.
+    /// Uses the [`crate::prost`] re-export, so types generated against
+    /// `rithmic_rs::prost` are compatible by construction.
+    ///
+    /// # Errors
+    ///
+    /// [`prost::DecodeError`] when the bytes are structurally incompatible with
+    /// `M`, such as a wire-type conflict on a field `M` declares.
+    ///
+    /// `Ok` is not proof the type was guessed right. Protobuf skips fields the
+    /// target doesn't declare, so an unrelated payload usually decodes into a
+    /// mostly-empty value.
+    pub fn decode_as<M: prost::Message + Default>(&self) -> Result<M, prost::DecodeError> {
+        M::decode(self.payload.clone())
+    }
+
+    /// The whole payload as lowercase hex, no truncation, no `0x` prefix.
+    ///
+    /// `Display` elides the payload to stay readable in a log line; this
+    /// doesn't.
+    pub fn payload_hex(&self) -> String {
+        use fmt::Write;
+
+        let mut hex = String::with_capacity(self.payload.len() * 2);
+
+        for byte in &self.payload {
+            // Writing to a String is infallible.
+            let _ = write!(hex, "{byte:02x}");
+        }
+
+        hex
+    }
+
+    /// Rebuild a frame from a [`payload_hex`](Self::payload_hex) dump.
+    ///
+    /// Ignores a leading `0x` and any whitespace, including newlines from a
+    /// wrapped log line. `None` unless `hex` holds an even number of hex
+    /// digits; empty input yields an empty payload.
+    pub fn from_payload_hex(template_id: i32, hex: &str) -> Option<Self> {
+        let hex = hex.trim();
+        let hex = hex
+            .strip_prefix("0x")
+            .or(hex.strip_prefix("0X"))
+            .unwrap_or(hex);
+
+        let digits: Vec<u8> = hex
+            .chars()
+            .filter(|character| !character.is_whitespace())
+            .map(|character| character.to_digit(16).map(|digit| digit as u8))
+            .collect::<Option<_>>()?;
+
+        if digits.len() % 2 != 0 {
+            return None;
+        }
+
+        let payload: Vec<u8> = digits
+            .chunks_exact(2)
+            .map(|pair| (pair[0] << 4) | pair[1])
+            .collect();
+
+        Some(Self::new(template_id, Bytes::from(payload)))
+    }
+}
+
+impl fmt::Display for UnknownTemplateMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "template_id={} ({} bytes)",
+            self.template_id,
+            self.payload.len()
+        )?;
+
+        if self.payload.is_empty() {
+            return Ok(());
+        }
+
+        write!(f, " {}", Hex(&self.payload))
+    }
+}
+
+impl fmt::Debug for UnknownTemplateMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // The derive would dump the payload as a list of byte literals.
+        f.debug_struct("UnknownTemplateMessage")
+            .field("template_id", &self.template_id)
+            .field("payload_len", &self.payload.len())
+            .field("payload", &format_args!("{}", Hex(&self.payload)))
+            .finish()
+    }
+}
+
+/// Renders bytes as hex, capped at [`MAX_RENDERED_BYTES`].
+struct Hex<'a>(&'a [u8]);
+
+impl fmt::Display for Hex<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.0.iter().take(MAX_RENDERED_BYTES) {
+            write!(f, "{byte:02x}")?;
+        }
+
+        let remaining = self.0.len().saturating_sub(MAX_RENDERED_BYTES);
+
+        if remaining > 0 {
+            write!(f, "…+{remaining}B")?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use prost::Message;
+
+    use super::*;
+    use crate::rti::{RequestCancelAllOrders, RithmicOrderNotification};
+
+    fn frame<M: Message>(template_id: i32, message: &M) -> UnknownTemplateMessage {
+        UnknownTemplateMessage {
+            template_id,
+            payload: Bytes::from(message.encode_to_vec()),
+        }
+    }
+
+    fn notification() -> RithmicOrderNotification {
+        RithmicOrderNotification {
+            template_id: 358,
+            basket_id: Some("9214-2".to_string()),
+            symbol: Some("MESU6".to_string()),
+            price: Some(6412.25),
+            ..RithmicOrderNotification::default()
+        }
+    }
+
+    #[test]
+    fn decodes_into_a_caller_supplied_type() {
+        let original = notification();
+
+        let decoded: RithmicOrderNotification = frame(358, &original)
+            .decode_as()
+            .expect("payload round-trips into the matching type");
+
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn decode_as_reports_structurally_incompatible_bytes() {
+        // template_id (154467) is an int32 everywhere, so sending it as
+        // length-delimited conflicts with what the target declares.
+        // Key = (154467 << 3) | 2, varint-encoded, then a 2-byte string.
+        let payload = vec![0x9a, 0xb6, 0x4b, 0x02, b'h', b'i'];
+
+        let frame = UnknownTemplateMessage {
+            template_id: 358,
+            payload: Bytes::from(payload),
+        };
+
+        assert!(frame.decode_as::<RequestCancelAllOrders>().is_err());
+    }
+
+    #[test]
+    fn decode_as_can_succeed_against_the_wrong_type() {
+        // Guards the documented caveat: unknown fields are skipped, so this
+        // decodes fine and drops everything but template_id.
+        let decoded = frame(358, &notification())
+            .decode_as::<RequestCancelAllOrders>()
+            .expect("unknown fields are skipped, so this decodes");
+
+        assert_eq!(decoded.template_id, 358);
+        assert_eq!(decoded.account_id, None);
+    }
+
+    #[test]
+    fn payload_hex_round_trips_verbatim() {
+        let captured = frame(358, &notification());
+        let hex = captured.payload_hex();
+
+        // Complete, unlike Display.
+        assert_eq!(hex.len(), captured.payload.len() * 2);
+        assert!(hex.chars().all(|character| character.is_ascii_hexdigit()));
+
+        let replayed = UnknownTemplateMessage::from_payload_hex(358, &hex)
+            .expect("payload_hex output parses back");
+
+        assert_eq!(replayed, captured);
+    }
+
+    #[test]
+    fn from_payload_hex_tolerates_copy_paste() {
+        let expected = UnknownTemplateMessage {
+            template_id: 358,
+            payload: Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]),
+        };
+
+        for input in [
+            "deadbeef",
+            "DEADBEEF",
+            "0xdeadbeef",
+            " dead beef\n",
+            "dead\nbeef",
+        ] {
+            assert_eq!(
+                UnknownTemplateMessage::from_payload_hex(358, input).as_ref(),
+                Some(&expected),
+                "{input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn from_payload_hex_rejects_malformed_input() {
+        // Odd digit count, and a non-hex character.
+        assert_eq!(UnknownTemplateMessage::from_payload_hex(358, "abc"), None);
+        assert_eq!(UnknownTemplateMessage::from_payload_hex(358, "zz"), None);
+    }
+
+    #[test]
+    fn display_elides_a_long_payload() {
+        let frame = UnknownTemplateMessage {
+            template_id: 358,
+            payload: Bytes::from(vec![0xab; MAX_RENDERED_BYTES + 20]),
+        };
+
+        let rendered = frame.to_string();
+
+        assert!(
+            rendered.starts_with("template_id=358 (52 bytes) "),
+            "{rendered}"
+        );
+        assert!(rendered.ends_with("…+20B"), "{rendered}");
+        assert_eq!(frame.payload_hex().len(), 104);
+    }
+}


### PR DESCRIPTION
Addresses the decode-failure half of #65. Additive — targets a 2.x minor release, not a major.

## The problem

#65 reports a gateway sending `template_id` 358, which this crate has no decoder for.

That was surfaced as `ProtocolError("Unknown message type")` at `error` level with the payload discarded. Two problems: it reads as a decode failure even though the header parsed and carried a `template_id`, and it throws away the only evidence of what the message was.

## What changed

Unmapped templates now decode to `RithmicMessage::UnknownTemplate` with `error: None`, carrying the message body as received. Routing is unchanged — both the old `Err` and the new `Ok` carry `is_update: true`, and `forward_response` branches only on that, so they land on the same channel. Only the log site and level moved.

A frame carrying *no* `template_id` stays an error. prost does not enforce proto2 `required` on decode, so the missing field arrives as `0`, leaving no template to route it to.

A downstream crate can handle an unmapped template with no change here:

- `rithmic_rs::prost` is re-exported, so types generated downstream are version-compatible
- `decode_as::<M>()` decodes into a type you generate from the `.proto` yourself
- `payload_hex()` / `from_payload_hex()` capture a frame and replay it verbatim in a test

## Compatibility — minor, not major

No public API is removed or changed. Everything added is new surface, and `RithmicMessage` is `#[non_exhaustive]`, so the added variant cannot break an existing match.

Verified rather than assumed: a consumer written against 2.0.0 — including one matching `RithmicMessage::Unknown` and `RithmicError::ProtocolError` — compiles unchanged against this branch.

The one behavioural difference is that code matching `RithmicMessage::Unknown` to catch unrecognized templates still compiles but no longer sees them; they arrive as `UnknownTemplate`. `Unknown` now means only that a frame failed to decode. That's a runtime behaviour change, not a source break.

Left under `## [Unreleased]` in the CHANGELOG, matching the repo's convention of bumping the version in a separate release-prep commit.

## Notes

- `decode_as` returning `Ok` is **not** proof the type was guessed right: protobuf skips undeclared fields, so an unrelated payload usually decodes into a mostly-empty value. Documented, and pinned by a test.
- The library's own `warn!` logs the template id and size only. The payload may carry account and order ids, and the caller now receives the frame, so what to log is left to them.
- `prost` is a public dependency (it already was, via the `rti` types), so a major bump of it remains a breaking change of this crate. Now stated explicitly.
- This does not decode 358 — it makes the frame recoverable so it can be identified. Checked against three independently-sourced proto sets: `igorrivin/rithmic` (template 3.7), `ff_rithmic_api` 0.2.4 (byte-identical message set to this crate's) and `async_rithmic` 1.6.3 (differs only by `ShowFillHistory` at 3512/3513). None defines anything in 357–400.
- Scope is deliberately limited to the decode path. An earlier revision also documented bracket-cancellation behaviour; those claims were inferred rather than verified against a live gateway, so they were dropped rather than shipped as library documentation.

## Verification

`cargo test` (174 unit + 15 doctests), `cargo clippy --all-targets --all-features`, `cargo fmt --check`, `cargo doc --no-deps` with `RUSTDOCFLAGS=-D warnings`, and `cargo +1.85 check --all-targets` for the declared MSRV — all clean.