### PR TITLE
docs: comments describe only what the code does; fix example listener and dead rejection arms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ Additive: no public API is removed or changed, so this lands in a 2.x minor rele
 
   This is a behavioural change, not a source-breaking one: code matching `RithmicMessage::Unknown` still compiles, but will no longer see unrecognized templates. Match `UnknownTemplate` for those; `Unknown` now means only that a frame failed to decode.
 - A frame carrying no `template_id` is still an error: prost does not enforce proto2 `required` on decode, so the missing field arrives as `0`, leaving no template to route it to.
+- **Documentation pass across the crate.** Comments and rustdoc now stick to what the code does, without describing server behaviour, citing external documents, or assuming familiarity with the wire protocol. No API changed.
+- **`RithmicAdvancedBracketOrder`'s rustdoc example no longer shows code that cannot compile downstream.** The struct is `#[non_exhaustive]`, so external crates cannot build it with a struct expression — including `..Default::default()` functional-update syntax. The example now starts from `Default` and assigns fields. It is fenced ```ignore, so nothing caught this.
+- **README samples no longer show incorrect API usage.** `cancel_order` takes a `RithmicCancelOrder`, not a bare id, and `place_bracket_order` had a literal `...` for its argument. The history plant block passed `&str` where those methods require owned `String`s and used `BarType` without importing it — it is not re-exported at the crate root. The blocks are still illustrative fragments rather than standalone programs, and are not doctested.
+
+### Fixed
+
+- **`examples/bracket_order.rs` no longer exits its listener on a recoverable error.** It broke out of the loop on any populated `update.error`, which a per-message decode failure also sets. Breaking there was redundant for the fatal cases — transport failure, forced logout and heartbeat timeout each arrive as their own `RithmicMessage` variant, which the listener already matches — so its only effect was that a single undecodable frame silently stopped order updates on a live bracket.
+- **Samples that handled a turned-down `subscribe` in an `Err` arm.** That arm can never match, so a `subscribe` the server turned down was reported as a success. Affects the crate-root docs, the `RithmicError` rustdoc, the README, `examples/reconnect.rs` and the 2.0.0 migration guide below. All now check `resp.error`, and show `Err(RequestRejected)` on `login`, which is the one call that returns it.
 
 ## [2.0.0]
 
@@ -54,23 +62,25 @@ match handle.subscribe("ESH6", "CME").await {
 After (2.0):
 ```rust
 match handle.subscribe("ESH6", "CME").await {
-    Ok(_) => { /* ... */ }
-    Err(RithmicError::RequestRejected(err)) => {
-        // Structured rp_code rejection — do NOT reconnect.
-        eprintln!(
-            "rejected code={} msg={}",
-            err.code.as_deref().unwrap_or("?"),
-            err.message.as_deref().unwrap_or(""),
-        );
-    }
-    Err(RithmicError::ProtocolError(msg)) => {
-        // Decode or non-rp_code protocol failure — do NOT reconnect.
-        eprintln!("protocol error: {msg}");
-    }
+    Ok(resp) => match &resp.error {
+        // A rejection now arrives here, not in an `Err` arm. Decode failures
+        // populate `error` too. Neither is a reconnect signal.
+        Some(err) => eprintln!("request failed: {err}"),
+        None => { /* success */ }
+    },
     Err(RithmicError::ConnectionClosed | RithmicError::SendFailed) => {
         // Transport failure — reconnect.
     }
     Err(e) => eprintln!("{e}"),
+}
+
+// `login` is the one call that returns this as `Err`:
+if let Err(RithmicError::RequestRejected(err)) = handle.login().await {
+    eprintln!(
+        "login rejected code={} msg={}",
+        err.code.as_deref().unwrap_or("?"),
+        err.message.as_deref().unwrap_or(""),
+    );
 }
 ```
 
@@ -111,8 +121,8 @@ match handle.subscribe("ESH6", "CME").await {
 - **Ping/heartbeat SEND transport failures** broadcast as `RithmicMessage::HeartbeatTimeout` (same signal as a true heartbeat timeout) instead of `ConnectionError`.
 - **`send_or_fail` timeout now drains all pending requests** and broadcasts `ConnectionError` before the next ping/heartbeat stops the actor. Previously only the single failing request was notified; remaining pending oneshots could hang on a half-open TCP connection since the poisoned sink is not guaranteed to surface through the reader.
 - **`RithmicError::SendFailed`** now also covers send timeouts — all plant WebSocket sends are bounded to 10 seconds; a hung sink surfaces as `SendFailed` rather than blocking the actor indefinitely
-- **`classify_rp_code` accepts `["0", <trailing>]` as success.** Per §2.1.b of the Rithmic R|Protocol Reference Guide, `rp_code[0] == "0"` is the authoritative success signal regardless of whether the server appends a trailing annotation. Previously `["0", "ok"]` was mis-classified as a rejection.
-- **`has_multiple` (multipart framing) now keys on presence, not value.** Per §3 of the Reference Guide, the presence of `rq_handler_rp_code` signals "more frames follow"; the value inside is not the multipart signal. Previously keying on `[0] == "0"` silently truncated multipart responses whose intermediate frames carried a non-`"0"` value.
+- **`classify_rp_code` accepts `["0", <trailing>]` as success.** Only the first element decides success; a trailing element does not change it. Previously `["0", "ok"]` was mis-classified as a rejection.
+- **`has_multiple` (multipart framing) now keys on presence, not value.** The presence of `rq_handler_rp_code` marks an intermediate frame; the value inside is not the multipart signal. Previously keying on `[0] == "0"` silently truncated multipart responses whose intermediate frames carried a non-`"0"` value.
 - **`load_ticks`** now delegates to `load_tick_bars` with `bar_length = 1` — no behavioral change for existing callers
 - **`request_tick_bar_replay`** on `RithmicSenderApi` now accepts a `bar_type_specifier` parameter instead of hard-coding `"1"`
 - **`examples/reconnect.rs` handles broadcast `RecvError::Lagged` explicitly** — a slow consumer that drops a connection-health frame through buffer wrap now logs and reconnects instead of silently exiting the read loop.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ let front_month = handle.get_front_month_contract("ES", "CME", false).await?;
 ```rust
 use rithmic_rs::{
     ConnectStrategy, NewOrderPriceType, NewOrderTransactionType, RithmicAccount,
-    RithmicConfig, RithmicEnv, RithmicOrder, RithmicOrderPlant,
+    RithmicCancelOrder, RithmicConfig, RithmicEnv, RithmicOrder, RithmicOrderPlant,
 };
 
 let config = RithmicConfig::from_env(RithmicEnv::Demo)?;
@@ -107,6 +107,7 @@ let account = RithmicAccount::from_env(RithmicEnv::Demo)?;
 let plant = RithmicOrderPlant::connect(&config, ConnectStrategy::Retry).await?;
 let mut handle = plant.get_handle(&account);
 handle.login().await?;
+handle.subscribe_order_updates().await?;
 
 // Place orders using the RithmicOrder API
 let order = RithmicOrder {
@@ -122,15 +123,20 @@ let order = RithmicOrder {
 handle.place_order(order).await?;
 
 // Bracket orders, OCO orders, advanced bracket orders
-handle.place_bracket_order(...).await?;
+handle.place_bracket_order(bracket_order).await?;
 handle.place_advanced_bracket_order(advanced_order).await?;
 
-// Manage positions
-handle.cancel_order(order_id).await?;
+// Cancel by the `basket_id` carried on the order notification
+handle.cancel_order(RithmicCancelOrder { id: basket_id }).await?;
+
+// Flatten by instrument, not by order
 handle.exit_position("ESM6", "CME").await?;
 ```
 
-For multi-account workflows, create one [`RithmicAccount`] per account and call
+Order state arrives on the subscription stream as `RithmicOrderNotification`
+updates, not in the response to the call.
+
+For multi-account workflows, create one `RithmicAccount` per account and call
 `get_handle(&account)` for each handle you need.
 
 ### Unrecognized message templates
@@ -155,12 +161,21 @@ if let RithmicMessage::UnknownTemplate(frame) = &update.message {
 ### History Plant
 
 ```rust
-// Load historical data (bar_type, period, start_time, end_time as i32 unix seconds)
-let bars = handle.load_time_bars("ESM6", "CME", BarType::MinuteBar, 5, start, end).await?;
-let ticks = handle.load_ticks("ESM6", "CME", start, end).await?;
+use rithmic_rs::rti::request_time_bar_replay::BarType;
+
+let symbol = "ESM6".to_string(); // Update to current front-month ES contract
+let exchange = "CME".to_string();
+
+// start_time / end_time are i32 unix seconds
+let bars = handle
+    .load_time_bars(symbol.clone(), exchange.clone(), BarType::MinuteBar, 5, start, end)
+    .await?;
+let ticks = handle
+    .load_ticks(symbol.clone(), exchange.clone(), start, end)
+    .await?;
 
 // Load N-tick bars (e.g., 5-tick bars)
-let tick_bars = handle.load_tick_bars("ESM6", "CME", 5, start, end).await?;
+let tick_bars = handle.load_tick_bars(symbol, exchange, 5, start, end).await?;
 ```
 
 ### PnL Plant
@@ -183,38 +198,34 @@ let snapshot = handle.pnl_position_snapshots().await?;
 
 ## Error Handling
 
-All plant handle methods return `Result<_, RithmicError>` with typed variants you can match on for recovery decisions:
-
 ```rust
 use rithmic_rs::RithmicError;
 
 match handle.subscribe("ESM6", "CME").await {
-    Ok(resp) => { /* success */ }
+    Ok(resp) => match &resp.error {
+        Some(err) => eprintln!("Server rejected: {}", err),
+        None => { /* success */ }
+    },
     Err(RithmicError::ConnectionClosed | RithmicError::SendFailed) => {
         handle.abort();
         // reconnect — see examples/reconnect.rs
     }
-    Err(RithmicError::InvalidArgument(msg)) => eprintln!("Bad argument: {}", msg),
-    Err(RithmicError::RequestRejected(err)) => {
-        eprintln!(
-            "Server rejected: code={} msg={}",
-            err.code.as_deref().unwrap_or("?"),
-            err.message.as_deref().unwrap_or(""),
-        );
-    }
-    Err(RithmicError::ProtocolError(msg)) => eprintln!("Protocol error: {}", msg),
     Err(e) => eprintln!("{}", e),
+}
+
+if let Err(RithmicError::RequestRejected(err)) = handle.login().await {
+    eprintln!(
+        "Login rejected: code={} msg={}",
+        err.code.as_deref().unwrap_or("?"),
+        err.message.as_deref().unwrap_or(""),
+    );
 }
 ```
 
 When inspecting a `RithmicResponse` directly (for example, entries from a
 subscription broadcast), match on `response.error` — it is `Option<RithmicError>`.
-Use [`RithmicError::is_connection_issue`] to distinguish transport failures from
-protocol rejections. The raw rp_code payload is also accessible:
-
-- `response.rp_code() -> Option<&[String]>` — full raw payload as received.
-- `response.rp_code_num() -> Option<&str>` — numeric code (first element).
-- `response.rp_code_text() -> Option<&str>` — human message (second element).
+Use `RithmicError::is_connection_issue` to distinguish transport failures from
+requests the server turned down.
 
 `RithmicError` implements `std::error::Error`, so `?` works in functions returning `Box<dyn Error>`.
 

--- a/examples/bracket_order.rs
+++ b/examples/bracket_order.rs
@@ -5,8 +5,7 @@
 //! - Profit target: limit order to take profits at a specified tick distance
 //! - Stop loss: stop order to limit losses at a specified tick distance
 //!
-//! When the entry fills, Rithmic automatically creates and links the profit and stop orders.
-//! When either the profit or stop fills, the other is automatically canceled.
+//! The listener below prints each order notification as it arrives.
 //!
 //! Run with: cargo run --example bracket_order
 
@@ -26,8 +25,7 @@ fn spawn_order_listener(mut receiver: SubscriptionFilter) {
             match receiver.recv().await {
                 Ok(update) => {
                     if let Some(error) = &update.error {
-                        info!("Connection error: {}", error);
-                        break;
+                        info!("Message error: {}", error);
                     }
 
                     match &update.message {

--- a/examples/reconnect.rs
+++ b/examples/reconnect.rs
@@ -3,10 +3,10 @@
 //! Sketches a production-shaped connection supervisor:
 //!
 //! - Transport failures reconnect with exponential backoff (capped at 60s).
-//! - `RequestRejected` on **login** is terminal (bad credentials / entitlements) —
-//!   retrying risks account lockout, so we log, disconnect, and exit.
-//! - `RequestRejected` on **subscribe** is per-symbol (e.g. unknown instrument) —
-//!   log it and keep going with the rest of the session.
+//! - `login` returns `Err(RequestRejected)` on a rejection; this example exits
+//!   rather than retrying.
+//! - `subscribe` returns `Ok` with `RithmicResponse::error` set on a rejection;
+//!   this example logs it and moves on to the next symbol.
 //! - Backoff resets after a session has produced real data for long enough to be
 //!   considered healthy, so a long-lived connection that drops doesn't inherit
 //!   a large backoff from earlier failures.
@@ -111,20 +111,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         for (symbol, exchange) in &subscriptions {
             match handle.subscribe(symbol, exchange).await {
-                Ok(_) => info!("Subscribed to {symbol} on {exchange}"),
+                Ok(resp) => match &resp.error {
+                    Some(err) => {
+                        warn!("Subscribe rejected for {symbol}/{exchange}: {err} — skipping")
+                    }
+                    None => info!("Subscribed to {symbol} on {exchange}"),
+                },
                 Err(RithmicError::ConnectionClosed | RithmicError::SendFailed) => {
                     warn!("Subscribe failed (connection lost), reconnecting…");
 
                     connection_lost = true;
 
                     break;
-                }
-                Err(RithmicError::RequestRejected(err)) => {
-                    warn!(
-                        "Subscribe rejected for {symbol}/{exchange}: code={} msg={} — skipping",
-                        err.code.as_deref().unwrap_or("?"),
-                        err.message.as_deref().unwrap_or(""),
-                    );
                 }
                 Err(e) => warn!("Subscribe error for {symbol}/{exchange}: {e}"),
             }

--- a/src/api/receiver_api.rs
+++ b/src/api/receiver_api.rs
@@ -1480,16 +1480,12 @@ impl RithmicReceiverApi {
     }
 }
 
-// Per the Rithmic R|Protocol Reference Guide (§3 "Responses From Server"):
-// a response message carries either `rq_hndlr_rp_code` OR `rp_code`, never
-// both. The *presence* of `rq_hndlr_rp_code` means more frames follow;
-// `rp_code` marks the terminal frame. The value inside `rq_handler_rp_code`
-// is not the multipart signal — presence is. Keying on `[0] == "0"` silently
-// truncates multipart responses whose intermediate frames carry a non-"0"
-// status.
+// The *presence* of `rq_handler_rp_code` is the multipart signal, not the value
+// inside it: keying on `[0] == "0"` truncates multipart responses whose
+// intermediate frames carry a non-"0" status.
 //
-// proto3 `repeated string` has no "absent" vs "empty" distinction on the wire,
-// so "presence" is equivalent to "non-empty".
+// A `repeated string` has no "absent" vs "empty" distinction on the wire, so
+// "presence" is equivalent to "non-empty".
 fn has_multiple(rq_handler_rp_code: &[String]) -> bool {
     !rq_handler_rp_code.is_empty()
 }
@@ -1636,11 +1632,8 @@ mod tests {
     // has_multiple() unit tests
     // =========================================================================
 
-    // Per §3 of the Rithmic Reference Guide, presence of `rq_hndlr_rp_code`
-    // (not any particular value) signals "more frames follow". Our has_multiple
-    // mirrors that: any non-empty slice means more frames follow; an empty
-    // slice means the field wasn't populated (terminal frame, rp_code is what
-    // gets inspected instead).
+    // has_multiple keys on presence, not value: any non-empty slice means more
+    // frames follow; an empty slice means the field wasn't populated.
 
     #[test]
     fn has_multiple_true_for_zero_only() {
@@ -1859,10 +1852,8 @@ mod tests {
 
     #[test]
     fn search_symbols_multipart_uses_rq_handler_field_presence_not_value() {
-        // Per §3 of the Rithmic Reference Guide, presence of `rq_handler_rp_code`
-        // on an intermediate multipart frame means "more frames follow",
-        // regardless of the value inside. The terminal frame carries `rp_code`
-        // instead (the two fields are mutually exclusive on the wire).
+        // Presence of `rq_handler_rp_code` marks an intermediate frame,
+        // regardless of the value inside.
         let api = RithmicReceiverApi {
             source: "test".to_string(),
         };

--- a/src/api/rithmic_command_types.rs
+++ b/src/api/rithmic_command_types.rs
@@ -33,8 +33,6 @@ pub struct LoginConfig {
 
 /// One leg of an OCO (One-Cancels-Other) order pair.
 ///
-/// When one leg fills, the other is automatically canceled.
-///
 /// # Example
 ///
 /// ```ignore
@@ -89,9 +87,6 @@ pub struct RithmicOcoOrderLeg {
 }
 
 /// Entry order with linked profit target and stop loss orders.
-///
-/// When the entry fills, the system creates the profit target and stop loss
-/// orders automatically.
 ///
 /// # Example
 ///
@@ -178,6 +173,10 @@ pub struct RithmicIfTouchedTrigger {
 ///
 /// # Example
 ///
+/// This struct is `#[non_exhaustive]`, so downstream crates cannot build it with
+/// a struct expression — including functional-update (`..Default::default()`)
+/// syntax. Start from [`Default`] and assign fields:
+///
 /// ```ignore
 /// use rithmic_rs::{
 ///     BracketCondition, BracketDuration, BracketPriceField, BracketPriceType,
@@ -185,37 +184,39 @@ pub struct RithmicIfTouchedTrigger {
 ///     RithmicIfTouchedTrigger,
 /// };
 ///
-/// let order = RithmicAdvancedBracketOrder {
-///     action: BracketTransactionType::Buy,
-///     duration: BracketDuration::Gtc,
+/// let mut order = RithmicAdvancedBracketOrder::default();
+///
+/// order.action = BracketTransactionType::Buy;
+/// order.duration = BracketDuration::Gtc;
+/// order.exchange = "CME".to_string();
+/// order.localid = "advanced-bracket-1".to_string();
+/// order.price_type = BracketPriceType::StopLimit;
+/// order.price = Some(5000.25);
+/// order.trigger_price = Some(4999.75);
+/// order.quantity = 3;
+/// order.symbol = "ESM6".to_string();
+///
+/// order.bracket_type = BracketType::TargetAndStop;
+/// order.target_quantity = vec![2, 1];
+/// order.target_ticks = vec![16, 24];
+/// order.stop_quantity = vec![3];
+/// order.stop_ticks = vec![8];
+///
+/// order.if_touched = Some(RithmicIfTouchedTrigger {
+///     symbol: "NQM6".to_string(),
 ///     exchange: "CME".to_string(),
-///     localid: "advanced-bracket-1".to_string(),
-///     price_type: BracketPriceType::StopLimit,
-///     price: Some(5000.25),
-///     trigger_price: Some(4999.75),
-///     quantity: 3,
-///     symbol: "ESM6".to_string(),
-///     bracket_type: BracketType::TargetAndStop,
-///     target_quantity: vec![2, 1],
-///     target_ticks: vec![16, 24],
-///     stop_quantity: vec![3],
-///     stop_ticks: vec![8],
-///     if_touched: Some(RithmicIfTouchedTrigger {
-///         symbol: "NQM6".to_string(),
-///         exchange: "CME".to_string(),
-///         condition: BracketCondition::GreaterThanEqualTo,
-///         price_field: BracketPriceField::TradePrice,
-///         price: 18250.5,
-///     }),
-///     break_even_ticks: Some(2),
-///     break_even_trigger_ticks: Some(10),
-///     trailing_stop_trigger_ticks: Some(12),
-///     target_market_order_if_touched: Some(true),
-///     stop_market_on_reject: Some(true),
-///     release_at_ssboe: Some(35900),
-///     cancel_after_secs: Some(120),
-///     ..Default::default()
-/// };
+///     condition: BracketCondition::GreaterThanEqualTo,
+///     price_field: BracketPriceField::TradePrice,
+///     price: 18250.5,
+/// });
+///
+/// order.break_even_ticks = Some(2);
+/// order.break_even_trigger_ticks = Some(10);
+/// order.trailing_stop_trigger_ticks = Some(12);
+/// order.target_market_order_if_touched = Some(true);
+/// order.stop_market_on_reject = Some(true);
+/// order.release_at_ssboe = Some(35900);
+/// order.cancel_after_secs = Some(120);
 /// ```
 #[non_exhaustive]
 #[derive(Debug, Clone)]
@@ -238,7 +239,7 @@ pub struct RithmicAdvancedBracketOrder {
     ///
     /// For a coherent bracket, this should equal the sum of
     /// `target_quantity` across all target legs. The crate does not validate
-    /// this invariant; Rithmic rejects inconsistent combinations.
+    /// this invariant.
     pub quantity: i32,
     /// Trading symbol (e.g., "ESH6").
     pub symbol: String,
@@ -414,9 +415,6 @@ pub struct RithmicCancelOrder {
 }
 
 /// Configuration for trailing stop orders.
-///
-/// When a trailing stop is configured, the stop price follows the market
-/// by the specified number of ticks.
 ///
 /// # Example
 ///

--- a/src/api/rp_code.rs
+++ b/src/api/rp_code.rs
@@ -125,9 +125,9 @@ pub(crate) fn response_rp_code_slice(message: &RithmicMessage) -> Option<&[Strin
 // decode test — e.g. `["7", "an error occurred while parsing data."]` shares
 // code "7" but is a real error.
 pub(crate) fn classify_rp_code(rp_code: &[String]) -> RpCodeClassification {
-    // Per §2.1.b, `rp_code[0] == "0"` is the authoritative success signal.
-    // Empty rp_code = success (defensive — multipart intermediates don't carry
-    // rp_code and short-circuit earlier, but this covers any edge case).
+    // `rp_code[0] == "0"` is the success signal. Empty rp_code is also treated
+    // as success (defensive — multipart intermediates don't carry rp_code and
+    // short-circuit earlier, but this covers any edge case).
     if rp_code.is_empty() || rp_code[0] == "0" {
         return RpCodeClassification::Success;
     }
@@ -290,10 +290,8 @@ mod tests {
 
     #[test]
     fn classify_rp_code_zero_with_trailing_annotation_is_success() {
-        // Per §2.1.b of the Rithmic Reference Guide, rp_code[0] == "0" is the
-        // authoritative success signal. A server that annotates success with
-        // a trailing message (e.g. ["0", "ok"] or ["0", ""]) must not be
-        // silently reclassified as a rejection.
+        // Only rp_code[0] decides success; a trailing element (e.g. ["0", "ok"]
+        // or ["0", ""]) must not be reclassified as a rejection.
         assert_eq!(
             classify_rp_code(&["0".to_string(), "ok".to_string()]),
             RpCodeClassification::Success

--- a/src/api/sender_api.rs
+++ b/src/api/sender_api.rs
@@ -806,13 +806,6 @@ impl RithmicSenderApi {
     /// # Returns
     ///
     /// A tuple containing the request buffer and the message id.
-    ///
-    /// # Note
-    ///
-    /// Large data requests may be truncated by the server. If the response contains
-    /// a round number of bars (e.g., 10 000) or does not cover the entire requested
-    /// time period, use [`request_resume_bars`](Self::request_resume_bars) with the
-    /// `request_key` from the response to fetch the remaining data.
     pub fn request_tick_bar_replay(
         &mut self,
         symbol: &str,
@@ -855,13 +848,6 @@ impl RithmicSenderApi {
     /// # Returns
     ///
     /// A tuple containing the request buffer and the message id
-    ///
-    /// # Note
-    ///
-    /// Large data requests may be truncated by the server. If the response contains
-    /// a round number of bars (e.g., 10000) or does not cover the entire requested
-    /// time period, use [`request_resume_bars`](Self::request_resume_bars) with the
-    /// `request_key` from the response to fetch the remaining data.
     pub fn request_time_bar_replay(
         &mut self,
         symbol: &str,
@@ -905,13 +891,6 @@ impl RithmicSenderApi {
     ///
     /// # Returns
     /// A tuple of (serialized request buffer, request ID)
-    ///
-    /// # Note
-    ///
-    /// Large data requests may be truncated by the server. If the response contains
-    /// a round number of bars (e.g., 10000) or does not cover the entire requested
-    /// time period, use [`request_resume_bars`](Self::request_resume_bars) with the
-    /// `request_key` from the response to fetch the remaining data.
     #[allow(clippy::too_many_arguments)]
     pub fn request_volume_profile_minute_bars(
         &mut self,
@@ -1405,8 +1384,7 @@ impl RithmicSenderApi {
 
     /// Request an OCO (One Cancels Other) order pair
     ///
-    /// Places two orders where if one is filled, the other is automatically cancelled.
-    /// This is commonly used for bracket-style trading (profit target and stop loss).
+    /// Builds a `RequestOcoOrder` carrying the two supplied legs.
     ///
     /// # Arguments
     /// * `order1` - First order leg
@@ -1467,8 +1445,7 @@ impl RithmicSenderApi {
 
     /// Request to link multiple orders together
     ///
-    /// Links orders so they are managed as a group. When one order is cancelled,
-    /// all linked orders are cancelled.
+    /// Links orders together by basket id.
     ///
     /// # Arguments
     /// * `basket_ids` - Vector of basket IDs to link together
@@ -1496,8 +1473,6 @@ impl RithmicSenderApi {
     }
 
     /// Request the easy-to-borrow list for short selling
-    ///
-    /// Returns a list of securities that are readily available for short selling.
     ///
     /// # Arguments
     /// * `request_type` - Subscribe or Unsubscribe from updates

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,27 +1,24 @@
 use std::fmt;
 
-/// Structured server-side rejection preserving both the Rithmic `rp_code`
-/// numeric code and the human-readable message.
+/// A request the server turned down, carrying the numeric code and the
+/// human-readable message separately so callers can branch on the code without
+/// parsing the message text.
 ///
-/// Rithmic returns request-level errors as a tuple `rp_code = [code, message]`;
-/// this struct keeps both pieces accessible so callers can branch on the
-/// numeric code (e.g. `"1039"` for "FCM Id field is not received") without
-/// parsing the string. The raw payload is preserved on [`Self::rp_code`] so
-/// consumers see exactly what the wire carried.
-///
-/// A populated `RithmicRequestError` is a **protocol-level** outcome — not a
-/// transport/connection failure. Receiving one must NOT trigger reconnection.
+/// This is a request-level outcome, not a connection failure. Receiving one
+/// does not mean the connection is unhealthy, so it is not a reason to
+/// reconnect.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct RithmicRequestError {
-    /// Raw rp_code payload exactly as received from Rithmic.
+    /// The response code exactly as received, before it is split into
+    /// [`Self::code`] and [`Self::message`].
     pub rp_code: Vec<String>,
-    /// First rp_code element when present.
+    /// Numeric code, when present.
     pub code: Option<String>,
-    /// Second rp_code element when present.
+    /// Human-readable message, when present.
     ///
-    /// `None` when the server emitted a single-element rp_code (e.g. `["5"]`).
-    /// Symmetric with [`Self::code`].
+    /// `None` when the response carried a code with no message. Symmetric with
+    /// [`Self::code`].
     pub message: Option<String>,
 }
 
@@ -55,22 +52,46 @@ impl std::error::Error for RithmicRequestError {}
 
 /// Typed errors returned by all plant handle methods.
 ///
+/// There are three outcomes to handle, not two:
+///
+/// - `Ok(resp)` with `resp.error == None` — the request succeeded.
+/// - `Ok(resp)` with `resp.error == Some(..)` — the request reached the server
+///   and the server turned it down.
+/// - `Err(..)` — the request could not be completed: an argument was invalid,
+///   the connection dropped, or no response came back.
+///
+/// The second case is the one that catches people out: a request the server
+/// turned down still returns `Ok`. Code that only checks for `Err` will treat
+/// it as a success. Check [`RithmicResponse::error`] to tell the first two
+/// apart.
+///
+/// `login` is the one call that returns it as
+/// `Err(`[`RequestRejected`](Self::RequestRejected)`)` instead — both cases are
+/// shown below.
+///
+/// [`RithmicResponse::error`]: crate::api::response::RithmicResponse::error
+///
 /// ```ignore
+/// // A `subscribe` the server turns down arrives as `Ok` with `error` set.
 /// match handle.subscribe("ESH6", "CME").await {
-///     Ok(resp) => { /* success */ }
+///     Ok(resp) => match &resp.error {
+///         Some(err) => eprintln!("rejected: {err}"),
+///         None => { /* success */ }
+///     },
 ///     Err(RithmicError::ConnectionClosed | RithmicError::SendFailed) => {
 ///         handle.abort();
 ///         // reconnect — see examples/reconnect.rs
 ///     }
-///     Err(RithmicError::InvalidArgument(msg)) => eprintln!("bad input: {msg}"),
-///     Err(RithmicError::RequestRejected(err)) => {
-///         eprintln!(
-///             "rejected code={} msg={}",
-///             err.code.as_deref().unwrap_or("?"),
-///             err.message.as_deref().unwrap_or(""),
-///         );
-///     }
 ///     Err(e) => eprintln!("{e}"),
+/// }
+///
+/// // A `login` the server turns down arrives as `Err`.
+/// if let Err(RithmicError::RequestRejected(err)) = handle.login().await {
+///     eprintln!(
+///         "login rejected code={} msg={}",
+///         err.code.as_deref().unwrap_or("?"),
+///         err.message.as_deref().unwrap_or(""),
+///     );
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -90,12 +111,12 @@ pub enum RithmicError {
     SendFailed,
     /// Server returned an empty response where at least one was expected.
     EmptyResponse,
-    /// Structured protocol-level rejection preserving the Rithmic `rp_code`
-    /// tuple. Not a reconnect signal — request-level only.
+    /// The server turned the request down, with the code and message it gave.
+    /// Request-level only — not a reason to reconnect.
     RequestRejected(RithmicRequestError),
-    /// Non-transport, non-rp_code response failure (e.g. decode failures or
-    /// other protocol-level outcomes that don't carry `rp_code`). Not a
-    /// reconnect signal.
+    /// A response arrived but could not be turned into a result — a decode
+    /// failure, or a failure the server reported without a code. Not a reason
+    /// to reconnect.
     ///
     /// An unrecognized `template_id` does not produce this error; it arrives as
     /// [`RithmicMessage::UnknownTemplate`](crate::rti::messages::RithmicMessage::UnknownTemplate).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,38 +108,37 @@
 //!
 //! ## Error Handling
 //!
-//! All plant handle methods return [`Result<_, RithmicError>`]. The [`RithmicError`] enum
-//! lets you programmatically distinguish error kinds:
+//! All plant handle methods return [`Result<_, RithmicError>`]. A request the
+//! server turns down still returns `Ok` — check `RithmicResponse::error` for it.
+//! `login` is the one call that returns it as `Err`:
 //!
 //! ```ignore
 //! use rithmic_rs::RithmicError;
 //!
 //! match handle.subscribe("ESM6", "CME").await {
-//!     Ok(resp) => { /* success */ }
+//!     Ok(resp) => match &resp.error {
+//!         Some(err) => eprintln!("Server rejected: {err}"),
+//!         None => { /* success */ }
+//!     },
 //!     Err(RithmicError::ConnectionClosed | RithmicError::SendFailed) => {
 //!         handle.abort();
 //!         // reconnect — see examples/reconnect.rs
 //!     }
-//!     Err(RithmicError::RequestRejected(err)) => {
-//!         eprintln!(
-//!             "Server rejected: code={} msg={}",
-//!             err.code.as_deref().unwrap_or("?"),
-//!             err.message.as_deref().unwrap_or(""),
-//!         );
-//!     }
-//!     Err(RithmicError::ProtocolError(msg)) => {
-//!         eprintln!("Protocol error: {msg}");
-//!     }
 //!     Err(e) => eprintln!("{e}"),
+//! }
+//!
+//! if let Err(RithmicError::RequestRejected(err)) = handle.login().await {
+//!     eprintln!(
+//!         "Login rejected: code={} msg={}",
+//!         err.code.as_deref().unwrap_or("?"),
+//!         err.message.as_deref().unwrap_or(""),
+//!     );
 //! }
 //! ```
 //!
 //! For inspecting a `RithmicResponse` directly, match on `response.error` — it
-//! is `Option<RithmicError>` with `RequestRejected` for rp_code rejections and
-//! `ProtocolError` for other non-transport failures. Use
-//! [`RithmicError::is_connection_issue`] to distinguish transport-level events
-//! that warrant reconnection. The raw rp_code payload is available via
-//! `response.rp_code()`, `response.rp_code_num()`, and `response.rp_code_text()`.
+//! is `Option<RithmicError>`. Use [`RithmicError::is_connection_issue`] to
+//! distinguish transport-level events that warrant reconnection.
 //!
 //! A graceful `disconnect().await` is separate from that reconnect path: it
 //! shuts the plant down without sending synthetic `HeartbeatTimeout` or

--- a/src/plants/core.rs
+++ b/src/plants/core.rs
@@ -373,10 +373,10 @@ where
                 }
             }
             Ok(Message::Ping(data)) => {
-                // RFC 6455 §5.5.3: a Ping must be answered with a Pong carrying
-                // the same payload.  With a split sink/stream the tungstenite
-                // internal write buffer is only flushed when the sink side is
-                // polled, so we send the Pong explicitly to guarantee delivery.
+                // Answer with a Pong carrying the same payload. With a split
+                // sink/stream the tungstenite internal write buffer is only
+                // flushed when the sink side is polled, so we send the Pong
+                // explicitly to guarantee delivery.
                 let source = self.rithmic_receiver_api.source.clone();
                 match send_with_timeout(
                     &mut self.rithmic_sender,

--- a/src/plants/history_plant.rs
+++ b/src/plants/history_plant.rs
@@ -700,13 +700,6 @@ impl RithmicHistoryPlantHandle {
     ///
     /// # Returns
     /// The historical tick data responses, or a [`RithmicError`] on failure.
-    ///
-    /// # Note
-    ///
-    /// Large requests may be truncated by the server. If the response contains a
-    /// round number of bars (e.g., 10 000) or does not cover the full time range,
-    /// use the `request_key` from the response with `request_resume_bars` on the
-    /// sender API to fetch the remaining data.
     pub async fn load_ticks(
         &self,
         symbol: String,
@@ -736,13 +729,6 @@ impl RithmicHistoryPlantHandle {
     /// # Errors
     /// * [`RithmicError::InvalidArgument`] if `bar_length` is 0.
     /// * [`RithmicError::ConnectionClosed`] if the history plant has shut down.
-    ///
-    /// # Note
-    ///
-    /// Large requests may be truncated by the server. If the response contains a
-    /// round number of bars (e.g., 10 000) or does not cover the full time range,
-    /// use the `request_key` from the response with `request_resume_bars` on the
-    /// sender API to fetch the remaining data.
     pub async fn load_tick_bars(
         &self,
         symbol: String,
@@ -853,12 +839,10 @@ impl RithmicHistoryPlantHandle {
         rx.await.map_err(|_| RithmicError::ConnectionClosed)?
     }
 
-    /// Resume a previously truncated bars request
-    ///
-    /// Use this when a bars request was truncated due to data limits.
+    /// Resume a bars request from a previous response's `request_key`.
     ///
     /// # Arguments
-    /// * `request_key` - The request key from the previous truncated response
+    /// * `request_key` - The `request_key` carried on the previous response
     ///
     /// # Returns
     /// The remaining bar data responses or an error message

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -225,10 +225,10 @@ pub(crate) enum OrderPlantCommand {
 /// # Connection Health Monitoring
 ///
 /// The subscription receiver provides connection health events:
-/// - **WebSocket ping/pong timeouts**: Primary indicator of dead connections (auto-detected)
-/// - **Heartbeat errors**: Only forwarded when Rithmic server returns an error (rare)
-/// - **Forced logout events**: Server-initiated disconnections requiring reconnection
-/// - **Order notifications**: Real-time order fills, cancellations, and status changes
+/// - **WebSocket ping/pong timeouts**: primary dead-connection signal (auto-detected)
+/// - **Heartbeat errors**: forwarded as `HeartbeatTimeout`
+/// - **Forced logout events**: session terminated by the server
+/// - **Order notifications**: real-time order fills, cancellations, and status changes
 ///
 /// **Note:** Heartbeat requests are sent automatically for protocol compliance,
 /// but successful responses are silently dropped. Only heartbeat errors from the server
@@ -1422,6 +1422,14 @@ impl RithmicOrderPlantHandle {
 
     /// Cancel an order
     ///
+    /// Resolves when the final frame of the response sequence arrives. That
+    /// result describes the request, not the order. Order state arrives
+    /// separately as [`RithmicOrderNotification`] updates on the subscription
+    /// stream; those carry an empty `request_id` and are broadcast to
+    /// subscribers, so they never resolve this call.
+    ///
+    /// [`RithmicOrderNotification`]: crate::rti::messages::RithmicMessage::RithmicOrderNotification
+    ///
     /// # Arguments
     /// * `order` - The cancel order parameters
     ///
@@ -1503,6 +1511,9 @@ impl RithmicOrderPlantHandle {
     }
 
     /// Request a list of all open orders
+    ///
+    /// The response is a `ResponseShowOrders`, which has no field for the
+    /// orders themselves.
     ///
     /// # Returns
     /// The order list response or an error message
@@ -1753,7 +1764,7 @@ impl RithmicOrderPlantHandle {
 
     /// Place an OCO (One Cancels Other) order pair
     ///
-    /// When one order is filled, the other is automatically cancelled.
+    /// This wrapper submits exactly two legs.
     ///
     /// # Arguments
     /// * `order1` - First order leg
@@ -1818,6 +1829,9 @@ impl RithmicOrderPlantHandle {
     ///
     /// This closes all open positions for the specified symbol/exchange.
     ///
+    /// Resolves when the final frame of the response sequence arrives. That
+    /// result describes the request, not the resulting orders.
+    ///
     /// # Arguments
     /// * `symbol` - The trading symbol (e.g., "ESH6")
     /// * `exchange` - The exchange code (e.g., "CME")
@@ -1844,8 +1858,6 @@ impl RithmicOrderPlantHandle {
     }
 
     /// Link multiple orders together
-    ///
-    /// When one linked order is cancelled, all linked orders are cancelled.
     ///
     /// # Arguments
     /// * `basket_ids` - Vector of basket IDs to link together

--- a/src/plants/ticker_plant.rs
+++ b/src/plants/ticker_plant.rs
@@ -199,15 +199,14 @@ impl TickerPlantCommand {
 /// # Connection Health Monitoring
 ///
 /// The subscription receiver provides connection health events:
-/// - **WebSocket ping/pong timeouts**: Primary indicator of dead connections (auto-detected)
-/// - **Heartbeat errors**: Only forwarded when Rithmic server returns an error (rare)
-/// - **Forced logout events**: Server-initiated disconnections requiring reconnection
-/// - **Market data updates**: Real-time trade and quote data
+/// - **WebSocket ping/pong timeouts**: primary dead-connection signal (auto-detected)
+/// - **Heartbeat errors**: forwarded as `HeartbeatTimeout`
+/// - **Forced logout events**: session terminated by the server
+/// - **Market data updates**: real-time trade and quote data
 ///
-/// **Note:** Heartbeat requests are sent automatically to comply with Rithmic's protocol,
-/// but successful responses are silently dropped. Only heartbeat errors from the server
-/// are forwarded as `HeartbeatTimeout` messages. The primary keep-alive mechanism is
-/// WebSocket ping/pong, which reliably detects dead connections 24/7.
+/// **Note:** Heartbeat requests are sent automatically for protocol compliance,
+/// but successful responses are dropped. Only heartbeat errors are forwarded as
+/// `HeartbeatTimeout` messages.
 ///
 /// # Example: Basic Usage
 ///
@@ -1379,11 +1378,8 @@ impl RithmicTickerPlantHandle {
 
     /// Subscribe to end-of-day price updates for a specific symbol.
     ///
-    /// Subscribes to `Close`, `Settlement`, `ProjectedSettlement`, and `AdjustedClose`.
-    /// The first three are delivered as real-time updates throughout the session.
-    /// `AdjustedClose` is a reference field and will not fire as a real-time callback;
-    /// it is included for end-of-session reconciliation use cases where its value is
-    /// populated after market close.
+    /// Sends the `Close`, `Settlement`, `ProjectedSettlement`, and
+    /// `AdjustedClose` update bits.
     ///
     /// # Arguments
     /// * `symbol` - The trading symbol (e.g., "ESH6")
@@ -1393,8 +1389,8 @@ impl RithmicTickerPlantHandle {
     /// The subscription response or an error message
     ///
     /// # Updates
-    /// After subscribing, close, settlement, and projected settlement updates arrive as
-    /// [`RithmicMessage::EndOfDayPrices`] on `subscription_receiver`.
+    /// Updates arrive as [`RithmicMessage::EndOfDayPrices`] on
+    /// `subscription_receiver`.
     pub async fn subscribe_end_of_day_prices(
         &self,
         symbol: &str,
@@ -1416,8 +1412,7 @@ impl RithmicTickerPlantHandle {
 
     /// Unsubscribe from end-of-day price updates for a specific symbol.
     ///
-    /// This reverses [`subscribe_end_of_day_prices`](Self::subscribe_end_of_day_prices),
-    /// including the non-streaming `AdjustedClose` reference field.
+    /// This reverses [`subscribe_end_of_day_prices`](Self::subscribe_end_of_day_prices).
     ///
     /// # Arguments
     /// * `symbol` - The trading symbol (e.g., "ESH6")


### PR DESCRIPTION
Companion to #66 (merged) — documentation and example defects found alongside it. One commit on top of `main`.

## Documentation pass

Comments and rustdoc now state only what the code does. Removed:

- **Server-behaviour claims** this crate cannot verify — OCO cancel-on-fill, link cancel-propagation, automatic bracket leg creation, `AdjustedClose` delivery, bar-replay truncation/resume, connection-health and rejection-shape notes. Deleted rather than hedged.
- **External-document citations** — vendor reference-guide sections (`§2.1.b`, `§3`, `§4`), a `.proto` filename, RFC 6455. Readers don't necessarily have those, and this project is unaffiliated with Rithmic.
- **`rp_code` as assumed knowledge** — named in passing across the crate-root docs, README, `RithmicError` and the order plant, where it explained nothing to a caller who has never seen the protocol. It now appears only where the crate classifies it (`src/api/rp_code.rs`) and on the accessors named after it, both unchanged.

`RithmicError`'s rustdoc states the three outcomes as a list rather than prose. `src/rti.rs` is generated and untouched.

## Fixed: `Err(RequestRejected)` arms that can never match

A request the server turns down returns `Ok` with `RithmicResponse::error` set; `Err` is reserved for transport failures. Exactly four sites crate-wide return it as `Err`, all in `login_with_config`.

Five samples handled a turned-down `subscribe` in an `Err(RequestRejected)` arm, reporting it as a success: the crate-root docs, the `RithmicError` rustdoc, the README, `examples/reconnect.rs`, and the 2.0.0 migration guide. All now check `resp.error` and show `Err` on `login`. Arms unreachable for the call they guard are gone too.

## Fixed: a listener that exited on a recoverable error

`examples/bracket_order.rs` broke out of its loop on any populated `update.error`, which a per-message decode failure also sets — and which was redundant for the fatal cases, since each arrives as its own `RithmicMessage` variant the listener already matches. One undecodable frame silently stopped order updates on a live bracket.

## Fixed: samples that could not compile

`RithmicAdvancedBracketOrder`'s example built a `#[non_exhaustive]` struct with a struct expression; it now starts from `Default`. In the README, `cancel_order` took a bare id, `place_bracket_order` had a literal `...`, and the history plant block passed `&str` where owned `String`s are required with `BarType` unimported. All are untested fragments, so nothing caught them. The README is back to getting-started weight.

## Review

Two principal-engineer passes, each of which blocked: a rustdoc that stated the rejection rule then violated it in its own example, seven surviving server-behaviour comments, a fifth instance of the `Err`-arm bug in the migration guide, and three false claims. All fixed. The doc-wording pass after the final sign-off is unreviewed.

## Verification

`cargo fmt --check`, `clippy -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo build --examples`, `cargo +1.85 check` (MSRV) — clean. `cargo test --all` — 189 passed, 21 ignored.

**Follow-up, not in this PR:** the `ESM6`/`ESH6` sample symbols are expired and appear in ~40 places. Worth its own sweep.
