### PR TITLE
docs: move unknown-template handling from README into rustdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,25 +139,6 @@ updates, not in the response to the call.
 For multi-account workflows, create one `RithmicAccount` per account and call
 `get_handle(&account)` for each handle you need.
 
-### Unrecognized message templates
-
-A `template_id` this crate has no definition for arrives as
-`RithmicMessage::UnknownTemplate` with `error: None`, carrying the message body
-as received:
-
-```rust
-if let RithmicMessage::UnknownTemplate(frame) = &update.message {
-    // template_id=358 (84 bytes) a2e135054d45535536aae13503434d45e2ed3506393231342d32faed35096361…+52B
-    tracing::warn!(payload = %frame.payload_hex(), "unmapped template: {frame}");
-
-    // Once you know what it maps to, generate the type from the .proto in your
-    // own crate; `rithmic_rs::prost` is re-exported so versions can't drift.
-    if let Ok(decoded) = frame.decode_as::<my_crate::Template358>() {
-        handle_it_yourself(decoded);
-    }
-}
-```
-
 ### History Plant
 
 ```rust

--- a/src/rti/messages.rs
+++ b/src/rti/messages.rs
@@ -176,6 +176,9 @@ pub enum RithmicMessage {
     ///
     /// The library logs only the template id and size; the payload may carry
     /// account and order ids, so what to log is left to the caller.
+    ///
+    /// [`UnknownTemplateMessage`] carries the handling API and an example of
+    /// logging and decoding one.
     UnknownTemplate(UnknownTemplateMessage),
 
     /// A frame that could not be decoded.

--- a/src/util/unknown_message.rs
+++ b/src/util/unknown_message.rs
@@ -14,6 +14,45 @@ const MAX_RENDERED_BYTES: usize = 32;
 /// still be handled downstream: [`decode_as`](Self::decode_as) decodes it into a
 /// type you generate yourself, and [`payload_hex`](Self::payload_hex) dumps it
 /// for later.
+///
+/// # Examples
+///
+/// A frame off a subscription stream arrives as
+/// [`RithmicMessage::UnknownTemplate`](crate::rti::messages::RithmicMessage::UnknownTemplate)
+/// with `error: None`. Log it, then decode it into a type generated in your own
+/// crate from the `.proto`; [`crate::prost`] is re-exported so the generated
+/// code can't drift from the version this crate decodes with.
+///
+/// ```
+/// use rithmic_rs::prost;
+/// use rithmic_rs::rti::messages::RithmicMessage;
+///
+/// // Generated in your crate by prost-build, once you know what 358 maps to.
+/// #[derive(Clone, PartialEq, prost::Message)]
+/// pub struct Template358 {
+///     #[prost(string, optional, tag = "110100")]
+///     pub symbol: Option<String>,
+/// }
+///
+/// fn on_message(message: &RithmicMessage) {
+///     let RithmicMessage::UnknownTemplate(frame) = message else {
+///         return;
+///     };
+///
+///     // template_id=358 (84 bytes) a2e135054d45535536aae13503434d45…+52B
+///     tracing::warn!(payload = %frame.payload_hex(), "unmapped template: {frame}");
+///
+///     if frame.template_id == 358 {
+///         if let Ok(decoded) = frame.decode_as::<Template358>() {
+///             println!("{:?}", decoded.symbol);
+///         }
+///     }
+/// }
+/// ```
+///
+/// [`payload_hex`](Self::payload_hex) is untruncated, so a frame captured in
+/// production can be replayed in a test through
+/// [`from_payload_hex`](Self::from_payload_hex).
 #[derive(Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct UnknownTemplateMessage {


### PR DESCRIPTION
The README's `### Unrecognized message templates` section read as a gap in the crate rather than an API note. Removed it; the sample now lives where the API does.

- `UnknownTemplateMessage` docblock gains an `# Examples` section: match the frame off a subscription stream, log `payload_hex()`, decode into a type generated in your own crate via `decode_as`. It compiles and runs as a doctest (`cargo test --doc unknown` → 1 passed), unlike the README snippet, which referenced a `my_crate::Template358` that never existed.
- `RithmicMessage::UnknownTemplate` points at that type for the handling API and example.

No code changes. `cargo clippy --all-targets --all-features` and `cargo doc --no-deps` are clean.