### PR TITLE
fix(plants): use the login heartbeat_interval as the heartbeat period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@ Public struct fields and a method signature change, so this lands in a major rel
 
 ### Fixed
 
+- **The `heartbeat_interval` in a login response is now used as the heartbeat period.** All four
+  plants took `hb.max(HEARTBEAT_SECS as f64)`, so the server's value only ever applied when it was
+  longer than the 60-second default: a server asking for a heartbeat every 30 seconds got one every
+  60 and dropped the connection as idle. The server's value is now used as given, and a period of 0
+  falls back to the 60-second default, as does a login response that carries no interval at all.
 - **`examples/bracket_order.rs` no longer exits its listener on a recoverable error.** It broke out of the loop on any populated `update.error`, which a per-message decode failure also sets. Breaking there was redundant for the fatal cases — transport failure, forced logout and heartbeat timeout each arrive as their own `RithmicMessage` variant, which the listener already matches — so its only effect was that a single undecodable frame silently stopped order updates on a live bracket.
 - **Samples that handled a turned-down `subscribe` in an `Err` arm.** That arm can never match, so a `subscribe` the server turned down was reported as a success. Affects the crate-root docs, the `RithmicError` rustdoc, the README, `examples/reconnect.rs` and the 2.0.0 migration guide below. All now check `resp.error`, and show `Err(RequestRejected)` on `login`, which is the one call that returns it.
 - **Single-order trailing stops now populate `trail_by_price_id`** (previously omitted, causing

--- a/src/plants/history_plant.rs
+++ b/src/plants/history_plant.rs
@@ -13,7 +13,7 @@ use crate::{
         messages::RithmicMessage, request_login::SysInfraType, request_tick_bar_update,
         request_time_bar_replay::BarType, request_time_bar_update,
     },
-    ws::{HEARTBEAT_SECS, PlantActor},
+    ws::PlantActor,
 };
 
 use tokio::{
@@ -635,7 +635,7 @@ impl RithmicHistoryPlantHandle {
 
         if let RithmicMessage::ResponseLogin(resp) = &response.message {
             if let Some(hb) = resp.heartbeat_interval {
-                let secs = hb.max(HEARTBEAT_SECS as f64) as u64;
+                let secs = hb as u64;
                 self.update_heartbeat(secs).await;
             }
 

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -24,7 +24,7 @@ use crate::{
         messages::RithmicMessage, request_account_rms_updates, request_easy_to_borrow_list,
         request_login::SysInfraType,
     },
-    ws::{HEARTBEAT_SECS, PlantActor},
+    ws::PlantActor,
 };
 
 use tokio::{
@@ -1279,7 +1279,7 @@ impl RithmicOrderPlantHandle {
 
         if let RithmicMessage::ResponseLogin(resp) = &response.message {
             if let Some(hb) = resp.heartbeat_interval {
-                let secs = hb.max(HEARTBEAT_SECS as f64) as u64;
+                let secs = hb as u64;
                 self.update_heartbeat(secs).await;
             }
 

--- a/src/plants/pnl_plant.rs
+++ b/src/plants/pnl_plant.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     request_handler::RithmicRequest,
     rti::{messages::RithmicMessage, request_login::SysInfraType, request_pn_l_position_updates},
-    ws::{HEARTBEAT_SECS, PlantActor},
+    ws::PlantActor,
 };
 
 use tokio::{
@@ -453,7 +453,7 @@ impl RithmicPnlPlantHandle {
 
         if let RithmicMessage::ResponseLogin(resp) = &response.message {
             if let Some(hb) = resp.heartbeat_interval {
-                let secs = hb.max(HEARTBEAT_SECS as f64) as u64;
+                let secs = hb as u64;
                 self.update_heartbeat(secs).await;
             }
 

--- a/src/plants/ticker_plant.rs
+++ b/src/plants/ticker_plant.rs
@@ -16,7 +16,7 @@ use crate::{
         request_market_data_update::{Request, UpdateBits},
         request_market_data_update_by_underlying, request_search_symbols,
     },
-    ws::{HEARTBEAT_SECS, PlantActor},
+    ws::PlantActor,
 };
 
 use tokio::{
@@ -884,7 +884,7 @@ impl RithmicTickerPlantHandle {
 
         if let RithmicMessage::ResponseLogin(resp) = &response.message {
             if let Some(hb) = resp.heartbeat_interval {
-                let secs = hb.max(HEARTBEAT_SECS as f64) as u64;
+                let secs = hb as u64;
                 self.update_heartbeat(secs).await;
             }
 

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -13,7 +13,8 @@ use tokio_tungstenite::{
     tungstenite::{Error, Message},
 };
 
-/// Number of seconds between heartbeats sent to the server.
+/// Number of seconds between heartbeats sent to the server when the login
+/// response carries no interval of its own.
 pub(crate) const HEARTBEAT_SECS: u64 = 60;
 
 /// Number of seconds between WebSocket ping frames sent to detect dead connections.
@@ -89,8 +90,15 @@ where
     }
 }
 
+/// Creates an interval for sending heartbeats.
+///
+/// `override_secs` is the period the server asked for in its login response.
+/// A period of 0 falls back to [`HEARTBEAT_SECS`], since `interval_at` panics
+/// on a zero period.
 pub(crate) fn get_heartbeat_interval(override_secs: Option<u64>) -> Interval {
-    let secs = override_secs.unwrap_or(HEARTBEAT_SECS);
+    let secs = override_secs
+        .filter(|secs| *secs > 0)
+        .unwrap_or(HEARTBEAT_SECS);
     let heartbeat_interval = Duration::from_secs(secs);
     let start_offset = Instant::now() + heartbeat_interval;
 
@@ -366,5 +374,25 @@ mod tests {
         .await;
 
         assert!(matches!(result, Err(WebSocketSendError::Timeout)));
+    }
+
+    #[tokio::test]
+    async fn get_heartbeat_interval_uses_the_server_period() {
+        assert_eq!(
+            get_heartbeat_interval(Some(30)).period(),
+            Duration::from_secs(30)
+        );
+        assert_eq!(
+            get_heartbeat_interval(Some(120)).period(),
+            Duration::from_secs(120)
+        );
+    }
+
+    #[tokio::test]
+    async fn get_heartbeat_interval_falls_back_to_the_default() {
+        let default = Duration::from_secs(HEARTBEAT_SECS);
+
+        assert_eq!(get_heartbeat_interval(None).period(), default);
+        assert_eq!(get_heartbeat_interval(Some(0)).period(), default);
     }
 }


### PR DESCRIPTION
## The issue

`HEARTBEAT_SECS = 60` is the default heartbeat period, and a login response can override it with its own `heartbeat_interval`. All four plants applied that override like this:

```rust
let secs = hb.max(HEARTBEAT_SECS as f64) as u64;
```

The `max` is backwards. It means the server's value only takes effect when it is *longer* than the default, so an override can only ever slow the heartbeat down, never speed it up. A server asking for a heartbeat every 30 seconds got one every 60 and dropped the connection as idle.

## The fix

Use the server's value as given:

```rust
let secs = hb as u64;
```

in the ticker, order, history and P&L plants. `get_heartbeat_interval` keeps `HEARTBEAT_SECS` as the default when the login response carries no interval, and now also falls back to it on a period of 0 — `interval_at` panics on a zero period, and a negative or non-finite `f64` saturates to 0 on the cast.

Two tests cover the interval that gets built: the server's period is used, and `None`/`0` fall back to the default. No public API change.