### PR TITLE
fix(plants): reject queued commands after close is requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,14 @@ Public struct fields and a method signature change, so this lands in a major rel
 
 ### Fixed
 
+- **The order and PnL plants now reject queued commands once a disconnect is in flight.** A
+  `PlaceOrder`, `ModifyOrder` or `CancelOrder` submitted from a cloned handle concurrently with
+  `disconnect()` was still serialized to Rithmic while its caller saw `ConnectionClosed` — a
+  recorded failure for an order that was live at the exchange. All four plants now apply the same
+  guard; no caller-visible change on the ticker and history plants, which already had one.
+- **`disconnect()` now sends `Close` even when the logout fails.** It returned early on a logout
+  error, leaving an actor that had already set `close_requested`: no heartbeats, every later command
+  dropped, pending requests never drained. All four plants send `Close` before propagating the error.
 - **The `heartbeat_interval` in a login response is now used as the heartbeat period.** All four
   plants took `hb.max(HEARTBEAT_SECS as f64)`, so the server's value only ever applied when it was
   longer than the 60-second default: a server asking for a heartbeat every 30 seconds got one every

--- a/src/plants.rs
+++ b/src/plants.rs
@@ -19,5 +19,7 @@ pub mod order_plant;
 pub mod pnl_plant;
 /// Account-scoped subscription helpers for shared order/PnL plants
 pub mod subscription;
+#[cfg(test)]
+pub(crate) mod test_support;
 /// Real-time market data subscription
 pub mod ticker_plant;

--- a/src/plants/core.rs
+++ b/src/plants/core.rs
@@ -573,12 +573,10 @@ where
         &mut self,
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
     ) {
-        // Flip `close_requested` before handing control to any later async step.
-        // The actor processes commands sequentially, so any command queued by a
-        // cloned handle *after* we dequeued `Logout` will find `close_requested`
-        // set and be rejected by `handle_command`'s guard. This closes the
-        // disconnect race where a concurrent `subscribe()` could slip between
-        // the Logout oneshot resolving and the Close command being sent.
+        // Flip `close_requested` before any later async step: the actor handles
+        // commands sequentially, so anything a cloned handle queues after
+        // `Logout` was dequeued finds it set and is dropped by the guard in
+        // every plant's `handle_command`.
         self.close_requested = true;
 
         let (logout_buf, id) = self.rithmic_sender_api.request_logout();

--- a/src/plants/history_plant.rs
+++ b/src/plants/history_plant.rs
@@ -1,6 +1,6 @@
 use futures_util::StreamExt;
 use tokio_tungstenite::tungstenite::Message;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     ConnectStrategy,
@@ -88,46 +88,6 @@ pub(crate) enum HistoryPlantCommand {
         request: request_tick_bar_update::Request,
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
     },
-}
-
-impl HistoryPlantCommand {
-    /// If the command carries a response sender, extract it; otherwise return
-    /// the command back to the caller unchanged.
-    ///
-    /// Used by the `close_requested` guard in `handle_command` to fail queued
-    /// requests fast once a disconnect is in flight.
-    fn into_response_sender_or_command(
-        self,
-    ) -> Result<oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>, Self> {
-        match self {
-            Self::ListSystemInfo { response_sender }
-            | Self::Login {
-                response_sender, ..
-            }
-            | Self::Logout { response_sender }
-            | Self::LoadTicks {
-                response_sender, ..
-            }
-            | Self::LoadTimeBars {
-                response_sender, ..
-            }
-            | Self::LoadVolumeProfileMinuteBars {
-                response_sender, ..
-            }
-            | Self::ResumeBars {
-                response_sender, ..
-            }
-            | Self::SubscribeTimeBarUpdates {
-                response_sender, ..
-            }
-            | Self::SubscribeTickBarUpdates {
-                response_sender, ..
-            } => Ok(response_sender),
-            other @ (Self::Close | Self::SetLogin | Self::UpdateHeartbeat { .. } | Self::Abort) => {
-                Err(other)
-            }
-        }
-    }
 }
 
 /// The RithmicHistoryPlant provides access to historical market data through the Rithmic API.
@@ -338,20 +298,21 @@ impl PlantActor for HistoryPlant {
     }
 
     async fn handle_command(&mut self, command: HistoryPlantCommand) {
-        // Disconnect race guard — see `TickerPlant::handle_command` for the
-        // rationale.
-        let command = if self.core.close_requested {
-            match command.into_response_sender_or_command() {
-                Ok(tx) => {
-                    let _ = tx.send(Err(RithmicError::ConnectionClosed));
+        // Disconnect race guard — see `TickerPlant::handle_command`.
+        if self.core.close_requested
+            && !matches!(
+                command,
+                HistoryPlantCommand::Close
+                    | HistoryPlantCommand::SetLogin
+                    | HistoryPlantCommand::UpdateHeartbeat { .. }
+                    | HistoryPlantCommand::Abort
+            )
+        {
+            debug!("history_plant: dropping a command queued after close was requested");
 
-                    return;
-                }
-                Err(cmd) => cmd,
-            }
-        } else {
-            command
-        };
+            return;
+        }
+
         match command {
             HistoryPlantCommand::Close => {
                 self.core.handle_close().await;
@@ -667,13 +628,15 @@ impl RithmicHistoryPlantHandle {
         };
 
         let _ = self.sender.send(command).await;
-        let response = rx
-            .await
-            .map_err(|_| RithmicError::ConnectionClosed)??
+        // Held rather than propagated here so that `Close` is queued either way —
+        // see `RithmicOrderPlantHandle::disconnect`.
+        let outcome = rx.await.map_err(|_| RithmicError::ConnectionClosed);
+        let _ = self.sender.send(HistoryPlantCommand::Close).await;
+
+        let response = outcome??
             .into_iter()
             .next()
             .ok_or(RithmicError::EmptyResponse)?;
-        let _ = self.sender.send(HistoryPlantCommand::Close).await;
 
         Ok(response)
     }
@@ -955,59 +918,4 @@ impl Clone for RithmicHistoryPlantHandle {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{HistoryPlantCommand, *};
-    use crate::error::RithmicError;
-
-    /// See the analogous ticker_plant test: the disconnect race guard in
-    /// `handle_command` depends on this contract.
-    #[test]
-    fn responder_bearing_variants_surface_sender() {
-        let (tx, _rx) = oneshot::channel();
-        let cmd = HistoryPlantCommand::LoadTicks {
-            bar_type_specifier: "1".to_string(),
-            end_time_sec: 1000,
-            exchange: "CME".to_string(),
-            response_sender: tx,
-            start_time_sec: 0,
-            symbol: "ESH6".to_string(),
-        };
-        assert!(cmd.into_response_sender_or_command().is_ok());
-    }
-
-    #[test]
-    fn fire_and_forget_variants_are_preserved() {
-        assert!(matches!(
-            HistoryPlantCommand::Close.into_response_sender_or_command(),
-            Err(HistoryPlantCommand::Close)
-        ));
-        assert!(matches!(
-            HistoryPlantCommand::Abort.into_response_sender_or_command(),
-            Err(HistoryPlantCommand::Abort)
-        ));
-    }
-
-    #[tokio::test]
-    async fn responder_drained_with_connection_closed() {
-        let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, RithmicError>>();
-        let cmd = HistoryPlantCommand::LoadTicks {
-            bar_type_specifier: "1".to_string(),
-            end_time_sec: 1000,
-            exchange: "CME".to_string(),
-            response_sender: tx,
-            start_time_sec: 0,
-            symbol: "ESH6".to_string(),
-        };
-
-        if let Ok(sender) = cmd.into_response_sender_or_command() {
-            let _ = sender.send(Err(RithmicError::ConnectionClosed));
-        } else {
-            panic!("LoadTicks must carry a responder");
-        }
-
-        assert!(matches!(
-            rx.await.unwrap(),
-            Err(RithmicError::ConnectionClosed)
-        ));
-    }
-}
+mod tests;

--- a/src/plants/history_plant/tests.rs
+++ b/src/plants/history_plant/tests.rs
@@ -1,0 +1,116 @@
+use tokio::net::TcpStream;
+
+use super::*;
+use crate::plants::test_support::{
+    self, Responder, assert_close_still_sent, assert_rejected_after_close, assert_sent_while_open,
+    assert_wire_silent,
+};
+
+async fn plant_with_wire() -> (HistoryPlant, mpsc::Sender<HistoryPlantCommand>, TcpStream) {
+    test_support::plant_with_wire("history_plant", |core, request_receiver| HistoryPlant {
+        core,
+        request_receiver,
+    })
+    .await
+}
+
+fn load_ticks(response_sender: Responder) -> HistoryPlantCommand {
+    HistoryPlantCommand::LoadTicks {
+        bar_type_specifier: "1".to_string(),
+        end_time_sec: 1000,
+        exchange: "CME".to_string(),
+        response_sender,
+        start_time_sec: 0,
+        symbol: "ESH6".to_string(),
+    }
+}
+
+#[tokio::test]
+async fn load_ticks_after_close_requested_is_not_sent() {
+    let (mut plant, _command_sender, mut client) = plant_with_wire().await;
+    plant.core.close_requested = true;
+
+    assert_rejected_after_close(&mut plant, &mut client, load_ticks).await;
+}
+
+#[tokio::test]
+async fn close_still_reaches_the_wire_after_close_requested() {
+    let (mut plant, _command_sender, mut client) = plant_with_wire().await;
+    plant.core.close_requested = true;
+
+    assert_close_still_sent(&mut plant, HistoryPlantCommand::Close, &mut client).await;
+}
+
+/// The same contract end to end through the public handle.
+#[tokio::test]
+async fn load_ticks_through_the_handle_after_close_requested_reports_connection_closed() {
+    let (mut plant, command_sender, mut client) = plant_with_wire().await;
+    plant.core.close_requested = true;
+
+    let subscription_sender = plant.core.subscription_sender.clone();
+    let handle = RithmicHistoryPlantHandle {
+        sender: command_sender,
+        subscription_receiver: subscription_sender.subscribe(),
+        subscription_sender,
+    };
+
+    let actor = tokio::spawn(async move { plant.run().await });
+
+    let err = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        handle.load_ticks("ESH6".to_string(), "CME".to_string(), 0, 1000),
+    )
+    .await
+    .expect("load_ticks must be answered, not left waiting")
+    .expect_err("load_ticks must fail once close was requested");
+
+    assert!(matches!(err, RithmicError::ConnectionClosed));
+    assert_wire_silent(&mut client).await;
+
+    handle.abort();
+    let _ = actor.await;
+}
+
+#[tokio::test]
+async fn load_ticks_is_sent_while_the_connection_is_open() {
+    let (mut plant, _command_sender, mut client) = plant_with_wire().await;
+
+    assert_sent_while_open(&mut plant, &mut client, load_ticks).await;
+}
+
+fn test_handle() -> (
+    RithmicHistoryPlantHandle,
+    mpsc::Receiver<HistoryPlantCommand>,
+) {
+    let (sender, command_receiver) = mpsc::channel(4);
+    let (subscription_sender, subscription_receiver) = broadcast::channel(4);
+
+    let handle = RithmicHistoryPlantHandle {
+        sender,
+        subscription_receiver,
+        subscription_sender,
+    };
+
+    (handle, command_receiver)
+}
+
+#[tokio::test]
+async fn disconnect_sends_close_even_when_logout_fails() {
+    let (handle, mut command_receiver) = test_handle();
+    let call = tokio::spawn(async move { handle.disconnect().await });
+
+    test_support::assert_close_follows_failed_logout(
+        &mut command_receiver,
+        |command| match command {
+            HistoryPlantCommand::Logout { response_sender } => Some(response_sender),
+            _ => None,
+        },
+        |command| matches!(command, HistoryPlantCommand::Close),
+    )
+    .await;
+
+    assert!(matches!(
+        call.await.expect("call task panicked"),
+        Err(RithmicError::SendFailed)
+    ));
+}

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use futures_util::StreamExt;
 use tokio_tungstenite::tungstenite::Message;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     ConnectStrategy,
@@ -482,6 +482,21 @@ impl PlantActor for OrderPlant {
     }
 
     async fn handle_command(&mut self, command: OrderPlantCommand) {
+        // Disconnect race guard — see `TickerPlant::handle_command`.
+        if self.core.close_requested
+            && !matches!(
+                command,
+                OrderPlantCommand::Close
+                    | OrderPlantCommand::SetLogin
+                    | OrderPlantCommand::UpdateHeartbeat { .. }
+                    | OrderPlantCommand::Abort
+            )
+        {
+            debug!("order_plant: dropping a command queued after close was requested");
+
+            return;
+        }
+
         match command {
             OrderPlantCommand::Close => {
                 self.core.handle_close().await;
@@ -1305,10 +1320,17 @@ impl RithmicOrderPlantHandle {
         };
 
         let _ = self.sender.send(command).await;
-        let r = rx.await.map_err(|_| RithmicError::ConnectionClosed)??;
+        // Held rather than propagated here so that `Close` is queued either way:
+        // `handle_logout` has already set `close_requested`, so an actor that
+        // never receives `Close` stops sending heartbeats, drops every later
+        // command, and never drains its pending requests.
+        let outcome = rx.await.map_err(|_| RithmicError::ConnectionClosed);
         let _ = self.sender.send(OrderPlantCommand::Close).await;
 
-        r.into_iter().next().ok_or(RithmicError::EmptyResponse)
+        outcome??
+            .into_iter()
+            .next()
+            .ok_or(RithmicError::EmptyResponse)
     }
 
     /// Immediately shut down the order plant actor without a graceful logout.
@@ -2261,85 +2283,4 @@ impl RithmicOrderPlantHandle {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::api::rithmic_command_types::RithmicOcoOrderLeg;
-
-    fn test_handle() -> (RithmicOrderPlantHandle, mpsc::Receiver<OrderPlantCommand>) {
-        let account = Arc::new(RithmicAccount::new("FCM_A", "IB_A", "ACCOUNT_A"));
-        let (sender, command_receiver) = mpsc::channel(4);
-        let (_, subscription_receiver) = broadcast::channel(4);
-
-        let handle = RithmicOrderPlantHandle {
-            account: account.clone(),
-            sender,
-            subscription_receiver: SubscriptionFilter::new(account, subscription_receiver),
-        };
-
-        (handle, command_receiver)
-    }
-
-    fn leg(tag: &str) -> RithmicOcoOrderLeg {
-        RithmicOcoOrderLeg {
-            symbol: "ESM6".to_string(),
-            exchange: "CME".to_string(),
-            quantity: 1,
-            price: 5000.0,
-            trigger_price: None,
-            transaction_type: crate::rti::request_oco_order::TransactionType::Buy,
-            duration: crate::rti::request_oco_order::Duration::Day,
-            price_type: crate::rti::request_oco_order::PriceType::Limit,
-            user_tag: tag.to_string(),
-            trailing_stop: None,
-        }
-    }
-
-    #[tokio::test]
-    async fn place_oco_order_multi_rejects_fewer_than_two_legs() {
-        for legs in [vec![], vec![leg("only")]] {
-            let (handle, mut command_receiver) = test_handle();
-
-            // Without the guard the command reaches the actor, which is not
-            // running here, and the call parks on its response channel. The
-            // timeout turns that into a failure instead of a hung suite.
-            let err = tokio::time::timeout(
-                std::time::Duration::from_secs(5),
-                handle.place_oco_order_multi(legs),
-            )
-            .await
-            .expect("must be rejected without reaching the actor")
-            .expect_err("fewer than two legs must be rejected");
-
-            assert!(matches!(err, RithmicError::InvalidArgument(_)));
-            // Rejected before reaching the actor, so nothing was queued.
-            assert!(command_receiver.try_recv().is_err());
-        }
-    }
-
-    #[tokio::test]
-    async fn place_oco_order_multi_forwards_two_or_more_legs() {
-        let (handle, mut command_receiver) = test_handle();
-
-        // The call parks on its response channel until the actor answers, so it
-        // has to run alongside the receive below rather than before it.
-        let call = tokio::spawn(async move {
-            handle
-                .place_oco_order_multi(vec![leg("a"), leg("b"), leg("c")])
-                .await
-        });
-
-        match command_receiver.recv().await {
-            Some(OrderPlantCommand::PlaceOcoOrderMulti { legs, .. }) => {
-                assert_eq!(legs.len(), 3);
-                assert_eq!(legs[2].user_tag, "c");
-                // Dropping the command drops the responder, which unparks the call.
-            }
-            _ => panic!("expected PlaceOcoOrderMulti to be queued"),
-        }
-
-        assert!(matches!(
-            call.await.expect("call task panicked"),
-            Err(RithmicError::ConnectionClosed)
-        ));
-    }
-}
+mod tests;

--- a/src/plants/order_plant/tests.rs
+++ b/src/plants/order_plant/tests.rs
@@ -1,0 +1,197 @@
+use tokio::net::TcpStream;
+
+use super::*;
+use crate::{
+    api::rithmic_command_types::RithmicOcoOrderLeg,
+    plants::test_support::{
+        self, Responder, assert_close_still_sent, assert_rejected_after_close,
+        assert_sent_while_open, assert_wire_silent, test_account,
+    },
+};
+
+fn test_handle() -> (RithmicOrderPlantHandle, mpsc::Receiver<OrderPlantCommand>) {
+    let account = test_account();
+    let (sender, command_receiver) = mpsc::channel(4);
+    let (_, subscription_receiver) = broadcast::channel(4);
+
+    let handle = RithmicOrderPlantHandle {
+        account: account.clone(),
+        sender,
+        subscription_receiver: SubscriptionFilter::new(account, subscription_receiver),
+    };
+
+    (handle, command_receiver)
+}
+
+fn leg(tag: &str) -> RithmicOcoOrderLeg {
+    RithmicOcoOrderLeg {
+        symbol: "ESM6".to_string(),
+        exchange: "CME".to_string(),
+        quantity: 1,
+        price: 5000.0,
+        trigger_price: None,
+        transaction_type: crate::rti::request_oco_order::TransactionType::Buy,
+        duration: crate::rti::request_oco_order::Duration::Day,
+        price_type: crate::rti::request_oco_order::PriceType::Limit,
+        user_tag: tag.to_string(),
+        trailing_stop: None,
+    }
+}
+
+async fn plant_with_wire() -> (OrderPlant, mpsc::Sender<OrderPlantCommand>, TcpStream) {
+    test_support::plant_with_wire("order_plant", |core, request_receiver| OrderPlant {
+        core,
+        request_receiver,
+    })
+    .await
+}
+
+fn place_order(response_sender: Responder) -> OrderPlantCommand {
+    OrderPlantCommand::PlaceOrder {
+        order: RithmicOrder::default(),
+        account: test_account(),
+        response_sender,
+    }
+}
+
+fn cancel_order(response_sender: Responder) -> OrderPlantCommand {
+    OrderPlantCommand::CancelOrder {
+        order_id: "basket-1".to_string(),
+        account: test_account(),
+        response_sender,
+    }
+}
+
+#[tokio::test]
+async fn place_oco_order_multi_rejects_fewer_than_two_legs() {
+    for legs in [vec![], vec![leg("only")]] {
+        let (handle, mut command_receiver) = test_handle();
+
+        // No actor is running, so without the guard this parks forever; the
+        // timeout turns that into a failure rather than a hung suite.
+        let err = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            handle.place_oco_order_multi(legs),
+        )
+        .await
+        .expect("must be rejected without reaching the actor")
+        .expect_err("fewer than two legs must be rejected");
+
+        assert!(matches!(err, RithmicError::InvalidArgument(_)));
+        // Rejected before reaching the actor, so nothing was queued.
+        assert!(command_receiver.try_recv().is_err());
+    }
+}
+
+#[tokio::test]
+async fn place_oco_order_multi_forwards_two_or_more_legs() {
+    let (handle, mut command_receiver) = test_handle();
+
+    // The call parks on its response channel until the actor answers, so it
+    // has to run alongside the receive below rather than before it.
+    let call = tokio::spawn(async move {
+        handle
+            .place_oco_order_multi(vec![leg("a"), leg("b"), leg("c")])
+            .await
+    });
+
+    match command_receiver.recv().await {
+        Some(OrderPlantCommand::PlaceOcoOrderMulti { legs, .. }) => {
+            assert_eq!(legs.len(), 3);
+            assert_eq!(legs[2].user_tag, "c");
+            // Dropping the command drops the responder, which unparks the call.
+        }
+        _ => panic!("expected PlaceOcoOrderMulti to be queued"),
+    }
+
+    assert!(matches!(
+        call.await.expect("call task panicked"),
+        Err(RithmicError::ConnectionClosed)
+    ));
+}
+
+#[tokio::test]
+async fn place_order_after_close_requested_is_not_sent() {
+    let (mut plant, _command_sender, mut client) = plant_with_wire().await;
+    plant.core.close_requested = true;
+
+    assert_rejected_after_close(&mut plant, &mut client, place_order).await;
+}
+
+#[tokio::test]
+async fn cancel_order_after_close_requested_is_not_sent() {
+    let (mut plant, _command_sender, mut client) = plant_with_wire().await;
+    plant.core.close_requested = true;
+
+    assert_rejected_after_close(&mut plant, &mut client, cancel_order).await;
+}
+
+#[tokio::test]
+async fn close_still_reaches_the_wire_after_close_requested() {
+    let (mut plant, _command_sender, mut client) = plant_with_wire().await;
+    plant.core.close_requested = true;
+
+    assert_close_still_sent(&mut plant, OrderPlantCommand::Close, &mut client).await;
+}
+
+/// The contract that matters: the order must not go live at the exchange while
+/// its caller records a failure.
+#[tokio::test]
+async fn place_order_through_the_handle_after_close_requested_reports_connection_closed() {
+    let (mut plant, command_sender, mut client) = plant_with_wire().await;
+    plant.core.close_requested = true;
+
+    let account = test_account();
+    let handle = RithmicOrderPlantHandle {
+        account: Arc::clone(&account),
+        sender: command_sender,
+        subscription_receiver: SubscriptionFilter::new(
+            account,
+            plant.core.subscription_sender.subscribe(),
+        ),
+    };
+
+    let actor = tokio::spawn(async move { plant.run().await });
+
+    let err = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        handle.place_order(RithmicOrder::default()),
+    )
+    .await
+    .expect("place_order must be answered, not left waiting")
+    .expect_err("place_order must fail once close was requested");
+
+    assert!(matches!(err, RithmicError::ConnectionClosed));
+    assert_wire_silent(&mut client).await;
+
+    handle.abort();
+    let _ = actor.await;
+}
+
+#[tokio::test]
+async fn place_order_is_sent_while_the_connection_is_open() {
+    let (mut plant, _command_sender, mut client) = plant_with_wire().await;
+
+    assert_sent_while_open(&mut plant, &mut client, place_order).await;
+}
+
+#[tokio::test]
+async fn disconnect_sends_close_even_when_logout_fails() {
+    let (handle, mut command_receiver) = test_handle();
+    let call = tokio::spawn(async move { handle.disconnect().await });
+
+    test_support::assert_close_follows_failed_logout(
+        &mut command_receiver,
+        |command| match command {
+            OrderPlantCommand::Logout { response_sender } => Some(response_sender),
+            _ => None,
+        },
+        |command| matches!(command, OrderPlantCommand::Close),
+    )
+    .await;
+
+    assert!(matches!(
+        call.await.expect("call task panicked"),
+        Err(RithmicError::SendFailed)
+    ));
+}

--- a/src/plants/pnl_plant.rs
+++ b/src/plants/pnl_plant.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use futures_util::StreamExt;
 use tokio_tungstenite::tungstenite::Message;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     ConnectStrategy,
@@ -271,6 +271,21 @@ impl PlantActor for PnlPlant {
     }
 
     async fn handle_command(&mut self, command: PnlPlantCommand) {
+        // Disconnect race guard — see `TickerPlant::handle_command`.
+        if self.core.close_requested
+            && !matches!(
+                command,
+                PnlPlantCommand::Close
+                    | PnlPlantCommand::SetLogin
+                    | PnlPlantCommand::UpdateHeartbeat { .. }
+                    | PnlPlantCommand::Abort
+            )
+        {
+            debug!("pnl_plant: dropping a command queued after close was requested");
+
+            return;
+        }
+
         match command {
             PnlPlantCommand::Close => {
                 self.core.handle_close().await;
@@ -485,10 +500,15 @@ impl RithmicPnlPlantHandle {
         };
 
         let _ = self.sender.send(command).await;
-        let r = rx.await.map_err(|_| RithmicError::ConnectionClosed)??;
+        // Held rather than propagated here so that `Close` is queued either way —
+        // see `RithmicOrderPlantHandle::disconnect`.
+        let outcome = rx.await.map_err(|_| RithmicError::ConnectionClosed);
         let _ = self.sender.send(PnlPlantCommand::Close).await;
 
-        r.into_iter().next().ok_or(RithmicError::EmptyResponse)
+        outcome??
+            .into_iter()
+            .next()
+            .ok_or(RithmicError::EmptyResponse)
     }
 
     /// Immediately shut down the PnL plant actor without a graceful logout.
@@ -563,3 +583,6 @@ impl RithmicPnlPlantHandle {
             .ok_or(RithmicError::EmptyResponse)
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/plants/pnl_plant/tests.rs
+++ b/src/plants/pnl_plant/tests.rs
@@ -1,0 +1,128 @@
+use tokio::net::TcpStream;
+
+use super::*;
+use crate::plants::test_support::{
+    self, Responder, assert_close_still_sent, assert_rejected_after_close, assert_sent_while_open,
+    assert_wire_silent, test_account,
+};
+
+async fn plant_with_wire() -> (PnlPlant, mpsc::Sender<PnlPlantCommand>, TcpStream) {
+    test_support::plant_with_wire("pnl_plant", |core, request_receiver| PnlPlant {
+        core,
+        request_receiver,
+    })
+    .await
+}
+
+fn subscribe_pnl_updates(response_sender: Responder) -> PnlPlantCommand {
+    PnlPlantCommand::SubscribePnlUpdates {
+        account: test_account(),
+        response_sender,
+    }
+}
+
+fn position_snapshots(response_sender: Responder) -> PnlPlantCommand {
+    PnlPlantCommand::PnlPositionSnapshots {
+        account: test_account(),
+        response_sender,
+    }
+}
+
+#[tokio::test]
+async fn subscribe_after_close_requested_is_not_sent() {
+    let (mut plant, _command_sender, mut client) = plant_with_wire().await;
+    plant.core.close_requested = true;
+
+    assert_rejected_after_close(&mut plant, &mut client, subscribe_pnl_updates).await;
+}
+
+#[tokio::test]
+async fn position_snapshots_after_close_requested_is_not_sent() {
+    let (mut plant, _command_sender, mut client) = plant_with_wire().await;
+    plant.core.close_requested = true;
+
+    assert_rejected_after_close(&mut plant, &mut client, position_snapshots).await;
+}
+
+#[tokio::test]
+async fn close_still_reaches_the_wire_after_close_requested() {
+    let (mut plant, _command_sender, mut client) = plant_with_wire().await;
+    plant.core.close_requested = true;
+
+    assert_close_still_sent(&mut plant, PnlPlantCommand::Close, &mut client).await;
+}
+
+/// The same contract end to end through the public handle.
+#[tokio::test]
+async fn subscribe_through_the_handle_after_close_requested_reports_connection_closed() {
+    let (mut plant, command_sender, mut client) = plant_with_wire().await;
+    plant.core.close_requested = true;
+
+    let account = test_account();
+    let handle = RithmicPnlPlantHandle {
+        account: Arc::clone(&account),
+        sender: command_sender,
+        subscription_receiver: SubscriptionFilter::new(
+            account,
+            plant.core.subscription_sender.subscribe(),
+        ),
+    };
+
+    let actor = tokio::spawn(async move { plant.run().await });
+
+    let err = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        handle.subscribe_pnl_updates(),
+    )
+    .await
+    .expect("subscribe_pnl_updates must be answered, not left waiting")
+    .expect_err("subscribe_pnl_updates must fail once close was requested");
+
+    assert!(matches!(err, RithmicError::ConnectionClosed));
+    assert_wire_silent(&mut client).await;
+
+    handle.abort();
+    let _ = actor.await;
+}
+
+#[tokio::test]
+async fn subscribe_is_sent_while_the_connection_is_open() {
+    let (mut plant, _command_sender, mut client) = plant_with_wire().await;
+
+    assert_sent_while_open(&mut plant, &mut client, subscribe_pnl_updates).await;
+}
+
+fn test_handle() -> (RithmicPnlPlantHandle, mpsc::Receiver<PnlPlantCommand>) {
+    let account = test_account();
+    let (sender, command_receiver) = mpsc::channel(4);
+    let (_, subscription_receiver) = broadcast::channel(4);
+
+    let handle = RithmicPnlPlantHandle {
+        account: Arc::clone(&account),
+        sender,
+        subscription_receiver: SubscriptionFilter::new(account, subscription_receiver),
+    };
+
+    (handle, command_receiver)
+}
+
+#[tokio::test]
+async fn disconnect_sends_close_even_when_logout_fails() {
+    let (handle, mut command_receiver) = test_handle();
+    let call = tokio::spawn(async move { handle.disconnect().await });
+
+    test_support::assert_close_follows_failed_logout(
+        &mut command_receiver,
+        |command| match command {
+            PnlPlantCommand::Logout { response_sender } => Some(response_sender),
+            _ => None,
+        },
+        |command| matches!(command, PnlPlantCommand::Close),
+    )
+    .await;
+
+    assert!(matches!(
+        call.await.expect("call task panicked"),
+        Err(RithmicError::SendFailed)
+    ));
+}

--- a/src/plants/test_support.rs
+++ b/src/plants/test_support.rs
@@ -1,0 +1,197 @@
+//! Scaffolding shared by the plant actor tests. Compiled only under `cfg(test)`.
+
+use std::{sync::Arc, time::Duration};
+
+use futures_util::StreamExt;
+use tokio::{
+    io::AsyncReadExt,
+    net::{TcpListener, TcpStream},
+    sync::{broadcast, mpsc, oneshot},
+};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, tungstenite::protocol::Role};
+
+use crate::{
+    api::{
+        receiver_api::{RithmicReceiverApi, RithmicResponse},
+        sender_api::RithmicSenderApi,
+    },
+    config::{RithmicAccount, RithmicConfig, RithmicEnv},
+    error::RithmicError,
+    ping_manager::PingManager,
+    plants::core::PlantCore,
+    request_handler::RithmicRequestHandler,
+    ws::{PING_TIMEOUT_SECS, PlantActor, get_heartbeat_interval, get_ping_interval},
+};
+
+const WIRE_WRITE_TIMEOUT: Duration = Duration::from_secs(5);
+const WIRE_SILENCE_WINDOW: Duration = Duration::from_millis(200);
+
+/// The response channel every request-bearing plant command carries.
+pub(crate) type Responder = oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>;
+
+pub(crate) fn test_account() -> Arc<RithmicAccount> {
+    Arc::new(RithmicAccount::new("FCM_A", "IB_A", "ACCOUNT_A"))
+}
+
+/// A logged-in `PlantCore` writing to the server half of a live loopback
+/// connection, returned with the client half so a test can watch the wire.
+pub(crate) async fn core_with_wire(source: &str) -> (PlantCore, TcpStream) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (client, server) =
+        tokio::join!(TcpStream::connect(addr), async { listener.accept().await });
+    let client = client.unwrap();
+    let (server, _) = server.unwrap();
+
+    let server_ws =
+        WebSocketStream::from_raw_socket(MaybeTlsStream::Plain(server), Role::Server, None).await;
+    let (rithmic_sender, rithmic_reader) = server_ws.split();
+
+    let config = RithmicConfig::builder(RithmicEnv::Demo)
+        .user("test_user")
+        .password("test_password")
+        .url("ws://localhost:9999")
+        .beta_url("ws://localhost:9998")
+        .app_name("test_app")
+        .app_version("1.0")
+        .build()
+        .unwrap();
+
+    let (subscription_sender, _sub_rx) = broadcast::channel(16);
+    let rithmic_sender_api = RithmicSenderApi::new(&config);
+
+    let core = PlantCore {
+        config,
+        close_requested: false,
+        interval: get_heartbeat_interval(None),
+        logged_in: true,
+        ping_interval: get_ping_interval(None),
+        ping_manager: PingManager::new(PING_TIMEOUT_SECS),
+        request_handler: RithmicRequestHandler::new(),
+        rithmic_reader,
+        rithmic_receiver_api: RithmicReceiverApi {
+            source: source.to_string(),
+        },
+        rithmic_sender,
+        rithmic_sender_api,
+        subscription_sender,
+    };
+
+    (core, client)
+}
+
+/// A plant actor built on `core_with_wire`, returned with its command sender and
+/// the client half of the socket.
+pub(crate) async fn plant_with_wire<P, C>(
+    source: &str,
+    build: impl FnOnce(PlantCore, mpsc::Receiver<C>) -> P,
+) -> (P, mpsc::Sender<C>, TcpStream) {
+    let (core, client) = core_with_wire(source).await;
+    let (command_sender, request_receiver) = mpsc::channel(4);
+
+    (build(core, request_receiver), command_sender, client)
+}
+
+/// Feeds a request to a plant whose close is already requested: it must put no
+/// bytes on the wire, and its caller must be answered `ConnectionClosed`.
+pub(crate) async fn assert_rejected_after_close<P: PlantActor>(
+    plant: &mut P,
+    client: &mut TcpStream,
+    build: impl FnOnce(Responder) -> P::Command,
+) {
+    let (tx, rx) = oneshot::channel();
+    plant.handle_command(build(tx)).await;
+
+    assert_wire_silent(client).await;
+    assert!(matches!(
+        awaited_caller_outcome(rx).await,
+        Err(RithmicError::ConnectionClosed)
+    ));
+}
+
+/// `Close` carries no responder and must still reach `handle_close()`.
+pub(crate) async fn assert_close_still_sent<P: PlantActor>(
+    plant: &mut P,
+    close: P::Command,
+    client: &mut TcpStream,
+) {
+    plant.handle_command(close).await;
+
+    assert_wire_wrote(client, "Close must still send the WebSocket Close frame").await;
+}
+
+/// Fails the `Logout` a `disconnect()` queued, then asserts it still queues
+/// `Close`. Without that `Close` the actor is left with `close_requested`
+/// already set: no heartbeats, every later command dropped, pending requests
+/// never drained.
+pub(crate) async fn assert_close_follows_failed_logout<C>(
+    command_receiver: &mut mpsc::Receiver<C>,
+    logout_responder: impl FnOnce(C) -> Option<Responder>,
+    is_close: impl FnOnce(&C) -> bool,
+) {
+    let logout = command_receiver
+        .recv()
+        .await
+        .expect("disconnect must queue a command");
+    let responder = logout_responder(logout).expect("disconnect must queue Logout first");
+    let _ = responder.send(Err(RithmicError::SendFailed));
+
+    let next = command_receiver
+        .recv()
+        .await
+        .expect("disconnect must queue Close even when logout fails");
+
+    assert!(
+        is_close(&next),
+        "disconnect must send Close even when logout fails"
+    );
+}
+
+/// Positive control — the same request on an open connection does reach the
+/// wire, so a silent wire above is evidence rather than a blind harness.
+pub(crate) async fn assert_sent_while_open<P: PlantActor>(
+    plant: &mut P,
+    client: &mut TcpStream,
+    build: impl FnOnce(Responder) -> P::Command,
+) {
+    let (tx, _rx) = oneshot::channel();
+    plant.handle_command(build(tx)).await;
+
+    assert_wire_wrote(
+        client,
+        "an open connection must still serialize the request",
+    )
+    .await;
+}
+
+/// Fails if anything is written to `client` within the silence window.
+pub(crate) async fn assert_wire_silent(client: &mut TcpStream) {
+    let mut buf = [0u8; 128];
+    let read = tokio::time::timeout(WIRE_SILENCE_WINDOW, client.read(&mut buf)).await;
+
+    assert!(
+        read.is_err(),
+        "a command was serialized to the wire after close was requested: {:?}",
+        read.map(|r| r.map(|n| &buf[..n]))
+    );
+}
+
+/// Fails if nothing is written to `client` before the write timeout.
+pub(crate) async fn assert_wire_wrote(client: &mut TcpStream, expectation: &str) {
+    let mut buf = [0u8; 128];
+    let read = tokio::time::timeout(WIRE_WRITE_TIMEOUT, client.read(&mut buf)).await;
+
+    assert!(matches!(read, Ok(Ok(n)) if n > 0), "{expectation}");
+}
+
+/// Resolves a response channel the way every plant handle method does: a
+/// dropped responder becomes `ConnectionClosed`. Fails rather than hangs.
+pub(crate) async fn awaited_caller_outcome(
+    rx: oneshot::Receiver<Result<Vec<RithmicResponse>, RithmicError>>,
+) -> Result<Vec<RithmicResponse>, RithmicError> {
+    tokio::time::timeout(WIRE_WRITE_TIMEOUT, async {
+        rx.await.map_err(|_| RithmicError::ConnectionClosed)?
+    })
+    .await
+    .expect("the caller must be given an answer, not left waiting")
+}

--- a/src/plants/ticker_plant.rs
+++ b/src/plants/ticker_plant.rs
@@ -1,6 +1,6 @@
 use futures_util::StreamExt;
 use tokio_tungstenite::tungstenite::Message;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     ConnectStrategy,
@@ -119,74 +119,6 @@ pub(crate) enum TickerPlantCommand {
         system_name: Option<String>,
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
     },
-}
-
-impl TickerPlantCommand {
-    /// If the command carries a response sender, extract it; otherwise return
-    /// the command back to the caller unchanged.
-    ///
-    /// Used by the `close_requested` guard in `handle_command` to fail queued
-    /// requests fast once a disconnect is in flight, rather than sending them
-    /// to a server we're about to leave. Non-responder commands (`Close`,
-    /// `SetLogin`, `UpdateHeartbeat`, `Abort`) are returned so the actor can
-    /// still process them — `Close` in particular must still reach
-    /// `handle_close()` to send the WS Close frame.
-    fn into_response_sender_or_command(
-        self,
-    ) -> Result<oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>, Self> {
-        match self {
-            Self::ListSystemInfo { response_sender }
-            | Self::Login {
-                response_sender, ..
-            }
-            | Self::Logout { response_sender }
-            | Self::Subscribe {
-                response_sender, ..
-            }
-            | Self::SubscribeOrderBook {
-                response_sender, ..
-            }
-            | Self::RequestDepthByOrderSnapshot {
-                response_sender, ..
-            }
-            | Self::SearchSymbols {
-                response_sender, ..
-            }
-            | Self::ListExchanges {
-                response_sender, ..
-            }
-            | Self::GetInstrumentByUnderlying {
-                response_sender, ..
-            }
-            | Self::SubscribeByUnderlying {
-                response_sender, ..
-            }
-            | Self::GetTickSizeTypeTable {
-                response_sender, ..
-            }
-            | Self::GetProductCodes {
-                response_sender, ..
-            }
-            | Self::GetVolumeAtPrice {
-                response_sender, ..
-            }
-            | Self::GetAuxilliaryReferenceData {
-                response_sender, ..
-            }
-            | Self::GetReferenceData {
-                response_sender, ..
-            }
-            | Self::GetFrontMonthContract {
-                response_sender, ..
-            }
-            | Self::GetSystemGatewayInfo {
-                response_sender, ..
-            } => Ok(response_sender),
-            other @ (Self::Close | Self::SetLogin | Self::UpdateHeartbeat { .. } | Self::Abort) => {
-                Err(other)
-            }
-        }
-    }
 }
 
 /// The RithmicTickerPlant provides access to real-time market data.
@@ -441,25 +373,23 @@ impl PlantActor for TickerPlant {
     }
 
     async fn handle_command(&mut self, command: TickerPlantCommand) {
-        // Disconnect race guard: once `close_requested` is set (by `handle_logout`
-        // or `handle_close`), any request-bearing command queued by a cloned
-        // handle is rejected fast instead of being sent to a server we're
-        // about to leave. `Close` / `SetLogin` / `UpdateHeartbeat` / `Abort`
-        // have no responder, so they fall through and execute normally — in
-        // particular, `Close` still reaches `handle_close()` to send the WS
-        // Close frame.
-        let command = if self.core.close_requested {
-            match command.into_response_sender_or_command() {
-                Ok(tx) => {
-                    let _ = tx.send(Err(RithmicError::ConnectionClosed));
+        // Drop a request queued after `close_requested`; handles report the dropped
+        // responder as `ConnectionClosed`. The listed variants carry none and must
+        // still run — `Close` has to reach `handle_close()`. All four plants alike.
+        if self.core.close_requested
+            && !matches!(
+                command,
+                TickerPlantCommand::Close
+                    | TickerPlantCommand::SetLogin
+                    | TickerPlantCommand::UpdateHeartbeat { .. }
+                    | TickerPlantCommand::Abort
+            )
+        {
+            debug!("ticker_plant: dropping a command queued after close was requested");
 
-                    return;
-                }
-                Err(cmd) => cmd,
-            }
-        } else {
-            command
-        };
+            return;
+        }
+
         match command {
             TickerPlantCommand::Close => {
                 self.core.handle_close().await;
@@ -910,9 +840,15 @@ impl RithmicTickerPlantHandle {
         };
 
         let _ = self.sender.send(command).await;
-        let r = rx.await.map_err(|_| RithmicError::ConnectionClosed)??;
+        // Held rather than propagated here so that `Close` is queued either way —
+        // see `RithmicOrderPlantHandle::disconnect`.
+        let outcome = rx.await.map_err(|_| RithmicError::ConnectionClosed);
         let _ = self.sender.send(TickerPlantCommand::Close).await;
-        let response = r.into_iter().next().ok_or(RithmicError::EmptyResponse)?;
+
+        let response = outcome??
+            .into_iter()
+            .next()
+            .ok_or(RithmicError::EmptyResponse)?;
         let _ = self.subscription_sender.send(response.clone());
 
         Ok(response)
@@ -1902,71 +1838,4 @@ impl Clone for RithmicTickerPlantHandle {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{TickerPlantCommand, *};
-    use crate::{
-        error::RithmicError,
-        rti::request_market_data_update::{Request, UpdateBits},
-    };
-
-    /// The disconnect race is closed by `handle_command` guarding on
-    /// `core.close_requested`. That guard uses `into_response_sender_or_command`
-    /// to pluck the responder out of request-bearing commands and drop them
-    /// with `ConnectionClosed` — so every request-bearing variant MUST return
-    /// `Ok(sender)`, and every fire-and-forget variant MUST return `Err(cmd)`
-    /// so that, e.g., `Close` still reaches `handle_close`.
-    #[test]
-    fn responder_bearing_variants_surface_sender() {
-        let (tx, _rx) = oneshot::channel();
-        let cmd = TickerPlantCommand::Subscribe {
-            symbol: "ESH6".to_string(),
-            exchange: "CME".to_string(),
-            fields: vec![UpdateBits::LastTrade],
-            request_type: Request::Subscribe,
-            response_sender: tx,
-        };
-        assert!(cmd.into_response_sender_or_command().is_ok());
-    }
-
-    #[test]
-    fn fire_and_forget_variants_are_preserved() {
-        assert!(matches!(
-            TickerPlantCommand::Close.into_response_sender_or_command(),
-            Err(TickerPlantCommand::Close)
-        ));
-        assert!(matches!(
-            TickerPlantCommand::Abort.into_response_sender_or_command(),
-            Err(TickerPlantCommand::Abort)
-        ));
-        assert!(matches!(
-            TickerPlantCommand::SetLogin.into_response_sender_or_command(),
-            Err(TickerPlantCommand::SetLogin)
-        ));
-    }
-
-    /// Reproduces the guard's outcome for a Subscribe queued after
-    /// `close_requested=true`: the responder resolves with
-    /// `RithmicError::ConnectionClosed` instead of hitting Rithmic.
-    #[tokio::test]
-    async fn responder_drained_with_connection_closed() {
-        let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, RithmicError>>();
-        let cmd = TickerPlantCommand::Subscribe {
-            symbol: "ESH6".to_string(),
-            exchange: "CME".to_string(),
-            fields: vec![UpdateBits::LastTrade],
-            request_type: Request::Subscribe,
-            response_sender: tx,
-        };
-
-        if let Ok(sender) = cmd.into_response_sender_or_command() {
-            let _ = sender.send(Err(RithmicError::ConnectionClosed));
-        } else {
-            panic!("Subscribe must carry a responder");
-        }
-
-        assert!(matches!(
-            rx.await.unwrap(),
-            Err(RithmicError::ConnectionClosed)
-        ));
-    }
-}
+mod tests;

--- a/src/plants/ticker_plant/tests.rs
+++ b/src/plants/ticker_plant/tests.rs
@@ -1,0 +1,115 @@
+use tokio::net::TcpStream;
+
+use super::*;
+use crate::{
+    plants::test_support::{
+        self, Responder, assert_close_still_sent, assert_rejected_after_close,
+        assert_sent_while_open, assert_wire_silent,
+    },
+    rti::request_market_data_update::{Request, UpdateBits},
+};
+
+async fn plant_with_wire() -> (TickerPlant, mpsc::Sender<TickerPlantCommand>, TcpStream) {
+    test_support::plant_with_wire("ticker_plant", |core, request_receiver| TickerPlant {
+        core,
+        request_receiver,
+    })
+    .await
+}
+
+fn subscribe(response_sender: Responder) -> TickerPlantCommand {
+    TickerPlantCommand::Subscribe {
+        symbol: "ESH6".to_string(),
+        exchange: "CME".to_string(),
+        fields: vec![UpdateBits::LastTrade],
+        request_type: Request::Subscribe,
+        response_sender,
+    }
+}
+
+#[tokio::test]
+async fn subscribe_after_close_requested_is_not_sent() {
+    let (mut plant, _command_sender, mut client) = plant_with_wire().await;
+    plant.core.close_requested = true;
+
+    assert_rejected_after_close(&mut plant, &mut client, subscribe).await;
+}
+
+#[tokio::test]
+async fn close_still_reaches_the_wire_after_close_requested() {
+    let (mut plant, _command_sender, mut client) = plant_with_wire().await;
+    plant.core.close_requested = true;
+
+    assert_close_still_sent(&mut plant, TickerPlantCommand::Close, &mut client).await;
+}
+
+/// The same contract end to end through the public handle.
+#[tokio::test]
+async fn subscribe_through_the_handle_after_close_requested_reports_connection_closed() {
+    let (mut plant, command_sender, mut client) = plant_with_wire().await;
+    plant.core.close_requested = true;
+
+    let subscription_sender = plant.core.subscription_sender.clone();
+    let handle = RithmicTickerPlantHandle {
+        sender: command_sender,
+        subscription_receiver: subscription_sender.subscribe(),
+        subscription_sender,
+    };
+
+    let actor = tokio::spawn(async move { plant.run().await });
+
+    let err = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        handle.subscribe("ESH6", "CME"),
+    )
+    .await
+    .expect("subscribe must be answered, not left waiting")
+    .expect_err("subscribe must fail once close was requested");
+
+    assert!(matches!(err, RithmicError::ConnectionClosed));
+    assert_wire_silent(&mut client).await;
+
+    handle.abort();
+    let _ = actor.await;
+}
+
+#[tokio::test]
+async fn subscribe_is_sent_while_the_connection_is_open() {
+    let (mut plant, _command_sender, mut client) = plant_with_wire().await;
+
+    assert_sent_while_open(&mut plant, &mut client, subscribe).await;
+}
+
+fn test_handle() -> (RithmicTickerPlantHandle, mpsc::Receiver<TickerPlantCommand>) {
+    let (sender, command_receiver) = mpsc::channel(4);
+    let (subscription_sender, subscription_receiver) = broadcast::channel(4);
+
+    let handle = RithmicTickerPlantHandle {
+        sender,
+        subscription_receiver,
+        subscription_sender,
+    };
+
+    (handle, command_receiver)
+}
+
+#[tokio::test]
+async fn disconnect_sends_close_even_when_logout_fails() {
+    let (handle, mut command_receiver) = test_handle();
+    let call = tokio::spawn(async move { handle.disconnect().await });
+
+    test_support::assert_close_follows_failed_logout(
+        &mut command_receiver,
+        |command| match command {
+            TickerPlantCommand::Logout { response_sender } => Some(response_sender),
+            _ => None,
+        },
+        |command| matches!(command, TickerPlantCommand::Close),
+    )
+    .await;
+
+    assert!(matches!(
+        call.await.expect("call task panicked"),
+        Err(RithmicError::SendFailed)
+    ));
+}


### PR DESCRIPTION
## Issue

`handle_logout` sets `close_requested` before it awaits, so a command queued by a cloned handle concurrently with `disconnect()` is still dequeued by `handle_command` afterwards.

The ticker and history plants guarded against this. The order and P&L plants did not. A `PlaceOrder`, `ModifyOrder` or `CancelOrder` racing `disconnect()` was serialized to Rithmic, and its oneshot then resolved `ConnectionClosed` — the caller recorded a failure while the order was live at the exchange. `core.rs`'s `handle_logout` comment already claimed this guard held for all plants.

The two plants that did guard used a different mechanism from the two that needed one: ticker and history routed through an `into_response_sender_or_command()` method that matched every variant to pull out the responder and send it an explicit `Err(ConnectionClosed)`. One rule, two implementations.

Underneath both, `disconnect()` propagated a logout error with `??` before queueing `Close`. `send_or_fail` fails only the request it was given and does not stop the actor, so a logout that failed on a transport error left the actor with `close_requested` already set and no `Close` coming: no heartbeats, no pings, every later command dropped, and pending requests never drained, since only `handle_close()` drains them. On a half-open connection nothing surfaces through the reader either, so the actor never stops.

## Solution

All four plants apply the same guard:

```rust
if self.core.close_requested
    && !matches!(
        command,
        TickerPlantCommand::Close
            | TickerPlantCommand::SetLogin
            | TickerPlantCommand::UpdateHeartbeat { .. }
            | TickerPlantCommand::Abort
    )
{
    debug!("ticker_plant: dropping a command queued after close was requested");
    return;
}
```

`into_response_sender_or_command` is deleted from both enums that had it.

Dropping the command drops the `response_sender` it carries, which is caller-visible identical to the explicit send it replaces: every handle method on all four plants resolves its receive with `.map_err(|_| RithmicError::ConnectionClosed)`. So this is a behaviour fix for the order and P&L plants and a refactor for ticker and history.

The exempt set is exactly the four variants that carry no responder, and the rule is deny-by-default — a variant added later is dropped once close is requested rather than needing a new arm. `Close` must stay exempt: it still has to reach `handle_close()` to send the WebSocket Close frame.

`disconnect()` now queues `Close` before propagating the logout outcome, on all four plants. `handle_close()` is best-effort — it drains pending requests and swallows send failures — so sending it after a failed logout is never worse than not sending it. This also matters more with the guard in place: it removes the one accidental escape hatch the order and P&L plants had, where a later command could still reach `send_or_fail` and trip its timeout drain.

Tests drive the real plants over a loopback socket and assert on bytes on the wire, because the returned error alone cannot distinguish a guarded plant from an unguarded one. The ticker and history tests being replaced called `into_response_sender_or_command` directly rather than going through `handle_command`, so they passed with the guard deleted. With the `close_requested` check stubbed out, 10 tests fail across all four plants; restoring `disconnect()`'s early return fails 4 more.

All four `#[cfg(test)] mod tests` bodies moved to sibling `<plant>/tests.rs` files sharing scaffolding from `plants::test_support`, so no plant source file contains test code.

No public API change. `CHANGELOG.md` updated under `[Unreleased] → Fixed`.
