### PR TITLE
fix(request-handler): fail pending requests past their deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Public struct fields and a method signature change, so this lands in a major rel
 - **`RithmicOrderPlantHandle::subscribe_account_rms_updates` gains a required `update_bits` parameter.**
   Pass `vec![]` for the prior behavior, or `vec![RmsUpdateBits::AutoLiqThresholdCurrentValue]` to
   stream auto-liq threshold updates.
+- **`RithmicConfig` gains a required `request_timeout: Duration` field.** Use
+  `RithmicConfig::builder(..)` or add `request_timeout: DEFAULT_REQUEST_TIMEOUT` to existing
+  struct literals.
 - **`RithmicOrderPlantHandle::adjust_profit` and `adjust_stop` take a `RithmicBracketLevelAdjustment`**
   instead of `(id, ticks)`, adding a `level` that selects the bracket leg. `level: None` keeps the
   prior behavior.
@@ -30,9 +33,12 @@ Public struct fields and a method signature change, so this lands in a major rel
 
 ### Added
 
+- **`rithmic_rs::DEFAULT_REQUEST_TIMEOUT`**, `RithmicConfigBuilder::request_timeout` and the
+  `RITHMIC_REQUEST_TIMEOUT_SECS` environment variable — how long a request waits for a response.
+  Defaults to 30 seconds, and zero selects the default. The environment variable takes plain
+  digits only — anything else is an error rather than a silent fallback.
 - **`RithmicBracketLevelAdjustment`** — the command struct for `adjust_profit` and `adjust_stop`:
   the basket `id`, the new `ticks` distance, and the `level` selecting a bracket leg.
-
 - **`RithmicMessage::RequestHeartbeat(RequestHeartbeat)`** — a keep-alive frame (template 18) sent by the server, which previously arrived as `UnknownTemplate`. Delivered on the subscription channel with `error: None` and an empty `request_id`: it answers no request you made, and its `user_msg` is the server's own token rather than an id this client handed out. The library does not reply to it. `RithmicMessage` is `#[non_exhaustive]`, so the new variant does not break existing matches.
 - **`RithmicMessage::UnknownTemplate(UnknownTemplateMessage)`** — a frame whose `template_id` has no message definition in this crate. Delivered with `error: None` and the message body kept as received. `RithmicMessage` is `#[non_exhaustive]`, so the new variant does not break existing matches.
 - **`UnknownTemplateMessage::decode_as<M>()`** — decode the payload into a caller-supplied `prost` type, so an unmapped template can be handled downstream without a change here. `Ok` is not proof the type was guessed right: protobuf skips undeclared fields, so an unrelated payload usually decodes into a mostly-empty value.
@@ -117,6 +123,10 @@ Public struct fields and a method signature change, so this lands in a major rel
   preferring one it marks default; `login()` reads them once and orders route off that snapshot for
   the life of the connection. Login logs each route it loaded, and the count, at `info`, or logs at
   `error` if none were published; the route each order takes logs at `debug`.
+- **Waits that never ended now end.** A request whose response never arrives fails after 30 seconds
+  of silence with the new `RithmicError::RequestTimeout` instead of parking its caller forever —
+  reconcile a timed-out order rather than re-sending it — and a missing pong reports a dead link
+  instead of spinning the plant's loop at the deadline.
 
 ## [2.0.0]
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Set your environment variables:
 RITHMIC_APP_NAME=your_app_name
 RITHMIC_APP_VERSION=1
 
+# Optional: seconds a request waits for a response (default 30; 0 selects the default)
+RITHMIC_REQUEST_TIMEOUT_SECS=30
+
 RITHMIC_DEMO_USER=your_username
 RITHMIC_DEMO_PW=your_password
 RITHMIC_DEMO_URL=<provided_by_rithmic>

--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -2,8 +2,6 @@
 //!
 //! Run with: cargo run --example error_handling
 
-use std::time::Duration;
-
 use tokio::sync::broadcast::error::RecvError;
 use tracing::{error, info, warn};
 
@@ -58,16 +56,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Err(e) => error!("subscribe: {e}"),
     }
 
-    // There's no per-request timeout, so add one if a hung call would hurt.
-    let front_month = tokio::time::timeout(
-        Duration::from_secs(5),
-        handle.get_front_month_contract("ES", "CME", false),
-    )
-    .await;
-    match front_month {
-        Ok(Ok(resp)) => info!("front month: {:?}", resp.message),
-        Ok(Err(e)) => error!("front month: {e}"),
-        Err(_) => warn!("front month timed out"),
+    match handle.get_front_month_contract("ES", "CME", false).await {
+        Ok(resp) => info!("front month: {:?}", resp.message),
+        Err(RithmicError::RequestTimeout) => warn!("front month: no response"),
+        Err(e) => error!("front month: {e}"),
     }
 
     loop {

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,9 @@
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 
-use std::{env, fmt, str::FromStr};
+use std::{env, fmt, str::FromStr, time::Duration};
+
+use crate::request_handler::DEFAULT_REQUEST_TIMEOUT;
 
 /// Trading environment selector.
 ///
@@ -185,6 +187,21 @@ impl RithmicAccount {
     }
 }
 
+const REQUEST_TIMEOUT_VAR: &str = "RITHMIC_REQUEST_TIMEOUT_SECS";
+
+/// Parse a duration given as a plain decimal count of seconds.
+///
+/// Stricter than `u64::from_str`, which also takes a sign and leading zeros:
+/// only canonical digits pass, so a mangled value cannot slip through as a
+/// plausible number.
+fn parse_whole_seconds(value: &str) -> Option<u64> {
+    let canonical = !value.is_empty()
+        && value.bytes().all(|b| b.is_ascii_digit())
+        && (value == "0" || !value.starts_with('0'));
+
+    if canonical { value.parse().ok() } else { None }
+}
+
 /// Configuration for Rithmic connections.
 ///
 /// This struct contains session-level connection and login details.
@@ -206,6 +223,9 @@ pub struct RithmicConfig {
     pub app_name: String,
     /// Application version string.
     pub app_version: String,
+    /// How long to wait for a response before a request times out.
+    /// A zero duration selects [`DEFAULT_REQUEST_TIMEOUT`].
+    pub request_timeout: Duration,
 }
 
 impl fmt::Debug for RithmicConfig {
@@ -219,6 +239,7 @@ impl fmt::Debug for RithmicConfig {
             .field("env", &self.env)
             .field("app_name", &self.app_name)
             .field("app_version", &self.app_version)
+            .field("request_timeout", &self.request_timeout)
             .finish()
     }
 }
@@ -306,6 +327,27 @@ impl RithmicConfig {
         let app_version = env::var("RITHMIC_APP_VERSION")
             .map_err(|_| ConfigError::MissingEnvVar("RITHMIC_APP_VERSION".to_string()))?;
 
+        let request_timeout = match env::var(REQUEST_TIMEOUT_VAR) {
+            Err(env::VarError::NotPresent) => DEFAULT_REQUEST_TIMEOUT,
+            Err(env::VarError::NotUnicode(_)) => {
+                return Err(ConfigError::InvalidValue {
+                    var: REQUEST_TIMEOUT_VAR.to_string(),
+                    reason: "expected whole seconds, got a non-unicode value".to_string(),
+                });
+            }
+            Ok(value) => match parse_whole_seconds(value.trim()) {
+                // Zero selects the default, consistent with the builder.
+                Some(0) => DEFAULT_REQUEST_TIMEOUT,
+                Some(secs) => Duration::from_secs(secs),
+                None => {
+                    return Err(ConfigError::InvalidValue {
+                        var: REQUEST_TIMEOUT_VAR.to_string(),
+                        reason: format!("expected whole seconds (digits only), got {value:?}"),
+                    });
+                }
+            },
+        };
+
         Ok(Self {
             url,
             beta_url,
@@ -315,6 +357,7 @@ impl RithmicConfig {
             env,
             app_name,
             app_version,
+            request_timeout,
         })
     }
 
@@ -349,6 +392,7 @@ pub struct RithmicConfigBuilder {
     system_name: Option<String>,
     app_name: Option<String>,
     app_version: Option<String>,
+    request_timeout: Duration,
 }
 
 impl RithmicConfigBuilder {
@@ -370,6 +414,7 @@ impl RithmicConfigBuilder {
             system_name: Some(system_name),
             app_name: None,
             app_version: None,
+            request_timeout: DEFAULT_REQUEST_TIMEOUT,
         }
     }
 
@@ -409,7 +454,20 @@ impl RithmicConfigBuilder {
         self
     }
 
-    /// Set the application version string.
+    /// Set how long to wait for a response before a request times out.
+    ///
+    /// A zero duration selects the default,
+    /// [`DEFAULT_REQUEST_TIMEOUT`].
+    pub fn request_timeout(mut self, request_timeout: Duration) -> Self {
+        self.request_timeout = if request_timeout.is_zero() {
+            DEFAULT_REQUEST_TIMEOUT
+        } else {
+            request_timeout
+        };
+        self
+    }
+
+    /// Set the application version string registered with Rithmic.
     pub fn app_version(mut self, app_version: impl Into<String>) -> Self {
         self.app_version = Some(app_version.into());
         self
@@ -444,12 +502,14 @@ impl RithmicConfigBuilder {
             app_version: self
                 .app_version
                 .ok_or_else(|| ConfigError::MissingField("app_version".to_string()))?,
+            request_timeout: self.request_timeout,
         })
     }
 }
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
 
     fn demo_env_vars() -> Vec<(&'static str, Option<&'static str>)> {
@@ -544,6 +604,76 @@ mod tests {
             assert_eq!(account.fcm_id, "test_fcm");
             assert_eq!(account.ib_id, "test_ib");
         });
+    }
+
+    #[test]
+    fn from_env_reads_the_request_timeout_when_set() {
+        let mut vars = demo_env_vars();
+        vars.push((REQUEST_TIMEOUT_VAR, Some("5")));
+
+        temp_env::with_vars(vars, || {
+            let config = RithmicConfig::from_env(RithmicEnv::Demo).unwrap();
+
+            assert_eq!(config.request_timeout, Duration::from_secs(5));
+        });
+    }
+
+    #[test]
+    fn from_env_defaults_the_request_timeout_when_unset() {
+        let mut vars = demo_env_vars();
+        vars.push((REQUEST_TIMEOUT_VAR, None));
+
+        temp_env::with_vars(vars, || {
+            let config = RithmicConfig::from_env(RithmicEnv::Demo).unwrap();
+
+            assert_eq!(config.request_timeout, DEFAULT_REQUEST_TIMEOUT);
+        });
+    }
+
+    #[test]
+    fn from_env_rejects_an_unusable_request_timeout() {
+        for value in ["soon", "+30", "-30", "007", "30.5", "30s", ""] {
+            let mut vars = demo_env_vars();
+            vars.push((REQUEST_TIMEOUT_VAR, Some(value)));
+
+            temp_env::with_vars(vars, || {
+                assert!(
+                    matches!(
+                        RithmicConfig::from_env(RithmicEnv::Demo),
+                        Err(ConfigError::InvalidValue { .. })
+                    ),
+                    "{value:?} should have been rejected"
+                );
+            });
+        }
+    }
+
+    #[test]
+    fn from_env_treats_a_zero_request_timeout_as_the_default() {
+        let mut vars = demo_env_vars();
+        vars.push((REQUEST_TIMEOUT_VAR, Some("0")));
+
+        temp_env::with_vars(vars, || {
+            let config = RithmicConfig::from_env(RithmicEnv::Demo).unwrap();
+
+            assert_eq!(config.request_timeout, DEFAULT_REQUEST_TIMEOUT);
+        });
+    }
+
+    #[test]
+    fn the_builder_treats_a_zero_request_timeout_as_the_default() {
+        let config = RithmicConfig::builder(RithmicEnv::Demo)
+            .user("u")
+            .password("p")
+            .url("ws://localhost:9999")
+            .beta_url("ws://localhost:9998")
+            .app_name("a")
+            .app_version("1")
+            .request_timeout(Duration::ZERO)
+            .build()
+            .unwrap();
+
+        assert_eq!(config.request_timeout, DEFAULT_REQUEST_TIMEOUT);
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -115,6 +115,8 @@ pub enum RithmicError {
     SendFailed,
     /// Server returned an empty response where at least one was expected.
     EmptyResponse,
+    /// The request was sent but no response came back in time.
+    RequestTimeout,
     /// The server turned the request down, with the code and message it gave.
     /// Request-level only — not a reason to reconnect.
     RequestRejected(RithmicRequestError),
@@ -175,6 +177,7 @@ impl fmt::Display for RithmicError {
             RithmicError::ConnectionClosed => write!(f, "connection closed"),
             RithmicError::SendFailed => write!(f, "WebSocket send failed or timed out"),
             RithmicError::EmptyResponse => write!(f, "empty response"),
+            RithmicError::RequestTimeout => write!(f, "request timed out"),
             RithmicError::RequestRejected(err) => {
                 let detail = err.to_string();
 
@@ -411,6 +414,14 @@ mod tests {
     }
 
     #[test]
+    fn request_timeout_display() {
+        assert_eq!(
+            RithmicError::RequestTimeout.to_string(),
+            "request timed out"
+        );
+    }
+
+    #[test]
     fn heartbeat_timeout_display() {
         assert_eq!(
             RithmicError::HeartbeatTimeout.to_string(),
@@ -497,6 +508,13 @@ mod tests {
             err.to_string(),
             "no trade route for exchange CBOT; cached: C[31mME"
         );
+    }
+
+    #[test]
+    fn request_timeout_is_not_a_connection_issue() {
+        // Otherwise callers that reconnect on `is_connection_issue()` would tear
+        // down a live session, and its subscriptions, over one lost request.
+        assert!(!RithmicError::RequestTimeout.is_connection_issue());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,13 +164,16 @@
 //!   connection problem rather than retrying in a loop.
 //! - [`ConnectionClosed`](RithmicError::ConnectionClosed) — the plant is gone.
 //!   Reconnect; calling again will not work.
+//! - [`RequestTimeout`](RithmicError::RequestTimeout) — no response came back in
+//!   time. The plant keeps running; check the subscription channel for
+//!   connection health.
 //!
 //! When a connection drops, everything in flight fails with `ConnectionClosed`
 //! whatever the real cause was. The cause goes out on the subscription channel,
 //! so look there if you need to tell a heartbeat timeout from a dead socket.
 //!
-//! There is no per-request timeout — if a response never arrives, the call
-//! waits. Wrap calls in `tokio::time::timeout` if you need a bound.
+//! Requests time out after 30 seconds by default; set
+//! [`RithmicConfigBuilder::request_timeout`] to change it.
 //!
 //! ([`ConnectionFailed`](RithmicError::ConnectionFailed) comes from `connect()`
 //! rather than a handle method, and only under [`ConnectStrategy::Simple`] —
@@ -301,6 +304,7 @@ pub use plants::ticker_plant::{RithmicTickerPlant, RithmicTickerPlantHandle};
 
 // Re-export modern configuration types for convenience
 pub use config::{ConfigError, RithmicAccount, RithmicConfig, RithmicConfigBuilder, RithmicEnv};
+pub use request_handler::DEFAULT_REQUEST_TIMEOUT;
 
 // Re-export error types
 pub use error::{RithmicError, RithmicRequestError};

--- a/src/ping_manager.rs
+++ b/src/ping_manager.rs
@@ -1,5 +1,5 @@
 use std::time::Duration;
-use tokio::time::Instant;
+use tokio::time::{Instant, sleep_until};
 use tracing::warn;
 
 /// Manages WebSocket ping/pong timeout detection for plant actors.
@@ -52,24 +52,22 @@ impl PingManager {
         self.pending = None;
     }
 
-    /// Checks if the pending ping has timed out.
+    /// Resolves once the pending ping has gone unanswered for the timeout.
     ///
-    /// Returns `true` and clears pending state if timeout exceeded.
-    /// Call when the instant from `next_timeout_at()` is reached.
-    pub fn check_timeout(&mut self) -> bool {
-        if let Some(sent_at) = self.pending {
-            if sent_at.elapsed() > self.timeout {
+    /// Never resolves while no ping is pending, so it can sit in a `select!` arm.
+    /// Clears the pending ping before returning, so a timeout is reported once.
+    pub async fn timed_out(&mut self) {
+        match self.pending {
+            Some(sent_at) => {
+                sleep_until(sent_at + self.timeout).await;
                 self.pending = None;
-                return true;
             }
+            None => std::future::pending().await,
         }
-        false
     }
 
     /// Returns the instant when the pending ping will timeout, if any.
-    ///
-    /// Use with `tokio::time::sleep_until()` in a select! loop.
-    /// Returns `None` if no ping is pending.
+    #[cfg(test)]
     pub fn next_timeout_at(&self) -> Option<Instant> {
         self.pending.map(|sent_at| sent_at + self.timeout)
     }
@@ -82,9 +80,8 @@ mod tests {
 
     #[test]
     fn new_has_no_pending() {
-        let mut mgr = PingManager::new(60);
+        let mgr = PingManager::new(60);
         assert!(mgr.next_timeout_at().is_none());
-        assert!(!mgr.check_timeout());
     }
 
     #[test]
@@ -100,21 +97,27 @@ mod tests {
         mgr.sent();
         mgr.received();
         assert!(mgr.next_timeout_at().is_none());
-        assert!(!mgr.check_timeout());
     }
 
-    #[test]
-    fn check_timeout_returns_false_before_deadline() {
+    #[tokio::test(start_paused = true)]
+    async fn timed_out_waits_for_the_timeout() {
         let mut mgr = PingManager::new(60);
         mgr.sent();
-        // Called immediately — timeout has not elapsed yet.
-        assert!(!mgr.check_timeout());
+
+        let started = Instant::now();
+        mgr.timed_out().await;
+
+        assert_eq!(Instant::now() - started, Duration::from_secs(60));
     }
 
-    #[test]
-    fn check_timeout_false_when_no_pending() {
+    #[tokio::test(start_paused = true)]
+    async fn timed_out_never_resolves_without_a_pending_ping() {
         let mut mgr = PingManager::new(60);
-        assert!(!mgr.check_timeout());
+
+        tokio::select! {
+            _ = mgr.timed_out() => panic!("resolved with no ping pending"),
+            _ = tokio::time::sleep(Duration::from_secs(3600)) => {}
+        }
     }
 
     #[test]
@@ -125,45 +128,19 @@ mod tests {
         assert!(mgr.next_timeout_at().is_some());
     }
 
-    #[tokio::test]
-    async fn check_timeout_returns_true_after_deadline() {
-        tokio::time::pause();
+    #[tokio::test(start_paused = true)]
+    async fn timed_out_clears_pending_so_it_reports_once() {
         let mut mgr = PingManager::new(1);
         mgr.sent();
-        tokio::time::advance(Duration::from_secs(2)).await;
-        assert!(mgr.check_timeout());
-    }
 
-    #[tokio::test]
-    async fn check_timeout_clears_pending_after_trigger() {
-        tokio::time::pause();
-        let mut mgr = PingManager::new(1);
-        mgr.sent();
-        tokio::time::advance(Duration::from_secs(2)).await;
-        assert!(mgr.check_timeout());
-        // State must be cleared — no double-trigger.
+        mgr.timed_out().await;
+
         assert!(mgr.next_timeout_at().is_none());
-        assert!(!mgr.check_timeout());
-    }
 
-    #[tokio::test]
-    async fn next_timeout_at_is_sent_at_plus_timeout() {
-        tokio::time::pause();
-        let timeout_secs = 30_u64;
-        let mut mgr = PingManager::new(timeout_secs);
-        let before = Instant::now();
-        mgr.sent();
-        let deadline = mgr.next_timeout_at().expect("should have a deadline");
-        let expected = before + Duration::from_secs(timeout_secs);
-        // Allow a tiny delta (1 ms) for any sub-millisecond clock granularity.
-        let delta = if deadline >= expected {
-            deadline - expected
-        } else {
-            expected - deadline
-        };
-        assert!(
-            delta <= Duration::from_millis(1),
-            "deadline delta too large: {delta:?}"
-        );
+        // A second wait must not resolve off the ping already reported.
+        tokio::select! {
+            _ = mgr.timed_out() => panic!("reported the same ping twice"),
+            _ = tokio::time::sleep(Duration::from_secs(3600)) => {}
+        }
     }
 }

--- a/src/plants/core.rs
+++ b/src/plants/core.rs
@@ -9,7 +9,7 @@ use futures_util::{
 
 use tokio::{
     net::TcpStream,
-    sync::{broadcast, oneshot},
+    sync::{broadcast, mpsc, oneshot},
     time::Interval,
 };
 
@@ -105,7 +105,7 @@ impl PlantCore<WsSink> {
             logged_in: false,
             ping_interval,
             ping_manager,
-            request_handler: RithmicRequestHandler::new(),
+            request_handler: RithmicRequestHandler::new(config.request_timeout),
             rithmic_reader,
             rithmic_receiver_api,
             rithmic_sender,
@@ -181,6 +181,30 @@ where
                     ),
                 );
             }
+        }
+    }
+
+    /// Await the next thing the actor must react to.
+    pub(crate) async fn next_event<C>(
+        &mut self,
+        receiver: &mut mpsc::Receiver<C>,
+    ) -> SelectResult<C> {
+        let interval = &mut self.interval;
+        let ping_interval = &mut self.ping_interval;
+        let ping_manager = &mut self.ping_manager;
+        let reader = &mut self.rithmic_reader;
+        let request_handler = &mut self.request_handler;
+
+        tokio::select! {
+            _ = interval.tick()      => SelectResult::HeartbeatFired,
+            _ = ping_interval.tick() => SelectResult::PingFired,
+            _ = ping_manager.timed_out() => SelectResult::PingTimeout,
+            _ = request_handler.fail_timed_out() => unreachable!(),
+            Some(cmd) = receiver.recv() => SelectResult::Command(cmd),
+            msg = reader.next() => match msg {
+                Some(m) => SelectResult::RithmicMessage(m),
+                None => SelectResult::StreamClosed,
+            },
         }
     }
 
@@ -603,7 +627,10 @@ mod tests {
     };
 
     use futures_util::StreamExt;
-    use tokio::sync::{broadcast, oneshot};
+    use tokio::{
+        sync::{broadcast, oneshot},
+        time::Instant,
+    };
     use tokio_tungstenite::tungstenite::{Error, Message, error::ProtocolError};
 
     use super::*;
@@ -741,6 +768,30 @@ mod tests {
         reader
     }
 
+    /// A reader whose peer stays connected, so polling it stays pending instead
+    /// of yielding EOF. The returned socket must be held for the test's life.
+    async fn make_open_ws_reader() -> (WsReader, TcpStream) {
+        use tokio::net::TcpListener;
+        use tokio_tungstenite::tungstenite::protocol::Role;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let (client_tcp, server_result) =
+            tokio::join!(TcpStream::connect(addr), async { listener.accept().await });
+
+        let client_tcp = client_tcp.unwrap();
+        let (server_tcp, _) = server_result.unwrap();
+
+        let server_ws =
+            WebSocketStream::from_raw_socket(MaybeTlsStream::Plain(server_tcp), Role::Server, None)
+                .await;
+
+        let (_, reader) = server_ws.split();
+
+        (reader, client_tcp)
+    }
+
     fn make_test_core(
         sink: MockMessageSink,
         rithmic_reader: WsReader,
@@ -748,12 +799,24 @@ mod tests {
         PlantCore<MockMessageSink>,
         broadcast::Receiver<RithmicResponse>,
     ) {
-        let config = test_config();
+        make_test_core_with_config(sink, rithmic_reader, test_config())
+    }
+
+    fn make_test_core_with_config(
+        sink: MockMessageSink,
+        rithmic_reader: WsReader,
+        config: RithmicConfig,
+    ) -> (
+        PlantCore<MockMessageSink>,
+        broadcast::Receiver<RithmicResponse>,
+    ) {
         let (sub_tx, sub_rx) = broadcast::channel(16);
         let rithmic_sender_api = RithmicSenderApi::new(&config);
         let rithmic_receiver_api = RithmicReceiverApi {
             source: "test".to_string(),
         };
+
+        let request_handler = RithmicRequestHandler::new(config.request_timeout);
 
         let core = PlantCore {
             config,
@@ -762,7 +825,7 @@ mod tests {
             logged_in: false,
             ping_interval: get_ping_interval(None),
             ping_manager: PingManager::new(PING_TIMEOUT_SECS),
-            request_handler: RithmicRequestHandler::new(),
+            request_handler,
             rithmic_reader,
             rithmic_receiver_api,
             rithmic_sender: sink,
@@ -973,6 +1036,63 @@ mod tests {
         assert!(
             sub_rx.try_recv().is_err(),
             "no broadcast should have been sent"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn the_configured_request_timeout_is_the_one_applied() {
+        let config = RithmicConfig::builder(RithmicEnv::Demo)
+            .user("u")
+            .password("p")
+            .url("ws://localhost:9999")
+            .beta_url("ws://localhost:9998")
+            .app_name("a")
+            .app_version("1")
+            .request_timeout(Duration::from_secs(5))
+            .build()
+            .unwrap();
+
+        let (reader, _peer) = make_open_ws_reader().await;
+        let (mut core, _sub_rx) =
+            make_test_core_with_config(MockMessageSink::ready(), reader, config);
+        let mut rx = register_request(&mut core, "req-1");
+        let (_cmd_tx, mut cmd_rx) = mpsc::channel::<()>(1);
+
+        let started = Instant::now();
+
+        // Race the caller against the loop: the request must fail at 5s, well
+        // before the 60s tick that would otherwise end next_event.
+        let elapsed = tokio::select! {
+            _ = core.next_event(&mut cmd_rx) => panic!("returned before the timeout"),
+            received = &mut rx => {
+                assert_eq!(received.unwrap().unwrap_err(), RithmicError::RequestTimeout);
+                Instant::now() - started
+            }
+        };
+
+        assert_eq!(elapsed, Duration::from_secs(5));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn next_event_times_out_a_request_while_waiting() {
+        // The only plant-level fact worth asserting: next_event polls the
+        // timeout loop. Timing semantics are covered in request_handler.
+        let (reader, _peer) = make_open_ws_reader().await;
+        let (mut core, mut sub_rx) = make_test_core(MockMessageSink::ready(), reader);
+        let mut rx = register_request(&mut core, "req-1");
+        let (_cmd_tx, mut cmd_rx) = mpsc::channel::<()>(1);
+
+        // The return is ignored on purpose: both 60s intervals come ready at
+        // the same instant, so which one `select!` reports is random.
+        core.next_event(&mut cmd_rx).await;
+
+        assert_eq!(
+            rx.try_recv().unwrap().unwrap_err(),
+            RithmicError::RequestTimeout
+        );
+        assert!(
+            sub_rx.try_recv().is_err(),
+            "timing a request out is not a connection-health event"
         );
     }
 

--- a/src/plants/history_plant.rs
+++ b/src/plants/history_plant.rs
@@ -1,4 +1,3 @@
-use futures_util::StreamExt;
 use tokio_tungstenite::tungstenite::Message;
 use tracing::{debug, error, info, warn};
 
@@ -19,7 +18,6 @@ use crate::{
 use tokio::{
     sync::{broadcast, mpsc, oneshot},
     task::JoinHandle,
-    time::sleep_until,
 };
 
 pub(crate) enum HistoryPlantCommand {
@@ -226,52 +224,25 @@ impl PlantActor for HistoryPlant {
 
     async fn run(&mut self) {
         loop {
-            let result = {
-                let interval = &mut self.core.interval;
-                let ping_interval = &mut self.core.ping_interval;
-                let ping_manager = &mut self.core.ping_manager;
-                let reader = &mut self.core.rithmic_reader;
-                let receiver = &mut self.request_receiver;
-
-                tokio::select! {
-                    _ = interval.tick()      => SelectResult::HeartbeatFired,
-                    _ = ping_interval.tick() => SelectResult::PingFired,
-                    _ = async {
-                        if let Some(t) = ping_manager.next_timeout_at() {
-                            sleep_until(t).await
-                        } else {
-                            std::future::pending::<()>().await
-                        }
-                    } => SelectResult::PingTimeout,
-                    Some(cmd) = receiver.recv() => SelectResult::Command(cmd),
-                    msg = reader.next() => match msg {
-                        Some(m) => SelectResult::RithmicMessage(m),
-                        None => SelectResult::StreamClosed,
-                    },
-                }
-            };
+            let result = self.core.next_event(&mut self.request_receiver).await;
 
             let stop = match result {
                 SelectResult::HeartbeatFired => self.core.send_heartbeat().await,
                 SelectResult::PingFired => self.core.send_ping().await,
                 SelectResult::PingTimeout => {
-                    if self.core.ping_manager.check_timeout() {
-                        if self.core.close_requested {
-                            warn!(
-                                "history_plant: ping timed out while waiting for server close echo — terminating"
-                            );
+                    if self.core.close_requested {
+                        warn!(
+                            "history_plant: ping timed out while waiting for server close echo — terminating"
+                        );
 
-                            self.core.request_handler.drain_and_drop();
-                        } else {
-                            self.core.fail_connection_and_drain(
-                                "websocket_ping_timeout",
-                                RithmicError::HeartbeatTimeout,
-                            );
-                        }
-                        true
+                        self.core.request_handler.drain_and_drop();
                     } else {
-                        false
+                        self.core.fail_connection_and_drain(
+                            "websocket_ping_timeout",
+                            RithmicError::HeartbeatTimeout,
+                        );
                     }
+                    true
                 }
                 SelectResult::Command(cmd) => {
                     if matches!(cmd, HistoryPlantCommand::Abort) {
@@ -643,7 +614,8 @@ impl RithmicHistoryPlantHandle {
 
     /// Immediately shut down the history plant actor without a graceful logout.
     ///
-    /// Use when the connection is known to be dead and `disconnect()` would hang.
+    /// Use when the connection is known to be dead and a graceful `disconnect()`
+    /// would not get through.
     /// All pending request callers will receive an error. The subscription channel
     /// receives a `ConnectionError` notification. Safe to call if the actor is already dead.
     pub fn abort(&self) {

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -1,6 +1,5 @@
 use std::sync::{Arc, OnceLock};
 
-use futures_util::StreamExt;
 use tokio_tungstenite::tungstenite::Message;
 use tracing::{debug, error, info, warn};
 
@@ -33,7 +32,6 @@ use crate::{
 use tokio::{
     sync::{broadcast, mpsc, oneshot},
     task::JoinHandle,
-    time::sleep_until,
 };
 
 pub(crate) enum OrderPlantCommand {
@@ -434,52 +432,25 @@ impl PlantActor for OrderPlant {
 
     async fn run(&mut self) {
         loop {
-            let result = {
-                let interval = &mut self.core.interval;
-                let ping_interval = &mut self.core.ping_interval;
-                let ping_manager = &mut self.core.ping_manager;
-                let reader = &mut self.core.rithmic_reader;
-                let receiver = &mut self.request_receiver;
-
-                tokio::select! {
-                    _ = interval.tick()      => SelectResult::HeartbeatFired,
-                    _ = ping_interval.tick() => SelectResult::PingFired,
-                    _ = async {
-                        if let Some(t) = ping_manager.next_timeout_at() {
-                            sleep_until(t).await
-                        } else {
-                            std::future::pending::<()>().await
-                        }
-                    } => SelectResult::PingTimeout,
-                    Some(cmd) = receiver.recv() => SelectResult::Command(cmd),
-                    msg = reader.next() => match msg {
-                        Some(m) => SelectResult::RithmicMessage(m),
-                        None => SelectResult::StreamClosed,
-                    },
-                }
-            };
+            let result = self.core.next_event(&mut self.request_receiver).await;
 
             let stop = match result {
                 SelectResult::HeartbeatFired => self.core.send_heartbeat().await,
                 SelectResult::PingFired => self.core.send_ping().await,
                 SelectResult::PingTimeout => {
-                    if self.core.ping_manager.check_timeout() {
-                        if self.core.close_requested {
-                            warn!(
-                                "order_plant: ping timed out while waiting for server close echo — terminating"
-                            );
+                    if self.core.close_requested {
+                        warn!(
+                            "order_plant: ping timed out while waiting for server close echo — terminating"
+                        );
 
-                            self.core.request_handler.drain_and_drop();
-                        } else {
-                            self.core.fail_connection_and_drain(
-                                "websocket_ping_timeout",
-                                RithmicError::HeartbeatTimeout,
-                            );
-                        }
-                        true
+                        self.core.request_handler.drain_and_drop();
                     } else {
-                        false
+                        self.core.fail_connection_and_drain(
+                            "websocket_ping_timeout",
+                            RithmicError::HeartbeatTimeout,
+                        );
                     }
+                    true
                 }
                 SelectResult::Command(cmd) => {
                     if matches!(cmd, OrderPlantCommand::Abort) {
@@ -1467,7 +1438,8 @@ impl RithmicOrderPlantHandle {
 
     /// Immediately shut down the order plant actor without a graceful logout.
     ///
-    /// Use when the connection is known to be dead and `disconnect()` would hang.
+    /// Use when the connection is known to be dead and a graceful `disconnect()`
+    /// would not get through.
     /// All pending request callers will receive an error. The subscription channel
     /// receives a `ConnectionError` notification. Safe to call if the actor is already dead.
     pub fn abort(&self) {

--- a/src/plants/pnl_plant.rs
+++ b/src/plants/pnl_plant.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use futures_util::StreamExt;
 use tokio_tungstenite::tungstenite::Message;
 use tracing::{debug, error, info, warn};
 
@@ -18,10 +17,7 @@ use crate::{
     ws::PlantActor,
 };
 
-use tokio::{
-    sync::{broadcast, mpsc, oneshot},
-    time::sleep_until,
-};
+use tokio::sync::{broadcast, mpsc, oneshot};
 
 pub(crate) enum PnlPlantCommand {
     Close,
@@ -203,50 +199,24 @@ impl PlantActor for PnlPlant {
 
     async fn run(&mut self) {
         loop {
-            let result = {
-                let interval = &mut self.core.interval;
-                let ping_interval = &mut self.core.ping_interval;
-                let ping_manager = &mut self.core.ping_manager;
-                let reader = &mut self.core.rithmic_reader;
-                let receiver = &mut self.request_receiver;
-                tokio::select! {
-                    _ = interval.tick()      => SelectResult::HeartbeatFired,
-                    _ = ping_interval.tick() => SelectResult::PingFired,
-                    _ = async {
-                        if let Some(t) = ping_manager.next_timeout_at() {
-                            sleep_until(t).await
-                        } else {
-                            std::future::pending::<()>().await
-                        }
-                    } => SelectResult::PingTimeout,
-                    Some(cmd) = receiver.recv() => SelectResult::Command(cmd),
-                    msg = reader.next() => match msg {
-                        Some(m) => SelectResult::RithmicMessage(m),
-                        None => SelectResult::StreamClosed,
-                    },
-                }
-            };
+            let result = self.core.next_event(&mut self.request_receiver).await;
             let stop = match result {
                 SelectResult::HeartbeatFired => self.core.send_heartbeat().await,
                 SelectResult::PingFired => self.core.send_ping().await,
                 SelectResult::PingTimeout => {
-                    if self.core.ping_manager.check_timeout() {
-                        if self.core.close_requested {
-                            warn!(
-                                "pnl_plant: ping timed out while waiting for server close echo — terminating"
-                            );
+                    if self.core.close_requested {
+                        warn!(
+                            "pnl_plant: ping timed out while waiting for server close echo — terminating"
+                        );
 
-                            self.core.request_handler.drain_and_drop();
-                        } else {
-                            self.core.fail_connection_and_drain(
-                                "websocket_ping_timeout",
-                                RithmicError::HeartbeatTimeout,
-                            );
-                        }
-                        true
+                        self.core.request_handler.drain_and_drop();
                     } else {
-                        false
+                        self.core.fail_connection_and_drain(
+                            "websocket_ping_timeout",
+                            RithmicError::HeartbeatTimeout,
+                        );
                     }
+                    true
                 }
                 SelectResult::Command(cmd) => {
                     if matches!(cmd, PnlPlantCommand::Abort) {
@@ -513,7 +483,8 @@ impl RithmicPnlPlantHandle {
 
     /// Immediately shut down the PnL plant actor without a graceful logout.
     ///
-    /// Use when the connection is known to be dead and `disconnect()` would hang.
+    /// Use when the connection is known to be dead and a graceful `disconnect()`
+    /// would not get through.
     /// All pending request callers will receive an error. The subscription channel
     /// receives a `ConnectionError` notification. Safe to call if the actor is already dead.
     pub fn abort(&self) {

--- a/src/plants/test_support.rs
+++ b/src/plants/test_support.rs
@@ -60,6 +60,8 @@ pub(crate) async fn core_with_wire(source: &str) -> (PlantCore, TcpStream) {
     let (subscription_sender, _sub_rx) = broadcast::channel(16);
     let rithmic_sender_api = RithmicSenderApi::new(&config);
 
+    let request_handler = RithmicRequestHandler::new(config.request_timeout);
+
     let core = PlantCore {
         config,
         close_requested: false,
@@ -67,7 +69,7 @@ pub(crate) async fn core_with_wire(source: &str) -> (PlantCore, TcpStream) {
         logged_in: true,
         ping_interval: get_ping_interval(None),
         ping_manager: PingManager::new(PING_TIMEOUT_SECS),
-        request_handler: RithmicRequestHandler::new(),
+        request_handler,
         rithmic_reader,
         rithmic_receiver_api: RithmicReceiverApi {
             source: source.to_string(),

--- a/src/plants/ticker_plant.rs
+++ b/src/plants/ticker_plant.rs
@@ -1,4 +1,3 @@
-use futures_util::StreamExt;
 use tokio_tungstenite::tungstenite::Message;
 use tracing::{debug, error, info, warn};
 
@@ -19,10 +18,7 @@ use crate::{
     ws::PlantActor,
 };
 
-use tokio::{
-    sync::{broadcast, mpsc, oneshot},
-    time::sleep_until,
-};
+use tokio::sync::{broadcast, mpsc, oneshot};
 
 pub(crate) enum TickerPlantCommand {
     Close,
@@ -305,50 +301,24 @@ impl PlantActor for TickerPlant {
     /// Execute the ticker plant actor loop.
     async fn run(&mut self) {
         loop {
-            let result = {
-                let interval = &mut self.core.interval;
-                let ping_interval = &mut self.core.ping_interval;
-                let ping_manager = &mut self.core.ping_manager;
-                let reader = &mut self.core.rithmic_reader;
-                let receiver = &mut self.request_receiver;
-                tokio::select! {
-                    _ = interval.tick()      => SelectResult::HeartbeatFired,
-                    _ = ping_interval.tick() => SelectResult::PingFired,
-                    _ = async {
-                        if let Some(t) = ping_manager.next_timeout_at() {
-                            sleep_until(t).await
-                        } else {
-                            std::future::pending::<()>().await
-                        }
-                    } => SelectResult::PingTimeout,
-                    Some(cmd) = receiver.recv() => SelectResult::Command(cmd),
-                    msg = reader.next() => match msg {
-                        Some(m) => SelectResult::RithmicMessage(m),
-                        None => SelectResult::StreamClosed,
-                    },
-                }
-            };
+            let result = self.core.next_event(&mut self.request_receiver).await;
             let stop = match result {
                 SelectResult::HeartbeatFired => self.core.send_heartbeat().await,
                 SelectResult::PingFired => self.core.send_ping().await,
                 SelectResult::PingTimeout => {
-                    if self.core.ping_manager.check_timeout() {
-                        if self.core.close_requested {
-                            warn!(
-                                "ticker_plant: ping timed out while waiting for server close echo — terminating"
-                            );
+                    if self.core.close_requested {
+                        warn!(
+                            "ticker_plant: ping timed out while waiting for server close echo — terminating"
+                        );
 
-                            self.core.request_handler.drain_and_drop();
-                        } else {
-                            self.core.fail_connection_and_drain(
-                                "websocket_ping_timeout",
-                                RithmicError::HeartbeatTimeout,
-                            );
-                        }
-                        true
+                        self.core.request_handler.drain_and_drop();
                     } else {
-                        false
+                        self.core.fail_connection_and_drain(
+                            "websocket_ping_timeout",
+                            RithmicError::HeartbeatTimeout,
+                        );
                     }
+                    true
                 }
                 SelectResult::Command(cmd) => {
                     if matches!(cmd, TickerPlantCommand::Abort) {
@@ -856,7 +826,8 @@ impl RithmicTickerPlantHandle {
 
     /// Immediately shut down the ticker plant actor without a graceful logout.
     ///
-    /// Use when the connection is known to be dead and `disconnect()` would hang.
+    /// Use when the connection is known to be dead and a graceful `disconnect()`
+    /// would not get through.
     /// All pending request callers will receive an error. The subscription channel
     /// receives a `ConnectionError` notification. Safe to call if the actor is already dead.
     pub fn abort(&self) {

--- a/src/request_handler.rs
+++ b/src/request_handler.rs
@@ -1,10 +1,20 @@
-use std::collections::HashMap;
-use tokio::sync::oneshot;
-use tracing::error;
+use std::{collections::HashMap, convert::Infallible, time::Duration};
+use tokio::{
+    sync::oneshot,
+    time::{Instant, sleep_until},
+};
+use tracing::{error, warn};
 
 use crate::{
     api::receiver_api::RithmicResponse, error::RithmicError, rti::messages::RithmicMessage,
 };
+
+/// Default time a request may go without progress before it is failed with
+/// [`RithmicError::RequestTimeout`].
+///
+/// Set [`RithmicConfigBuilder::request_timeout`](crate::RithmicConfigBuilder::request_timeout)
+/// to change it for a connection.
+pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug)]
 pub struct RithmicRequest {
@@ -12,23 +22,86 @@ pub struct RithmicRequest {
     pub responder: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
 }
 
+/// A registered request awaiting its response, and the instant it times out.
+#[derive(Debug)]
+struct PendingRequest {
+    responder: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
+    timeout_at: Instant,
+}
+
+/// Matches Rithmic responses to the callers waiting on them.
+///
+/// Each registered request times out, so a response that never arrives does
+/// not park its caller forever. See [`Self::fail_timed_out`].
 #[derive(Debug)]
 pub struct RithmicRequestHandler {
-    handle_map: HashMap<String, oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>>,
+    handle_map: HashMap<String, PendingRequest>,
     response_vec_map: HashMap<String, Vec<RithmicResponse>>,
+    request_timeout: Duration,
 }
 
 impl RithmicRequestHandler {
-    pub fn new() -> Self {
+    /// Create a handler that fails requests after `request_timeout` of silence.
+    ///
+    /// A zero `request_timeout` selects [`DEFAULT_REQUEST_TIMEOUT`], so a
+    /// zeroed-out config cannot fail every request on arrival.
+    pub fn new(request_timeout: Duration) -> Self {
+        let request_timeout = if request_timeout.is_zero() {
+            DEFAULT_REQUEST_TIMEOUT
+        } else {
+            request_timeout
+        };
+
         Self {
             handle_map: HashMap::new(),
             response_vec_map: HashMap::new(),
+            request_timeout,
         }
     }
 
+    /// Register a request; it times out `request_timeout` from now.
     pub fn register_request(&mut self, request: RithmicRequest) {
-        self.handle_map
-            .insert(request.request_id, request.responder);
+        self.handle_map.insert(
+            request.request_id,
+            PendingRequest {
+                responder: request.responder,
+                timeout_at: Instant::now() + self.request_timeout,
+            },
+        );
+    }
+
+    /// Fail requests as they time out, forever.
+    ///
+    /// This never resolves — drive it from a `select!` arm. Dropping it loses
+    /// nothing, since the timeouts live in `self`.
+    ///
+    /// Waking on the soonest timeout and then failing everything already timed
+    /// out means each pass removes at least that request, so this cannot stall.
+    pub async fn fail_timed_out(&mut self) -> Infallible {
+        loop {
+            let Some(soonest) = self.handle_map.values().map(|p| p.timeout_at).min() else {
+                std::future::pending::<()>().await;
+                continue;
+            };
+
+            sleep_until(soonest).await;
+
+            let timed_out = self
+                .handle_map
+                .iter()
+                .filter(|(_, pending)| pending.timeout_at <= soonest)
+                .map(|(request_id, _)| request_id.clone())
+                .collect::<Vec<_>>();
+
+            for request_id in &timed_out {
+                warn!(
+                    "No response for request_id {} within {:?}: failing it as timed out",
+                    request_id, self.request_timeout
+                );
+
+                self.fail_request(request_id, RithmicError::RequestTimeout);
+            }
+        }
     }
 
     fn send_to_responder(
@@ -53,8 +126,8 @@ impl RithmicRequestHandler {
     /// Returns `true` if the request was found and the error was sent.
     pub fn fail_request(&mut self, request_id: &str, error: RithmicError) -> bool {
         self.response_vec_map.remove(request_id);
-        if let Some(responder) = self.handle_map.remove(request_id) {
-            let _ = responder.send(Err(error));
+        if let Some(pending) = self.handle_map.remove(request_id) {
+            let _ = pending.responder.send(Err(error));
             true
         } else {
             false
@@ -65,9 +138,9 @@ impl RithmicRequestHandler {
         match response.message {
             RithmicMessage::ResponseHeartbeat(_) => {
                 // Handle heartbeat response if a callback is registered
-                if let Some(responder) = self.handle_map.remove(&response.request_id) {
+                if let Some(pending) = self.handle_map.remove(&response.request_id) {
                     let request_id = response.request_id.clone();
-                    self.send_to_responder(responder, vec![response], &request_id);
+                    self.send_to_responder(pending.responder, vec![response], &request_id);
                 }
             }
             _ => {
@@ -77,20 +150,27 @@ impl RithmicRequestHandler {
                     // multi-part response early and lands here.
                     self.response_vec_map.remove(&response.request_id);
 
-                    if let Some(responder) = self.handle_map.remove(&response.request_id) {
+                    if let Some(pending) = self.handle_map.remove(&response.request_id) {
                         let request_id = response.request_id.clone();
-                        self.send_to_responder(responder, vec![response], &request_id);
+                        self.send_to_responder(pending.responder, vec![response], &request_id);
                     } else {
                         error!("No responder found for response: {:#?}", response);
                     }
                 } else {
                     // If response has more, we store it in a vector and wait for more messages
                     if response.has_more {
-                        self.response_vec_map
-                            .entry(response.request_id.clone())
-                            .or_default()
-                            .push(response);
-                    } else if let Some(responder) = self.handle_map.remove(&response.request_id) {
+                        // Accumulate only while a responder is waiting: parts for
+                        // a gone id would re-create an entry nothing removes.
+                        if let Some(pending) = self.handle_map.get_mut(&response.request_id) {
+                            // The part is progress, so the timeout restarts.
+                            pending.timeout_at = Instant::now() + self.request_timeout;
+
+                            self.response_vec_map
+                                .entry(response.request_id.clone())
+                                .or_default()
+                                .push(response);
+                        }
+                    } else if let Some(pending) = self.handle_map.remove(&response.request_id) {
                         let request_id = response.request_id.clone();
                         let response_vec = match self.response_vec_map.remove(&request_id) {
                             Some(mut vec) => {
@@ -101,7 +181,7 @@ impl RithmicRequestHandler {
                                 vec![response]
                             }
                         };
-                        self.send_to_responder(responder, response_vec, &request_id);
+                        self.send_to_responder(pending.responder, response_vec, &request_id);
                     } else {
                         error!("No responder found for response: {:#?}", response);
                     }
@@ -116,16 +196,10 @@ impl RithmicRequestHandler {
     /// Call this during an unclean shutdown (e.g., abort) to unblock any tasks that are
     /// waiting for a response that will never arrive.
     pub fn drain_and_drop(&mut self) {
-        for (_, responder) in self.handle_map.drain() {
-            let _ = responder.send(Err(RithmicError::ConnectionClosed));
+        for (_, pending) in self.handle_map.drain() {
+            let _ = pending.responder.send(Err(RithmicError::ConnectionClosed));
         }
         self.response_vec_map.clear();
-    }
-}
-
-impl Default for RithmicRequestHandler {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -164,7 +238,7 @@ mod tests {
 
     #[test]
     fn single_response_delivered_to_responder() {
-        let mut handler = RithmicRequestHandler::new();
+        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
         let (tx, mut rx) = oneshot::channel();
 
         handler.register_request(RithmicRequest {
@@ -181,7 +255,7 @@ mod tests {
 
     #[test]
     fn single_response_removes_request_from_handler() {
-        let mut handler = RithmicRequestHandler::new();
+        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
         let (tx, mut rx) = oneshot::channel();
 
         handler.register_request(RithmicRequest {
@@ -202,7 +276,7 @@ mod tests {
 
     #[test]
     fn multi_response_collects_all_parts() {
-        let mut handler = RithmicRequestHandler::new();
+        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
         let (tx, mut rx) = oneshot::channel();
 
         handler.register_request(RithmicRequest {
@@ -230,7 +304,7 @@ mod tests {
 
     #[test]
     fn multi_response_single_message_no_has_more() {
-        let mut handler = RithmicRequestHandler::new();
+        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
         let (tx, mut rx) = oneshot::channel();
 
         handler.register_request(RithmicRequest {
@@ -254,7 +328,7 @@ mod tests {
 
     #[test]
     fn heartbeat_delivered_when_responder_registered() {
-        let mut handler = RithmicRequestHandler::new();
+        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
         let (tx, mut rx) = oneshot::channel();
 
         handler.register_request(RithmicRequest {
@@ -270,7 +344,7 @@ mod tests {
 
     #[test]
     fn heartbeat_without_responder_does_not_panic() {
-        let mut handler = RithmicRequestHandler::new();
+        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
         // No responder registered — should silently ignore
         handler.handle_response(make_response("hb", heartbeat_message()));
     }
@@ -281,7 +355,7 @@ mod tests {
 
     #[test]
     fn fail_request_sends_error_and_returns_true() {
-        let mut handler = RithmicRequestHandler::new();
+        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
         let (tx, mut rx) = oneshot::channel();
 
         handler.register_request(RithmicRequest {
@@ -297,7 +371,7 @@ mod tests {
 
     #[test]
     fn fail_request_returns_false_for_unknown_id() {
-        let mut handler = RithmicRequestHandler::new();
+        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
         assert!(!handler.fail_request("unknown", RithmicError::SendFailed));
     }
 
@@ -307,7 +381,7 @@ mod tests {
 
     #[test]
     fn drain_and_drop_sends_connection_closed_to_all_pending() {
-        let mut handler = RithmicRequestHandler::new();
+        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
         let (tx1, rx1) = oneshot::channel();
         let (tx2, rx2) = oneshot::channel();
 
@@ -331,7 +405,7 @@ mod tests {
 
     #[test]
     fn drain_and_drop_clears_partial_multi_responses() {
-        let mut handler = RithmicRequestHandler::new();
+        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
         let (tx, _rx) = oneshot::channel();
 
         handler.register_request(RithmicRequest {
@@ -347,7 +421,9 @@ mod tests {
 
         handler.drain_and_drop();
 
-        // After drain, a new request with the same ID should work cleanly
+        assert!(handler.response_vec_map.is_empty());
+
+        // After drain, a new request with the same ID should work cleanly.
         let (tx2, mut rx2) = oneshot::channel();
 
         handler.register_request(RithmicRequest {
@@ -355,10 +431,300 @@ mod tests {
             responder: tx2,
         });
 
-        handler.handle_response(make_response("m", login_message()));
+        // Probe with a terminal multi-part response: only that branch merges
+        // `response_vec_map`, so only it can observe a leftover part.
+        let mut probe = make_response("m", ref_data_message());
+        probe.multi_response = true;
+        probe.has_more = false;
+        handler.handle_response(probe);
 
         let result = rx2.try_recv().unwrap().unwrap();
-        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result.len(),
+            1,
+            "a stale partial part must not be merged into a later response"
+        );
+    }
+
+    // =========================================================================
+    // fail_timed_out
+    // =========================================================================
+
+    fn timeout_handler() -> RithmicRequestHandler {
+        RithmicRequestHandler::new(Duration::from_secs(30))
+    }
+
+    fn register(
+        handler: &mut RithmicRequestHandler,
+        id: &str,
+    ) -> oneshot::Receiver<Result<Vec<RithmicResponse>, RithmicError>> {
+        let (tx, rx) = oneshot::channel();
+
+        handler.register_request(RithmicRequest {
+            request_id: id.to_string(),
+            responder: tx,
+        });
+
+        rx
+    }
+
+    /// Run the timeout loop until `rx` resolves. Time is paused, so the elapsed
+    /// figure is exactly what a caller would have waited.
+    async fn time_out_until(
+        handler: &mut RithmicRequestHandler,
+        rx: oneshot::Receiver<Result<Vec<RithmicResponse>, RithmicError>>,
+    ) -> (RithmicError, Duration) {
+        let started = Instant::now();
+
+        let err = tokio::select! {
+            _ = handler.fail_timed_out() => unreachable!(),
+            received = rx => received.unwrap().unwrap_err(),
+        };
+
+        (err, Instant::now() - started)
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_zero_timeout_falls_back_to_the_default() {
+        // A config built by hand can carry Duration::ZERO; that must mean
+        // "default", not "fail every request on arrival".
+        let mut handler = RithmicRequestHandler::new(Duration::ZERO);
+        let rx = register(&mut handler, "zero");
+
+        let (err, elapsed) = time_out_until(&mut handler, rx).await;
+
+        assert_eq!(err, RithmicError::RequestTimeout);
+        assert_eq!(elapsed, DEFAULT_REQUEST_TIMEOUT);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_silent_request_fails_exactly_at_its_timeout() {
+        let mut handler = timeout_handler();
+        let rx = register(&mut handler, "late");
+
+        let (err, elapsed) = time_out_until(&mut handler, rx).await;
+
+        assert_eq!(err, RithmicError::RequestTimeout);
+        assert_eq!(elapsed, Duration::from_secs(30));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn the_request_that_times_out_soonest_fails_first() {
+        let mut handler = timeout_handler();
+        let soon = register(&mut handler, "soon");
+
+        tokio::time::advance(Duration::from_secs(10)).await;
+
+        let late = register(&mut handler, "late");
+
+        let (_, elapsed) = time_out_until(&mut handler, soon).await;
+        assert_eq!(elapsed, Duration::from_secs(20), "registered 10s earlier");
+
+        let (_, elapsed) = time_out_until(&mut handler, late).await;
+        assert_eq!(elapsed, Duration::from_secs(10), "10s behind the first");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn every_request_due_at_the_same_time_fails_together() {
+        let mut handler = timeout_handler();
+        let mut receivers: Vec<_> = (0..5)
+            .map(|i| register(&mut handler, &format!("req-{i}")))
+            .collect();
+
+        let last = receivers.pop().unwrap();
+        let (_, elapsed) = time_out_until(&mut handler, last).await;
+
+        assert_eq!(elapsed, Duration::from_secs(30));
+        assert!(
+            handler.handle_map.is_empty(),
+            "one pass, not one per request"
+        );
+
+        for mut rx in receivers {
+            assert_eq!(
+                rx.try_recv().unwrap().unwrap_err(),
+                RithmicError::RequestTimeout
+            );
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_drained_request_is_not_timed_out_afterwards() {
+        let mut handler = timeout_handler();
+        let mut rx = register(&mut handler, "req-1");
+
+        handler.drain_and_drop();
+
+        assert_eq!(
+            rx.try_recv().unwrap().unwrap_err(),
+            RithmicError::ConnectionClosed
+        );
+
+        // Nothing left to time out, so the loop parks instead of firing.
+        tokio::select! {
+            _ = handler.fail_timed_out() => panic!("fired on a drained request"),
+            _ = tokio::time::sleep(Duration::from_secs(3600)) => {}
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_response_just_before_the_timeout_still_wins() {
+        let mut handler = timeout_handler();
+        let mut rx = register(&mut handler, "close-call");
+
+        tokio::time::advance(Duration::from_secs(29)).await;
+        handler.handle_response(make_response("close-call", login_message()));
+
+        assert_eq!(rx.try_recv().unwrap().unwrap().len(), 1);
+
+        tokio::select! {
+            _ = handler.fail_timed_out() => panic!("fired on an answered request"),
+            _ = tokio::time::sleep(Duration::from_secs(3600)) => {}
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_timed_out_request_is_removed() {
+        let mut handler = timeout_handler();
+        let rx = register(&mut handler, "late");
+
+        time_out_until(&mut handler, rx).await;
+
+        assert!(handler.handle_map.is_empty());
+        assert!(!handler.fail_request("late", RithmicError::SendFailed));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_request_answered_in_time_is_never_failed() {
+        let mut handler = timeout_handler();
+        let mut rx = register(&mut handler, "ok");
+
+        handler.handle_response(make_response("ok", login_message()));
+
+        assert_eq!(rx.try_recv().unwrap().unwrap().len(), 1);
+
+        // Nothing registered, so the loop parks rather than firing.
+        tokio::select! {
+            _ = handler.fail_timed_out() => unreachable!(),
+            _ = tokio::time::sleep(Duration::from_secs(3600)) => {}
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_multi_response_part_restarts_the_timeout() {
+        let mut handler = timeout_handler();
+        let rx = register(&mut handler, "stream");
+
+        // A part arrives 20s in, moving the timeout to 20s + 30s.
+        tokio::time::advance(Duration::from_secs(20)).await;
+
+        let mut part = make_response("stream", ref_data_message());
+        part.multi_response = true;
+        part.has_more = true;
+        handler.handle_response(part);
+
+        let (err, elapsed) = time_out_until(&mut handler, rx).await;
+
+        assert_eq!(err, RithmicError::RequestTimeout);
+        assert_eq!(elapsed, Duration::from_secs(30), "measured from the part");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_timeout_clears_partial_multi_responses() {
+        let mut handler = timeout_handler();
+        let rx = register(&mut handler, "m");
+
+        let mut part = make_response("m", ref_data_message());
+        part.multi_response = true;
+        part.has_more = true;
+        handler.handle_response(part);
+
+        time_out_until(&mut handler, rx).await;
+
+        assert!(handler.response_vec_map.is_empty());
+
+        // A new request reusing the ID must not inherit the stale part. Only a
+        // terminal multi-part response merges the map, so probe with one.
+        let mut rx2 = register(&mut handler, "m");
+
+        let mut probe = make_response("m", ref_data_message());
+        probe.multi_response = true;
+        probe.has_more = false;
+        handler.handle_response(probe);
+
+        assert_eq!(rx2.try_recv().unwrap().unwrap().len(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn parts_arriving_after_a_timeout_do_not_re_create_the_partial_buffer() {
+        let mut handler = timeout_handler();
+        let rx = register(&mut handler, "42");
+
+        let mut first = make_response("42", ref_data_message());
+        first.multi_response = true;
+        first.has_more = true;
+        handler.handle_response(first);
+
+        time_out_until(&mut handler, rx).await;
+
+        // The server resumes streaming the request that was just failed.
+        for _ in 0..3 {
+            let mut late = make_response("42", ref_data_message());
+            late.multi_response = true;
+            late.has_more = true;
+            handler.handle_response(late);
+        }
+
+        assert!(
+            handler.response_vec_map.is_empty(),
+            "parts for an unregistered id must not re-create the buffer"
+        );
+
+        // The terminal part finds no responder and must not leave one behind.
+        let mut terminal = make_response("42", ref_data_message());
+        terminal.multi_response = true;
+        terminal.has_more = false;
+        handler.handle_response(terminal);
+
+        assert!(handler.response_vec_map.is_empty());
+    }
+
+    #[test]
+    fn parts_for_a_never_registered_id_do_not_accumulate() {
+        let mut handler = timeout_handler();
+
+        for _ in 0..3 {
+            let mut part = make_response("ghost", ref_data_message());
+            part.multi_response = true;
+            part.has_more = true;
+            handler.handle_response(part);
+        }
+
+        assert!(
+            handler.response_vec_map.is_empty(),
+            "parts for an id that was never registered must not accumulate"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_caller_that_walked_away_does_not_stall_the_loop() {
+        let mut handler = timeout_handler();
+        let (tx, rx) = oneshot::channel();
+
+        handler.register_request(RithmicRequest {
+            request_id: "gone".to_string(),
+            responder: tx,
+        });
+
+        // The caller gave up and dropped its receiver, so nothing observes the
+        // failure. The entry must still be removed rather than retried forever.
+        drop(rx);
+
+        let live = register(&mut handler, "live");
+        let (_, elapsed) = time_out_until(&mut handler, live).await;
+
+        assert_eq!(elapsed, Duration::from_secs(30));
+        assert!(handler.handle_map.is_empty());
     }
 
     // =========================================================================
@@ -367,14 +733,14 @@ mod tests {
 
     #[test]
     fn response_for_unregistered_id_does_not_panic() {
-        let mut handler = RithmicRequestHandler::new();
+        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
 
         handler.handle_response(make_response("ghost", login_message()));
     }
 
     #[test]
     fn dropped_receiver_does_not_panic() {
-        let mut handler = RithmicRequestHandler::new();
+        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
         let (tx, rx) = oneshot::channel();
 
         handler.register_request(RithmicRequest {
@@ -390,7 +756,7 @@ mod tests {
     #[test]
     fn single_response_clears_partial_multi_responses_for_the_same_id() {
         // Mirrors a decode failure landing mid multi-part response.
-        let mut handler = RithmicRequestHandler::new();
+        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
         let (tx, mut rx) = oneshot::channel();
 
         handler.register_request(RithmicRequest {


### PR DESCRIPTION
## The problem

If the server never answered a request (or answered with a request id we weren't waiting on), the caller was stuck forever. Nothing resolved a pending request except a matching response or `drain_and_drop()` on disconnect, so on the order plant a `place_order().await` could just never return.

While digging into that I found two neighboring issues. Parts of multi-part responses were buffered by request id unconditionally, so parts arriving for a request that had already been resolved or failed would quietly re-create the buffer entry, and since request ids are never reused that memory stuck around until the next disconnect. And the ping timeout had an off-by-one at the deadline itself: `next_timeout_at()` said the timeout was at `sent_at + timeout` but `check_timeout()` required strictly more than that to have elapsed, so the loop could wake at the deadline, decide nothing had happened, and spin until the clock moved on.

## The fix

Requests now carry a deadline. `RithmicRequestHandler::fail_timed_out()` sleeps until the soonest one, fails everything due with the new `RithmicError::RequestTimeout`, and repeats. It never returns, so it lives as a `select!` arm in the plant loop with no per-plant wiring. The timeout measures silence rather than total duration: each part of a multi-part response pushes the deadline out, so a slow replay that keeps arriving doesn't get cut off. Parts are also only buffered while someone is actually waiting on the request, which closes the memory growth. The default is 30 seconds, configurable per connection with `RithmicConfigBuilder::request_timeout` or the `RITHMIC_REQUEST_TIMEOUT_SECS` env var (zero or unset means the default). `RithmicConfig` gains the `request_timeout` field, which is breaking, but this release already has queued breaking changes.

`PingManager` got the same treatment: `timed_out()` sleeps to the deadline and resolves once, replacing the sleep-then-recheck dance, so `SelectResult::PingTimeout` now simply means the link is dead. With that gone the four plants' `select!` blocks were byte-identical, so they moved into `PlantCore::next_event` and each plant loop shrank by about 56 lines.

One caveat worth keeping in mind: a timed-out request was still sent. `RequestTimeout` is deliberately not treated as a connection issue, and an order that times out should be reconciled against the order-update stream, not blindly re-sent. This is called out in the crate docs and changelog.