### PR TITLE
fix(plants): stop the actor on a server ForcedLogout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Public struct fields and a method signature change, so this lands in a major rel
   Rithmic to reject the trailing stop with rp_code 1112).
 - **`request_account_rms_updates` sent `update_bits: None`**, so `auto_liq_threshold_current_value`
   never streamed even when subscribed.
+- **A server `ForcedLogout` (template 77) now stops the plant actor.** All four plants drain their pending requests with `ConnectionClosed`, set `close_requested` and stop the loop, instead of heartbeating a session the server has ended while callers await oneshots that never resolve. Subscribers receive the `ForcedLogout` frame unchanged, followed by the `ConnectionError` actor-lifecycle event every stopping path emits — stopping the loop means no later path raises it.
 
 ## [2.0.0]
 

--- a/src/plants/core.rs
+++ b/src/plants/core.rs
@@ -370,7 +370,16 @@ where
                 let source = self.rithmic_receiver_api.source.clone();
 
                 match self.rithmic_receiver_api.buf_to_message(data) {
-                    Ok(response) => self.forward_response(&source, response),
+                    Ok(response) => {
+                        let forced_logout =
+                            matches!(response.message, RithmicMessage::ForcedLogout(_));
+
+                        self.forward_response(&source, response);
+
+                        if forced_logout {
+                            stop = self.handle_forced_logout();
+                        }
+                    }
                     Err(err_response) => {
                         error!("{}: decode failure: {:?}", source, err_response);
                         self.forward_response(&source, err_response);
@@ -467,6 +476,26 @@ where
         }
 
         stop
+    }
+
+    /// Terminate the session after a server-sent `ForcedLogout` (template 77).
+    /// Returns `true` (stop).
+    ///
+    /// `forward_response` has already broadcast the frame itself, which is what
+    /// distinguishes this from an ordinary disconnect; the `ConnectionError`
+    /// lifecycle event emitted here follows it, since stopping the loop means no
+    /// later path emits one.
+    pub(crate) fn handle_forced_logout(&mut self) -> bool {
+        error!(
+            "{}: server sent a forced logout — stopping",
+            self.rithmic_receiver_api.source
+        );
+        // Drain first: the loop is about to stop, so nothing else will resolve these.
+        self.request_handler.drain_and_drop();
+        self.emit_connection_health_event("", RithmicError::ConnectionClosed);
+        self.close_requested = true;
+
+        true
     }
 
     /// Handle a clean EOF on the WebSocket reader stream. Returns `true` (stop).
@@ -1262,6 +1291,66 @@ mod tests {
         ));
         let result = rx1.try_recv().unwrap();
         assert!(matches!(result, Err(RithmicError::ConnectionClosed)));
+    }
+
+    /// A server-sent `ForcedLogout` (template 77) ends the session: the actor
+    /// loop stops, `close_requested` is set, pending requests resolve with an
+    /// error, and subscribers get the frame followed by the `ConnectionError`
+    /// event every stopping path emits.
+    #[tokio::test]
+    async fn forced_logout_stops_actor_and_emits_frame_then_connection_error() {
+        use crate::rti::ForcedLogout;
+        use prost::Message as _;
+
+        let reader = make_dormant_ws_reader().await;
+        let (mut core, mut sub_rx) = make_test_core(MockMessageSink::ready(), reader);
+        let mut rx = register_request(&mut core, "req-1");
+
+        let mut payload = Vec::new();
+        ForcedLogout { template_id: 77 }
+            .encode(&mut payload)
+            .unwrap();
+        let mut framed = (payload.len() as u32).to_be_bytes().to_vec();
+        framed.extend(payload);
+
+        let stop = core
+            .handle_rithmic_message(Ok(Message::Binary(framed.into())))
+            .await;
+
+        assert!(stop, "forced logout must stop the actor loop");
+        assert!(
+            core.close_requested,
+            "forced logout must set close_requested"
+        );
+
+        let result = rx
+            .try_recv()
+            .expect("pending request must be resolved, not left hanging");
+        assert!(matches!(result, Err(RithmicError::ConnectionClosed)));
+
+        let frame_event = sub_rx.try_recv().unwrap();
+        assert!(
+            matches!(frame_event.message, RithmicMessage::ForcedLogout(_)),
+            "the ForcedLogout frame must arrive first, got {:?}",
+            frame_event.message
+        );
+        assert!(
+            frame_event
+                .error
+                .as_ref()
+                .expect("error should be set")
+                .is_connection_issue(),
+            "reconnect-driving callers must see a connection issue"
+        );
+
+        let lifecycle_event = sub_rx
+            .try_recv()
+            .expect("forced logout must emit the actor-lifecycle event every stopping path emits");
+        assert!(
+            matches!(lifecycle_event.message, RithmicMessage::ConnectionError),
+            "the lifecycle event must follow the frame, got {:?}",
+            lifecycle_event.message
+        );
     }
 
     /// Heartbeat success with a registered oneshot must resolve the oneshot


### PR DESCRIPTION
## Issue

A server `ForcedLogout` (template 77) decoded correctly and was broadcast, but nothing acted on it. The actor kept heartbeating a session the server had already terminated, and pending oneshots in the request handler were never resolved, so callers awaited responses that could never arrive.

## Solution

`handle_rithmic_message` flags a `ForcedLogout` before `forward_response` consumes the response, then calls `handle_forced_logout()`, which drains pending requests with `ConnectionClosed`, emits the `ConnectionError` lifecycle event, sets `close_requested` and stops the loop. It lives on `PlantCore`, so all four plants get it without a per-plant change.

Subscribers see the `ForcedLogout` frame first — that is what distinguishes a forced logout from an ordinary disconnect — then the lifecycle event. Stopping the loop means the close-frame, TCP-drop and ping-timeout paths never run, so the lifecycle event has to be raised here for a subscriber keying reconnect on it to see one.

Covered by one test: the actor stops, `close_requested` is set, a pending request resolves with an error, and the two events arrive in order. Reverting the fix fails it.
