### PR TITLE
fix(orders): apply bracket adjustments to the requested leg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,14 @@ Public struct fields and a method signature change, so this lands in a major rel
 - **`RithmicOrderPlantHandle::subscribe_account_rms_updates` gains a required `update_bits` parameter.**
   Pass `vec![]` for the prior behavior, or `vec![RmsUpdateBits::AutoLiqThresholdCurrentValue]` to
   stream auto-liq threshold updates.
+- **`RithmicOrderPlantHandle::adjust_profit` and `adjust_stop` take a `RithmicBracketLevelAdjustment`**
+  instead of `(id, ticks)`, adding a `level` that selects the bracket leg. `level: None` keeps the
+  prior behavior.
 
 ### Added
+
+- **`RithmicBracketLevelAdjustment`** — the command struct for `adjust_profit` and `adjust_stop`:
+  the basket `id`, the new `ticks` distance, and the `level` selecting a bracket leg.
 
 - **`RithmicMessage::RequestHeartbeat(RequestHeartbeat)`** — a keep-alive frame (template 18) sent by the server, which previously arrived as `UnknownTemplate`. Delivered on the subscription channel with `error: None` and an empty `request_id`: it answers no request you made, and its `user_msg` is the server's own token rather than an id this client handed out. The library does not reply to it. `RithmicMessage` is `#[non_exhaustive]`, so the new variant does not break existing matches.
 - **`RithmicMessage::UnknownTemplate(UnknownTemplateMessage)`** — a frame whose `template_id` has no message definition in this crate. Delivered with `error: None` and the message body kept as received. `RithmicMessage` is `#[non_exhaustive]`, so the new variant does not break existing matches.
@@ -86,6 +92,8 @@ Public struct fields and a method signature change, so this lands in a major rel
   FCM and IB logins listed no accounts. `login()` now retrieves the login info once and scopes the
   account list, account RMS info, bracket orders and cancel-all with it — so **`get_account_list` and
   `get_account_rms_info` may return fewer accounts than before**, including for `Trader` logins.
+- **Bracket target/stop level updates omitted the `level` field**, so on a multi-leg bracket every
+  adjustment landed on the server's default leg and the other legs were unreachable.
 
 ## [2.0.0]
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -26,8 +26,9 @@ pub use crate::config::RithmicAccount;
 pub use receiver_api::RithmicResponse;
 
 pub use rithmic_command_types::{
-    LoginConfig, RithmicAdvancedBracketOrder, RithmicBracketOrder, RithmicCancelOrder,
-    RithmicIfTouchedTrigger, RithmicModifyOrder, RithmicOcoOrderLeg, RithmicOrder, TrailingStop,
+    LoginConfig, RithmicAdvancedBracketOrder, RithmicBracketLevelAdjustment, RithmicBracketOrder,
+    RithmicCancelOrder, RithmicIfTouchedTrigger, RithmicModifyOrder, RithmicOcoOrderLeg,
+    RithmicOrder, TrailingStop,
 };
 
 // Re-export bracket order enums

--- a/src/api/rithmic_command_types.rs
+++ b/src/api/rithmic_command_types.rs
@@ -421,6 +421,34 @@ pub struct RithmicCancelOrder {
     pub id: String,
 }
 
+/// Adjust one leg of a bracket's profit target or stop loss.
+///
+/// The same shape serves `adjust_profit` and `adjust_stop`.
+///
+/// # Example
+///
+/// ```ignore
+/// use rithmic_rs::RithmicBracketLevelAdjustment;
+///
+/// let adjustment = RithmicBracketLevelAdjustment {
+///     id: "123456".to_string(),  // basket_id from order notification
+///     ticks: 16,
+///     level: Some(2),
+/// };
+/// handle.adjust_profit(adjustment).await?;
+/// ```
+#[derive(Debug, Clone)]
+pub struct RithmicBracketLevelAdjustment {
+    /// The `basket_id` from the order notification
+    pub id: String,
+    /// The new distance in ticks
+    pub ticks: i32,
+    /// Which bracket leg to adjust, in the order the legs were placed (see
+    /// [`RithmicAdvancedBracketOrder`]). Sent verbatim; the crate defines no
+    /// numbering. `None` omits the field.
+    pub level: Option<i32>,
+}
+
 /// Configuration for trailing stop orders.
 ///
 /// Used both by [`RithmicOrder::trailing_stop`] for a standalone order and by

--- a/src/api/sender_api.rs
+++ b/src/api/sender_api.rs
@@ -748,10 +748,22 @@ impl RithmicSenderApi {
         self.request_to_buf(req, id)
     }
 
+    /// Update the profit target level of a bracket
+    ///
+    /// # Arguments
+    /// * `basket_id` - The basket the bracket belongs to
+    /// * `profit_ticks` - The new profit target distance in ticks
+    /// * `level` - Which bracket leg to adjust, in the order the legs were placed.
+    ///   Sent verbatim; the crate defines no numbering. `None` omits the field.
+    /// * `account` - The account the bracket belongs to
+    ///
+    /// # Returns
+    /// A tuple of (serialized request buffer, request ID)
     pub fn request_update_target_bracket_level(
         &mut self,
         basket_id: &str,
         profit_ticks: i32,
+        level: Option<i32>,
         account: &RithmicAccount,
     ) -> (Vec<u8>, String) {
         let id = self.get_next_message_id();
@@ -762,18 +774,30 @@ impl RithmicSenderApi {
             ib_id: Some(account.ib_id.clone()),
             account_id: Some(account.account_id.clone()),
             basket_id: Some(basket_id.into()),
+            level,
             target_ticks: Some(profit_ticks),
             user_msg: vec![id.clone()],
-            ..RequestUpdateTargetBracketLevel::default()
         };
 
         self.request_to_buf(req, id)
     }
 
+    /// Update the stop loss level of a bracket
+    ///
+    /// # Arguments
+    /// * `basket_id` - The basket the bracket belongs to
+    /// * `stop_ticks` - The new stop loss distance in ticks
+    /// * `level` - Which bracket leg to adjust, in the order the legs were placed.
+    ///   Sent verbatim; the crate defines no numbering. `None` omits the field.
+    /// * `account` - The account the bracket belongs to
+    ///
+    /// # Returns
+    /// A tuple of (serialized request buffer, request ID)
     pub fn request_update_stop_bracket_level(
         &mut self,
         basket_id: &str,
         stop_ticks: i32,
+        level: Option<i32>,
         account: &RithmicAccount,
     ) -> (Vec<u8>, String) {
         let id = self.get_next_message_id();
@@ -784,9 +808,9 @@ impl RithmicSenderApi {
             ib_id: Some(account.ib_id.clone()),
             account_id: Some(account.account_id.clone()),
             basket_id: Some(basket_id.into()),
+            level,
             stop_ticks: Some(stop_ticks),
             user_msg: vec![id.clone()],
-            ..RequestUpdateStopBracketLevel::default()
         };
 
         self.request_to_buf(req, id)
@@ -2557,5 +2581,62 @@ mod tests {
             assert_eq!(request.account_id.as_deref(), Some("ACCOUNT_B"));
             assert_eq!(request.user_type, Some(cancel_all.into()));
         }
+    }
+
+    /// Every field is asserted, not just `level`: the builder now names them all
+    /// outright rather than leaning on `Default`.
+    #[test]
+    fn update_target_bracket_level_carries_requested_level() {
+        let mut api = RithmicSenderApi::new(&test_config());
+
+        let (buf, _) =
+            api.request_update_target_bracket_level("basket-1", 16, Some(2), &default_account());
+        let request: RequestUpdateTargetBracketLevel = decode_request(&buf);
+
+        assert_eq!(request.fcm_id.as_deref(), Some("FCM_A"));
+        assert_eq!(request.ib_id.as_deref(), Some("IB_A"));
+        assert_eq!(request.account_id.as_deref(), Some("ACCOUNT_A"));
+        assert_eq!(request.basket_id.as_deref(), Some("basket-1"));
+        assert_eq!(request.target_ticks, Some(16));
+        assert_eq!(request.level, Some(2));
+    }
+
+    #[test]
+    fn update_stop_bracket_level_carries_requested_level() {
+        let mut api = RithmicSenderApi::new(&test_config());
+
+        let (buf, _) =
+            api.request_update_stop_bracket_level("basket-1", 8, Some(2), &default_account());
+        let request: RequestUpdateStopBracketLevel = decode_request(&buf);
+
+        assert_eq!(request.fcm_id.as_deref(), Some("FCM_A"));
+        assert_eq!(request.ib_id.as_deref(), Some("IB_A"));
+        assert_eq!(request.account_id.as_deref(), Some("ACCOUNT_A"));
+        assert_eq!(request.basket_id.as_deref(), Some("basket-1"));
+        assert_eq!(request.stop_ticks, Some(8));
+        assert_eq!(request.level, Some(2));
+    }
+
+    /// `level` is proto2 `optional`, so a decoded `None` proves the field never
+    /// reached the wire — an explicit zero comes back as `Some(0)`.
+    #[test]
+    fn bracket_level_requests_omit_level_when_unset() {
+        let mut api = RithmicSenderApi::new(&test_config());
+
+        let target = |api: &mut RithmicSenderApi, level| {
+            let (buf, _) =
+                api.request_update_target_bracket_level("basket-1", 16, level, &default_account());
+            decode_request::<RequestUpdateTargetBracketLevel>(&buf).level
+        };
+        let stop = |api: &mut RithmicSenderApi, level| {
+            let (buf, _) =
+                api.request_update_stop_bracket_level("basket-1", 8, level, &default_account());
+            decode_request::<RequestUpdateStopBracketLevel>(&buf).level
+        };
+
+        assert_eq!(target(&mut api, None), None);
+        assert_eq!(target(&mut api, Some(0)), Some(0));
+        assert_eq!(stop(&mut api, None), None);
+        assert_eq!(stop(&mut api, Some(0)), Some(0));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,9 +310,9 @@ pub use api::{
     BracketCondition, BracketDuration, BracketPriceField, BracketPriceType, BracketTransactionType,
     BracketType, EasyToBorrowRequest, LoginConfig, ModifyPriceType, NewOrderDuration,
     NewOrderPriceType, NewOrderTransactionType, OcoDuration, OcoPriceType, OcoTransactionType,
-    RithmicAdvancedBracketOrder, RithmicBracketOrder, RithmicCancelOrder, RithmicIfTouchedTrigger,
-    RithmicModifyOrder, RithmicOcoOrderLeg, RithmicOrder, RithmicResponse, RmsUpdateBits,
-    TrailingStop,
+    RithmicAdvancedBracketOrder, RithmicBracketLevelAdjustment, RithmicBracketOrder,
+    RithmicCancelOrder, RithmicIfTouchedTrigger, RithmicModifyOrder, RithmicOcoOrderLeg,
+    RithmicOrder, RithmicResponse, RmsUpdateBits, TrailingStop,
 };
 
 // Re-export utility types for convenience

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -9,8 +9,9 @@ use crate::{
     api::{
         receiver_api::RithmicResponse,
         rithmic_command_types::{
-            LoginConfig, RithmicAdvancedBracketOrder, RithmicBracketOrder, RithmicCancelOrder,
-            RithmicModifyOrder, RithmicOcoOrderLeg, RithmicOrder,
+            LoginConfig, RithmicAdvancedBracketOrder, RithmicBracketLevelAdjustment,
+            RithmicBracketOrder, RithmicCancelOrder, RithmicModifyOrder, RithmicOcoOrderLeg,
+            RithmicOrder,
         },
         sender_api::LoginScope,
     },
@@ -78,14 +79,16 @@ pub(crate) enum OrderPlantCommand {
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
     },
     ModifyStop {
-        order_id: String,
+        basket_id: String,
         ticks: i32,
+        level: Option<i32>,
         account: Arc<RithmicAccount>,
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
     },
     ModifyProfit {
-        order_id: String,
+        basket_id: String,
         ticks: i32,
+        level: Option<i32>,
         account: Arc<RithmicAccount>,
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
     },
@@ -673,15 +676,16 @@ impl PlantActor for OrderPlant {
                     .await;
             }
             OrderPlantCommand::ModifyStop {
-                order_id,
+                basket_id,
                 ticks,
+                level,
                 account,
                 response_sender,
             } => {
                 let (req_buf, id) = self
                     .core
                     .rithmic_sender_api
-                    .request_update_stop_bracket_level(&order_id, ticks, &account);
+                    .request_update_stop_bracket_level(&basket_id, ticks, level, &account);
 
                 self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
@@ -693,15 +697,16 @@ impl PlantActor for OrderPlant {
                     .await;
             }
             OrderPlantCommand::ModifyProfit {
-                order_id,
+                basket_id,
                 ticks,
+                level,
                 account,
                 response_sender,
             } => {
                 let (req_buf, id) = self
                     .core
                     .rithmic_sender_api
-                    .request_update_target_bracket_level(&order_id, ticks, &account);
+                    .request_update_target_bracket_level(&basket_id, ticks, level, &account);
 
                 self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
@@ -1556,21 +1561,20 @@ impl RithmicOrderPlantHandle {
     /// Adjust the profit target level of a bracket order
     ///
     /// # Arguments
-    /// * `id` - The order ID
-    /// * `ticks` - Number of ticks to adjust the profit target
+    /// * `adjustment` - The bracket, the new tick distance, and the leg to adjust
     ///
     /// # Returns
     /// The adjustment response or an error message
     pub async fn adjust_profit(
         &self,
-        id: &str,
-        ticks: i32,
+        adjustment: RithmicBracketLevelAdjustment,
     ) -> Result<RithmicResponse, RithmicError> {
         let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, RithmicError>>();
 
         let command = OrderPlantCommand::ModifyProfit {
-            order_id: id.to_string(),
-            ticks,
+            basket_id: adjustment.id,
+            ticks: adjustment.ticks,
+            level: adjustment.level,
             account: self.account.clone(),
             response_sender: tx,
         };
@@ -1587,17 +1591,20 @@ impl RithmicOrderPlantHandle {
     /// Adjust the stop loss level of a bracket order
     ///
     /// # Arguments
-    /// * `id` - The order ID
-    /// * `ticks` - Number of ticks to adjust the stop loss
+    /// * `adjustment` - The bracket, the new tick distance, and the leg to adjust
     ///
     /// # Returns
     /// The adjustment response or an error message
-    pub async fn adjust_stop(&self, id: &str, ticks: i32) -> Result<RithmicResponse, RithmicError> {
+    pub async fn adjust_stop(
+        &self,
+        adjustment: RithmicBracketLevelAdjustment,
+    ) -> Result<RithmicResponse, RithmicError> {
         let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, RithmicError>>();
 
         let command = OrderPlantCommand::ModifyStop {
-            order_id: id.to_string(),
-            ticks,
+            basket_id: adjustment.id,
+            ticks: adjustment.ticks,
+            level: adjustment.level,
             account: self.account.clone(),
             response_sender: tx,
         };

--- a/src/plants/order_plant/tests.rs
+++ b/src/plants/order_plant/tests.rs
@@ -28,6 +28,14 @@ fn test_handle() -> (RithmicOrderPlantHandle, mpsc::Receiver<OrderPlantCommand>)
     (handle, command_receiver)
 }
 
+fn adjustment(id: &str, ticks: i32, level: Option<i32>) -> RithmicBracketLevelAdjustment {
+    RithmicBracketLevelAdjustment {
+        id: id.to_string(),
+        ticks,
+        level,
+    }
+}
+
 fn leg(tag: &str) -> RithmicOcoOrderLeg {
     RithmicOcoOrderLeg {
         symbol: "ESM6".to_string(),
@@ -114,6 +122,50 @@ async fn place_oco_order_multi_forwards_two_or_more_legs() {
         call.await.expect("call task panicked"),
         Err(RithmicError::ConnectionClosed)
     ));
+}
+
+/// Both calls park on their response channels, so they run alongside the
+/// receives below. Dropping each command drops its responder and unparks one.
+#[tokio::test]
+async fn adjust_profit_and_stop_forward_the_bracket_level() {
+    let (handle, mut command_receiver) = test_handle();
+
+    let call = tokio::spawn(async move {
+        let _ = handle
+            .adjust_profit(adjustment("basket-1", 16, Some(2)))
+            .await;
+        let _ = handle.adjust_stop(adjustment("basket-2", 8, None)).await;
+    });
+
+    match command_receiver.recv().await {
+        Some(OrderPlantCommand::ModifyProfit {
+            basket_id,
+            ticks,
+            level,
+            ..
+        }) => {
+            assert_eq!(basket_id, "basket-1");
+            assert_eq!(ticks, 16);
+            assert_eq!(level, Some(2));
+        }
+        _ => panic!("expected ModifyProfit to be queued"),
+    }
+
+    match command_receiver.recv().await {
+        Some(OrderPlantCommand::ModifyStop {
+            basket_id,
+            ticks,
+            level,
+            ..
+        }) => {
+            assert_eq!(basket_id, "basket-2");
+            assert_eq!(ticks, 8);
+            assert_eq!(level, None);
+        }
+        _ => panic!("expected ModifyStop to be queued"),
+    }
+
+    call.await.expect("call task panicked");
 }
 
 #[tokio::test]
@@ -456,4 +508,43 @@ async fn a_logged_in_actor_scopes_every_request_that_carries_a_user_type() {
         cancel_all.user_type,
         Some(crate::rti::request_cancel_all_orders::UserType::Ib.into())
     );
+}
+
+/// The hop the handle-level test cannot see. Its two arms are adjacent
+/// near-copies, so every value differs: a crossed arm fails rather than passes.
+#[tokio::test]
+async fn bracket_level_commands_carry_their_level_to_the_wire() {
+    let (mut plant, _sender, mut client) = plant_with_wire().await;
+
+    let target: crate::rti::RequestUpdateTargetBracketLevel =
+        sent_request(&mut plant, &mut client, |response_sender| {
+            OrderPlantCommand::ModifyProfit {
+                basket_id: "basket-1".to_string(),
+                ticks: 16,
+                level: Some(2),
+                account: test_account(),
+                response_sender,
+            }
+        })
+        .await;
+
+    assert_eq!(target.basket_id.as_deref(), Some("basket-1"));
+    assert_eq!(target.target_ticks, Some(16));
+    assert_eq!(target.level, Some(2));
+
+    let stop: crate::rti::RequestUpdateStopBracketLevel =
+        sent_request(&mut plant, &mut client, |response_sender| {
+            OrderPlantCommand::ModifyStop {
+                basket_id: "basket-2".to_string(),
+                ticks: 8,
+                level: Some(3),
+                account: test_account(),
+                response_sender,
+            }
+        })
+        .await;
+
+    assert_eq!(stop.basket_id.as_deref(), Some("basket-2"));
+    assert_eq!(stop.stop_ticks, Some(8));
+    assert_eq!(stop.level, Some(3));
 }


### PR DESCRIPTION
## Issue

`request_update_target_bracket_level` and `request_update_stop_bracket_level` both omitted `level` — `optional int32`, tag `154244` on both request types — the field that selects **which bracket leg** an adjustment applies to.

The crate supports multi-leg brackets (`RithmicAdvancedBracketOrder::target_ticks` is a `Vec<i32>`), so leg 2 and beyond were unreachable: every adjustment landed on the server's default leg. The request succeeded either way, so there was no diagnostic — the wrong leg simply moved.

## Solution

`adjust_profit` and `adjust_stop` take a `RithmicBracketLevelAdjustment { id, ticks, level }` instead of `(id, ticks)`. `level` threads through both `OrderPlantCommand` variants and both builders down to the wire.

A command struct rather than a third positional parameter, because `adjust_profit(id, 16, Some(2))` is two adjacent numeric values with nothing naming them — transposing ticks and leg is silent and produces the same wrong-leg outcome this PR exists to fix. It also matches `place_order`, `modify_order` and `cancel_order`, which already take named command structs.

`level` is sent **verbatim**: this crate defines no numbering for it and the proto carries no hint, so callers supply whatever their vendor documentation specifies. `None` omits the field, preserving the previous behavior. Do not add an offset here without a documented source.

Both request literals now name every field instead of closing with `..Default::default()`, so a field dropped in a future edit is a compile error rather than a silent default — which is how `level` went missing originally.

**Breaking change.** `adjust_profit(id, ticks)` becomes `adjust_profit(RithmicBracketLevelAdjustment { id: id.to_string(), ticks, level: None })`. No call sites in `README.md`, `examples/` or the crate docs. The migration note sits with the others in `CHANGELOG.md` under `[Unreleased] → Breaking Changes`.
