### PR TITLE
fix(orders): scope requests to the login context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,10 @@ Public struct fields and a method signature change, so this lands in a major rel
 - **`request_account_rms_updates` sent `update_bits: None`**, so `auto_liq_threshold_current_value`
   never streamed even when subscribed.
 - **A server `ForcedLogout` (template 77) now stops the plant actor.** All four plants drain their pending requests with `ConnectionClosed`, set `close_requested` and stop the loop, instead of heartbeating a session the server has ended while callers await oneshots that never resolve. Subscribers receive the `ForcedLogout` frame unchanged, followed by the `ConnectionError` actor-lifecycle event every stopping path emits — stopping the loop means no later path raises it.
+- **Requests sent a hardcoded `Trader` user type,** and the account list sent no `fcm_id`/`ib_id`, so
+  FCM and IB logins listed no accounts. `login()` now retrieves the login info once and scopes the
+  account list, account RMS info, bracket orders and cancel-all with it — so **`get_account_list` and
+  `get_account_rms_info` may return fewer accounts than before**, including for `Trader` logins.
 
 ## [2.0.0]
 

--- a/src/api/sender_api.rs
+++ b/src/api/sender_api.rs
@@ -26,22 +26,89 @@ use crate::{
         RequestSubscribeToBracketUpdates, RequestTickBarReplay, RequestTickBarUpdate,
         RequestTimeBarReplay, RequestTimeBarUpdate, RequestTradeRoutes,
         RequestUpdateStopBracketLevel, RequestUpdateTargetBracketLevel,
-        RequestVolumeProfileMinuteBars,
-        request_account_list::UserType,
-        request_account_rms_updates, request_cancel_all_orders, request_depth_by_order_updates,
-        request_easy_to_borrow_list,
+        RequestVolumeProfileMinuteBars, ResponseLoginInfo, request_account_list,
+        request_account_rms_info, request_account_rms_updates, request_bracket_order,
+        request_cancel_all_orders, request_depth_by_order_updates, request_easy_to_borrow_list,
         request_login::SysInfraType,
         request_market_data_update::{Request, UpdateBits},
         request_market_data_update_by_underlying, request_modify_order, request_oco_order,
         request_pn_l_position_updates, request_search_symbols,
         request_tick_bar_replay::{BarSubType, BarType, Direction, TimeOrder},
         request_tick_bar_update, request_time_bar_replay, request_time_bar_update,
+        response_login_info,
     },
 };
 
 pub(crate) const TRADE_ROUTE_LIVE: &str = "globex";
 pub(crate) const TRADE_ROUTE_DEMO: &str = "simulator";
-pub(crate) const USER_TYPE: i32 = 3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LoginUserType {
+    Fcm,
+    Ib,
+    Trader,
+}
+
+// Each request proto declares its own `UserType`. List every one here so no request is
+// left hardcoding a user type the login never granted.
+//
+// Mapped by name, not by cast — the numbers agree today, but a cast would keep sending
+// the old one if a proto were renumbered.
+macro_rules! login_user_type_accessors {
+    ($($accessor:ident => $request:ty),+ $(,)?) => {
+        impl LoginUserType {
+            $(
+                fn $accessor(self) -> $request {
+                    match self {
+                        LoginUserType::Fcm => <$request>::Fcm,
+                        LoginUserType::Ib => <$request>::Ib,
+                        LoginUserType::Trader => <$request>::Trader,
+                    }
+                }
+            )+
+        }
+    };
+}
+
+login_user_type_accessors! {
+    account_list => request_account_list::UserType,
+    account_rms_info => request_account_rms_info::UserType,
+    bracket_order => request_bracket_order::UserType,
+    cancel_all_orders => request_cancel_all_orders::UserType,
+}
+
+/// What a login grants, used to scope requests by it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LoginScope {
+    pub(crate) fcm_id: Option<String>,
+    pub(crate) ib_id: Option<String>,
+    pub(crate) user_type: LoginUserType,
+}
+
+impl LoginScope {
+    /// The only way to build one, so a scope that exists is always one the requests can
+    /// send. `None` for a user type they can't: `Admin`, out of range, or absent.
+    ///
+    /// `Admin` is missing from the account-list and RMS-info protos entirely, so a scope
+    /// only half the requests could use would be worse than none.
+    pub(crate) fn from_login_info(info: &ResponseLoginInfo) -> Option<Self> {
+        let user_type = match info
+            .user_type
+            .and_then(|ty| response_login_info::UserType::try_from(ty).ok())?
+        {
+            response_login_info::UserType::Fcm => LoginUserType::Fcm,
+            response_login_info::UserType::Ib => LoginUserType::Ib,
+            response_login_info::UserType::Trader => LoginUserType::Trader,
+            response_login_info::UserType::Admin => return None,
+        };
+
+        Some(LoginScope {
+            fcm_id: info.fcm_id.clone(),
+            ib_id: info.ib_id.clone(),
+            user_type,
+        })
+    }
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct RithmicSenderApi {
@@ -388,14 +455,26 @@ impl RithmicSenderApi {
         self.request_to_buf(req, id)
     }
 
-    pub fn request_account_list(&mut self) -> (Vec<u8>, String) {
+    /// Request the accounts visible to the logged-in user
+    ///
+    /// # Arguments
+    /// * `scope` - Narrows the query to the login. `None` sends no ids and `Trader`.
+    ///
+    /// # Returns
+    /// A tuple of (serialized request buffer, request ID)
+    pub fn request_account_list(&mut self, scope: Option<&LoginScope>) -> (Vec<u8>, String) {
         let id = self.get_next_message_id();
 
         let req = RequestAccountList {
             template_id: 302,
-            fcm_id: None,
-            ib_id: None,
-            user_type: Some(UserType::Trader.into()),
+            fcm_id: scope.and_then(|s| s.fcm_id.clone()),
+            ib_id: scope.and_then(|s| s.ib_id.clone()),
+            user_type: Some(
+                scope
+                    .map_or(LoginUserType::Trader, |s| s.user_type)
+                    .account_list()
+                    .into(),
+            ),
             user_msg: vec![id.clone()],
         };
 
@@ -488,14 +567,16 @@ impl RithmicSenderApi {
         &mut self,
         bracket_order: RithmicBracketOrder,
         account: &RithmicAccount,
+        scope: Option<&LoginScope>,
     ) -> (Vec<u8>, String) {
-        self.request_advanced_bracket_order(bracket_order.into(), account)
+        self.request_advanced_bracket_order(bracket_order.into(), account, scope)
     }
 
     pub fn request_advanced_bracket_order(
         &mut self,
         bracket_order: RithmicAdvancedBracketOrder,
         account: &RithmicAccount,
+        scope: Option<&LoginScope>,
     ) -> (Vec<u8>, String) {
         let id = self.get_next_message_id();
 
@@ -512,7 +593,12 @@ impl RithmicSenderApi {
             trade_route: Some(trade_route.into()),
             exchange: Some(bracket_order.exchange),
             symbol: Some(bracket_order.symbol),
-            user_type: Some(USER_TYPE),
+            user_type: Some(
+                scope
+                    .map_or(LoginUserType::Trader, |s| s.user_type)
+                    .bracket_order()
+                    .into(),
+            ),
             quantity: Some(bracket_order.quantity),
             transaction_type: Some(bracket_order.action.into()),
             price_type: Some(bracket_order.price_type.into()),
@@ -988,7 +1074,11 @@ impl RithmicSenderApi {
     ///
     /// # Returns
     /// A tuple of (serialized request buffer, request ID)
-    pub fn request_cancel_all_orders(&mut self, account: &RithmicAccount) -> (Vec<u8>, String) {
+    pub fn request_cancel_all_orders(
+        &mut self,
+        account: &RithmicAccount,
+        scope: Option<&LoginScope>,
+    ) -> (Vec<u8>, String) {
         let id = self.get_next_message_id();
 
         let req = RequestCancelAllOrders {
@@ -996,7 +1086,12 @@ impl RithmicSenderApi {
             fcm_id: Some(account.fcm_id.clone()),
             ib_id: Some(account.ib_id.clone()),
             account_id: Some(account.account_id.clone()),
-            user_type: Some(USER_TYPE),
+            user_type: Some(
+                scope
+                    .map_or(LoginUserType::Trader, |s| s.user_type)
+                    .cancel_all_orders()
+                    .into(),
+            ),
             manual_or_auto: Some(request_cancel_all_orders::OrderPlacement::Manual.into()),
             user_msg: vec![id.clone()],
         };
@@ -1006,19 +1101,39 @@ impl RithmicSenderApi {
 
     /// Request account RMS (Risk Management System) information
     ///
-    /// Returns risk management limits and settings for the account.
+    /// Template 304 has no `account_id` field, so this covers every account the login
+    /// reaches rather than one account.
+    ///
+    /// # Arguments
+    /// * `account` - Supplies the ids only when there is no scope.
+    /// * `scope` - Narrows the query to the login.
     ///
     /// # Returns
     /// A tuple of (serialized request buffer, request ID)
-    pub fn request_account_rms_info(&mut self, account: &RithmicAccount) -> (Vec<u8>, String) {
+    pub fn request_account_rms_info(
+        &mut self,
+        account: &RithmicAccount,
+        scope: Option<&LoginScope>,
+    ) -> (Vec<u8>, String) {
         let id = self.get_next_message_id();
 
         let req = RequestAccountRmsInfo {
             template_id: 304,
             user_msg: vec![id.clone()],
-            fcm_id: Some(account.fcm_id.clone()),
-            ib_id: Some(account.ib_id.clone()),
-            user_type: Some(USER_TYPE),
+            fcm_id: match scope {
+                Some(scope) => scope.fcm_id.clone(),
+                None => Some(account.fcm_id.clone()),
+            },
+            ib_id: match scope {
+                Some(scope) => scope.ib_id.clone(),
+                None => Some(account.ib_id.clone()),
+            },
+            user_type: Some(
+                scope
+                    .map_or(LoginUserType::Trader, |s| s.user_type)
+                    .account_rms_info()
+                    .into(),
+            ),
         };
 
         self.request_to_buf(req, id)
@@ -1902,7 +2017,7 @@ mod tests {
             symbol: "ESM6".to_string(),
         };
 
-        let (buf, _) = api.request_bracket_order(bracket, &override_account());
+        let (buf, _) = api.request_bracket_order(bracket, &override_account(), None);
         let request: RequestBracketOrder = decode_request(&buf);
 
         assert_eq!(request.fcm_id.as_deref(), Some("FCM_B"));
@@ -1925,7 +2040,8 @@ mod tests {
     fn advanced_bracket_request_sets_account_and_trade_route_fields() {
         let mut api = RithmicSenderApi::new(&test_config());
 
-        let (buf, _) = api.request_advanced_bracket_order(advanced_bracket(), &override_account());
+        let (buf, _) =
+            api.request_advanced_bracket_order(advanced_bracket(), &override_account(), None);
         let request: RequestBracketOrder = decode_request(&buf);
 
         assert_eq!(request.fcm_id.as_deref(), Some("FCM_B"));
@@ -1939,7 +2055,8 @@ mod tests {
     fn advanced_bracket_request_encodes_trigger_and_if_touched_fields() {
         let mut api = RithmicSenderApi::new(&test_config());
 
-        let (buf, _) = api.request_advanced_bracket_order(advanced_bracket(), &default_account());
+        let (buf, _) =
+            api.request_advanced_bracket_order(advanced_bracket(), &default_account(), None);
         let request: RequestBracketOrder = decode_request(&buf);
         assert_eq!(request.price, Some(5000.25));
         assert_eq!(request.trigger_price, Some(4999.75));
@@ -1972,7 +2089,8 @@ mod tests {
     fn advanced_bracket_request_encodes_management_and_timing_fields() {
         let mut api = RithmicSenderApi::new(&test_config());
 
-        let (buf, _) = api.request_advanced_bracket_order(advanced_bracket(), &default_account());
+        let (buf, _) =
+            api.request_advanced_bracket_order(advanced_bracket(), &default_account(), None);
         let request: RequestBracketOrder = decode_request(&buf);
 
         assert_eq!(request.break_even_ticks, Some(2));
@@ -2288,5 +2406,156 @@ mod tests {
         let request: RequestModifyOrder = decode_request(&buf);
 
         assert_eq!(request.trigger_price, Some(5005.0));
+    }
+
+    /// A login granting `user_type`.
+    fn test_login_info(user_type: response_login_info::UserType) -> ResponseLoginInfo {
+        ResponseLoginInfo {
+            template_id: 301,
+            fcm_id: Some("FCM_LOGIN".to_string()),
+            ib_id: Some("IB_LOGIN".to_string()),
+            user_type: Some(user_type.into()),
+            ..ResponseLoginInfo::default()
+        }
+    }
+
+    #[test]
+    fn login_scope_maps_each_expressible_user_type() {
+        for (from, expected) in [
+            (response_login_info::UserType::Fcm, LoginUserType::Fcm),
+            (response_login_info::UserType::Ib, LoginUserType::Ib),
+            (response_login_info::UserType::Trader, LoginUserType::Trader),
+        ] {
+            let scope = LoginScope::from_login_info(&test_login_info(from))
+                .unwrap_or_else(|| panic!("{from:?} is expressible"));
+
+            assert_eq!(scope.user_type, expected);
+            assert_eq!(scope.fcm_id.as_deref(), Some("FCM_LOGIN"));
+            assert_eq!(scope.ib_id.as_deref(), Some("IB_LOGIN"));
+        }
+    }
+
+    #[test]
+    fn login_scope_rejects_a_user_type_it_cannot_express() {
+        // Carrying the ids under a substituted `Trader` would narrow the query to a
+        // scope the login never granted, so there is no partial scope to build.
+        for info in [
+            test_login_info(response_login_info::UserType::Admin),
+            ResponseLoginInfo {
+                user_type: Some(99),
+                ..test_login_info(response_login_info::UserType::Ib)
+            },
+            ResponseLoginInfo {
+                user_type: None,
+                ..test_login_info(response_login_info::UserType::Ib)
+            },
+        ] {
+            assert!(
+                LoginScope::from_login_info(&info).is_none(),
+                "{:?} must not produce a scope",
+                info.user_type
+            );
+        }
+    }
+
+    /// A scope as a successful login would leave it.
+    fn test_scope(user_type: LoginUserType) -> LoginScope {
+        LoginScope {
+            fcm_id: Some("FCM_LOGIN".to_string()),
+            ib_id: Some("IB_LOGIN".to_string()),
+            user_type,
+        }
+    }
+
+    #[test]
+    fn account_list_carries_the_scope() {
+        let mut api = RithmicSenderApi::new(&test_config());
+
+        // Trader is included on purpose: those logins carry ids too, so their bytes
+        // change as well.
+        for (user_type, expected) in [
+            (LoginUserType::Fcm, request_account_list::UserType::Fcm),
+            (LoginUserType::Ib, request_account_list::UserType::Ib),
+            (
+                LoginUserType::Trader,
+                request_account_list::UserType::Trader,
+            ),
+        ] {
+            let (buf, _) = api.request_account_list(Some(&test_scope(user_type)));
+            let request: RequestAccountList = decode_request(&buf);
+
+            assert_eq!(request.fcm_id.as_deref(), Some("FCM_LOGIN"));
+            assert_eq!(request.ib_id.as_deref(), Some("IB_LOGIN"));
+            assert_eq!(request.user_type, Some(expected.into()));
+        }
+    }
+
+    /// 304 has no `account_id`, so the login wins over the account passed in.
+    #[test]
+    fn account_rms_info_carries_the_scope_over_the_account() {
+        let mut api = RithmicSenderApi::new(&test_config());
+
+        for (user_type, expected) in [
+            (LoginUserType::Fcm, request_account_rms_info::UserType::Fcm),
+            (LoginUserType::Ib, request_account_rms_info::UserType::Ib),
+            (
+                LoginUserType::Trader,
+                request_account_rms_info::UserType::Trader,
+            ),
+        ] {
+            let (buf, _) =
+                api.request_account_rms_info(&override_account(), Some(&test_scope(user_type)));
+            let request: RequestAccountRmsInfo = decode_request(&buf);
+
+            assert_eq!(request.fcm_id.as_deref(), Some("FCM_LOGIN"));
+            assert_eq!(request.ib_id.as_deref(), Some("IB_LOGIN"));
+            assert_eq!(request.user_type, Some(expected.into()));
+        }
+    }
+
+    /// 330 and 346 name an account, so only the user type comes from the scope.
+    #[test]
+    fn account_requests_take_only_the_user_type_from_the_scope() {
+        let mut api = RithmicSenderApi::new(&test_config());
+
+        for (user_type, bracket, cancel_all) in [
+            (
+                LoginUserType::Fcm,
+                request_bracket_order::UserType::Fcm,
+                request_cancel_all_orders::UserType::Fcm,
+            ),
+            (
+                LoginUserType::Ib,
+                request_bracket_order::UserType::Ib,
+                request_cancel_all_orders::UserType::Ib,
+            ),
+            (
+                LoginUserType::Trader,
+                request_bracket_order::UserType::Trader,
+                request_cancel_all_orders::UserType::Trader,
+            ),
+        ] {
+            let scope = test_scope(user_type);
+
+            let (buf, _) = api.request_advanced_bracket_order(
+                advanced_bracket(),
+                &override_account(),
+                Some(&scope),
+            );
+            let request: RequestBracketOrder = decode_request(&buf);
+
+            assert_eq!(request.fcm_id.as_deref(), Some("FCM_B"));
+            assert_eq!(request.ib_id.as_deref(), Some("IB_B"));
+            assert_eq!(request.account_id.as_deref(), Some("ACCOUNT_B"));
+            assert_eq!(request.user_type, Some(bracket.into()));
+
+            let (buf, _) = api.request_cancel_all_orders(&override_account(), Some(&scope));
+            let request: RequestCancelAllOrders = decode_request(&buf);
+
+            assert_eq!(request.fcm_id.as_deref(), Some("FCM_B"));
+            assert_eq!(request.ib_id.as_deref(), Some("IB_B"));
+            assert_eq!(request.account_id.as_deref(), Some("ACCOUNT_B"));
+            assert_eq!(request.user_type, Some(cancel_all.into()));
+        }
     }
 }

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use futures_util::StreamExt;
 use tokio_tungstenite::tungstenite::Message;
@@ -12,6 +12,7 @@ use crate::{
             LoginConfig, RithmicAdvancedBracketOrder, RithmicBracketOrder, RithmicCancelOrder,
             RithmicModifyOrder, RithmicOcoOrderLeg, RithmicOrder,
         },
+        sender_api::LoginScope,
     },
     config::{RithmicAccount, RithmicConfig},
     error::RithmicError,
@@ -324,6 +325,8 @@ pub struct RithmicOrderPlant {
     pub(crate) connection_handle: JoinHandle<()>,
     sender: mpsc::Sender<OrderPlantCommand>,
     subscription_sender: broadcast::Sender<RithmicResponse>,
+    /// Shared with the actor and every handle, so one login scopes them all.
+    login_scope: Arc<OnceLock<LoginScope>>,
 }
 
 impl RithmicOrderPlant {
@@ -346,7 +349,15 @@ impl RithmicOrderPlant {
     ) -> Result<RithmicOrderPlant, RithmicError> {
         let (req_tx, req_rx) = mpsc::channel::<OrderPlantCommand>(64);
         let (sub_tx, _sub_rx) = broadcast::channel(10_000);
-        let mut order_plant = OrderPlant::new(req_rx, sub_tx.clone(), config, strategy).await?;
+        let login_scope = Arc::new(OnceLock::new());
+        let mut order_plant = OrderPlant::new(
+            req_rx,
+            sub_tx.clone(),
+            config,
+            strategy,
+            Arc::clone(&login_scope),
+        )
+        .await?;
 
         let connection_handle = tokio::spawn(async move {
             order_plant.run().await;
@@ -356,6 +367,7 @@ impl RithmicOrderPlant {
             connection_handle,
             sender: req_tx,
             subscription_sender: sub_tx,
+            login_scope,
         })
     }
 }
@@ -376,6 +388,7 @@ impl RithmicOrderPlant {
 
         RithmicOrderPlantHandle {
             account,
+            login_scope: Arc::clone(&self.login_scope),
             sender: self.sender.clone(),
             subscription_receiver: SubscriptionFilter::new(
                 account_for_filter,
@@ -389,6 +402,7 @@ impl RithmicOrderPlant {
 struct OrderPlant {
     core: PlantCore,
     request_receiver: mpsc::Receiver<OrderPlantCommand>,
+    login_scope: Arc<OnceLock<LoginScope>>,
 }
 
 impl OrderPlant {
@@ -397,12 +411,14 @@ impl OrderPlant {
         subscription_sender: broadcast::Sender<RithmicResponse>,
         config: &RithmicConfig,
         strategy: ConnectStrategy,
+        login_scope: Arc<OnceLock<LoginScope>>,
     ) -> Result<OrderPlant, RithmicError> {
         let core = PlantCore::new(subscription_sender, config, strategy, "order_plant").await?;
 
         Ok(OrderPlant {
             core,
             request_receiver,
+            login_scope,
         })
     }
 }
@@ -522,7 +538,10 @@ impl PlantActor for OrderPlant {
                 self.core.handle_update_heartbeat(seconds);
             }
             OrderPlantCommand::AccountList { response_sender } => {
-                let (req_buf, id) = self.core.rithmic_sender_api.request_account_list();
+                let (req_buf, id) = self
+                    .core
+                    .rithmic_sender_api
+                    .request_account_list(self.login_scope.get());
 
                 self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
@@ -574,10 +593,11 @@ impl PlantActor for OrderPlant {
                 account,
                 response_sender,
             } => {
-                let (req_buf, id) = self
-                    .core
-                    .rithmic_sender_api
-                    .request_bracket_order(bracket_order, &account);
+                let (req_buf, id) = self.core.rithmic_sender_api.request_bracket_order(
+                    bracket_order,
+                    &account,
+                    self.login_scope.get(),
+                );
 
                 self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
@@ -593,10 +613,11 @@ impl PlantActor for OrderPlant {
                 account,
                 response_sender,
             } => {
-                let (req_buf, id) = self
-                    .core
-                    .rithmic_sender_api
-                    .request_advanced_bracket_order(bracket_order, &account);
+                let (req_buf, id) = self.core.rithmic_sender_api.request_advanced_bracket_order(
+                    bracket_order,
+                    &account,
+                    self.login_scope.get(),
+                );
 
                 self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
@@ -713,7 +734,7 @@ impl PlantActor for OrderPlant {
                 let (req_buf, id) = self
                     .core
                     .rithmic_sender_api
-                    .request_cancel_all_orders(&account);
+                    .request_cancel_all_orders(&account, self.login_scope.get());
 
                 self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
@@ -731,7 +752,7 @@ impl PlantActor for OrderPlant {
                 let (req_buf, id) = self
                     .core
                     .rithmic_sender_api
-                    .request_account_rms_info(&account);
+                    .request_account_rms_info(&account, self.login_scope.get());
 
                 self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
@@ -1206,6 +1227,8 @@ impl PlantActor for OrderPlant {
 /// updates arrive on [`subscription_receiver`](Self::subscription_receiver).
 pub struct RithmicOrderPlantHandle {
     account: Arc<RithmicAccount>,
+    /// Set by the first successful login on any handle from this plant.
+    login_scope: Arc<OnceLock<LoginScope>>,
     sender: mpsc::Sender<OrderPlantCommand>,
     /// Receiver for real-time order updates and responses.
     pub subscription_receiver: SubscriptionFilter,
@@ -1303,6 +1326,23 @@ impl RithmicOrderPlantHandle {
             }
         }
 
+        // Non-fatal: the login already succeeded, so failing to get the scope just
+        // leaves later requests unscoped rather than failing the connection.
+        match self.get_login_info().await {
+            Ok(response) => {
+                if let Some(err) = &response.error {
+                    warn!(
+                        "order_plant: login info rejected, account list will be unscoped: {:?}",
+                        err
+                    );
+                }
+            }
+            Err(err) => warn!(
+                "order_plant: login info unavailable, account list will be unscoped: {:?}",
+                err
+            ),
+        }
+
         info!("order_plant: logged in");
 
         Ok(response)
@@ -1344,10 +1384,18 @@ impl RithmicOrderPlantHandle {
 
     /// Get a list of available trading accounts
     ///
+    /// Returns the accounts the login covers. Unscoped, and so possibly wider, if
+    /// [`Self::login`] could not retrieve the login info.
+    ///
     /// # Returns
     /// A vector of account list responses or an error message
     pub async fn get_account_list(&self) -> Result<Vec<RithmicResponse>, RithmicError> {
         let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, RithmicError>>();
+
+        // Warn here too, not just at login: this is where the wider list comes back.
+        if self.login_scope.get().is_none() {
+            warn!("order_plant: no login info retained, listing accounts unscoped");
+        }
 
         let command = OrderPlantCommand::AccountList {
             response_sender: tx,
@@ -1615,6 +1663,9 @@ impl RithmicOrderPlantHandle {
     }
 
     /// Get account RMS (Risk Management System) information
+    ///
+    /// Template 304 names no account, so like [`get_account_list`](Self::get_account_list)
+    /// this covers every account the login reaches, not just this handle's.
     ///
     /// # Returns
     /// A vector of RMS info responses or an error message
@@ -2118,6 +2169,9 @@ impl RithmicOrderPlantHandle {
 
     /// Get login information for the current session
     ///
+    /// [`Self::login`] already calls this once and the first success is what scopes
+    /// later requests, so calling it again returns the response but changes nothing.
+    ///
     /// # Returns
     /// The login info response or an error message
     pub async fn get_login_info(&self) -> Result<RithmicResponse, RithmicError> {
@@ -2129,11 +2183,27 @@ impl RithmicOrderPlantHandle {
 
         let _ = self.sender.send(command).await;
 
-        rx.await
+        let response = rx
+            .await
             .map_err(|_| RithmicError::ConnectionClosed)??
             .into_iter()
             .next()
-            .ok_or(RithmicError::EmptyResponse)
+            .ok_or(RithmicError::EmptyResponse)?;
+
+        // A rejected response has no usable identity in it. (A `match` rather than a
+        // let-chain: those need Rust 1.88 and the MSRV is 1.85.)
+        let scope = match &response.message {
+            RithmicMessage::ResponseLoginInfo(info) if response.error.is_none() => {
+                LoginScope::from_login_info(info)
+            }
+            _ => None,
+        };
+
+        if let Some(scope) = scope {
+            let _ = self.login_scope.set(scope);
+        }
+
+        Ok(response)
     }
 
     /// List unaccepted agreements

--- a/src/plants/order_plant/tests.rs
+++ b/src/plants/order_plant/tests.rs
@@ -2,10 +2,14 @@ use tokio::net::TcpStream;
 
 use super::*;
 use crate::{
-    api::rithmic_command_types::RithmicOcoOrderLeg,
+    RithmicRequestError,
+    api::{
+        rithmic_command_types::{RithmicBracketOrder, RithmicOcoOrderLeg},
+        sender_api::LoginUserType,
+    },
     plants::test_support::{
         self, Responder, assert_close_still_sent, assert_rejected_after_close,
-        assert_sent_while_open, assert_wire_silent, test_account,
+        assert_sent_while_open, assert_wire_silent, read_wire_request, test_account,
     },
 };
 
@@ -16,6 +20,7 @@ fn test_handle() -> (RithmicOrderPlantHandle, mpsc::Receiver<OrderPlantCommand>)
 
     let handle = RithmicOrderPlantHandle {
         account: account.clone(),
+        login_scope: Arc::new(OnceLock::new()),
         sender,
         subscription_receiver: SubscriptionFilter::new(account, subscription_receiver),
     };
@@ -42,6 +47,7 @@ async fn plant_with_wire() -> (OrderPlant, mpsc::Sender<OrderPlantCommand>, TcpS
     test_support::plant_with_wire("order_plant", |core, request_receiver| OrderPlant {
         core,
         request_receiver,
+        login_scope: Arc::new(OnceLock::new()),
     })
     .await
 }
@@ -144,6 +150,7 @@ async fn place_order_through_the_handle_after_close_requested_reports_connection
     let account = test_account();
     let handle = RithmicOrderPlantHandle {
         account: Arc::clone(&account),
+        login_scope: Arc::new(OnceLock::new()),
         sender: command_sender,
         subscription_receiver: SubscriptionFilter::new(
             account,
@@ -194,4 +201,259 @@ async fn disconnect_sends_close_even_when_logout_fails() {
         call.await.expect("call task panicked"),
         Err(RithmicError::SendFailed)
     ));
+}
+
+fn login_response() -> RithmicResponse {
+    RithmicResponse {
+        request_id: "1".to_string(),
+        message: RithmicMessage::ResponseLogin(crate::rti::ResponseLogin {
+            template_id: 11,
+            rp_code: vec!["0".to_string()],
+            ..crate::rti::ResponseLogin::default()
+        }),
+        is_update: false,
+        has_more: false,
+        multi_response: false,
+        error: None,
+        source: "order_plant".to_string(),
+    }
+}
+
+/// Answer `Login` and `SetLogin`, leaving the next command for the caller.
+async fn drive_login_to_login_info(command_receiver: &mut mpsc::Receiver<OrderPlantCommand>) {
+    match next_command(command_receiver).await {
+        OrderPlantCommand::Login {
+            response_sender, ..
+        } => {
+            let _ = response_sender.send(Ok(vec![login_response()]));
+        }
+        _ => panic!("expected Login first"),
+    }
+
+    match next_command(command_receiver).await {
+        OrderPlantCommand::SetLogin => {}
+        _ => panic!("expected SetLogin"),
+    }
+}
+
+/// An IB login. Its FCM and IB differ from the account's so a test can tell which
+/// one reached the wire.
+fn login_info() -> crate::rti::ResponseLoginInfo {
+    crate::rti::ResponseLoginInfo {
+        template_id: 301,
+        fcm_id: Some("FCM_LOGIN".to_string()),
+        ib_id: Some("IB_LOGIN".to_string()),
+        user_type: Some(crate::rti::response_login_info::UserType::Ib.into()),
+        ..crate::rti::ResponseLoginInfo::default()
+    }
+}
+
+/// A template-301 response as the receiver builds it: a server rejection arrives as
+/// a payload with `error` set, not as `Err`.
+fn login_info_response(error: Option<RithmicError>) -> RithmicResponse {
+    RithmicResponse {
+        request_id: "2".to_string(),
+        message: RithmicMessage::ResponseLoginInfo(login_info()),
+        is_update: false,
+        has_more: false,
+        multi_response: false,
+        error,
+        source: "order_plant".to_string(),
+    }
+}
+
+/// Take the next command, failing rather than hanging if none arrives.
+async fn next_command(
+    command_receiver: &mut mpsc::Receiver<OrderPlantCommand>,
+) -> OrderPlantCommand {
+    tokio::time::timeout(std::time::Duration::from_secs(5), command_receiver.recv())
+        .await
+        .expect("timed out waiting for a command")
+        .expect("command channel closed")
+}
+
+/// Answer the `GetLoginInfo` that `login` issues with `response`.
+async fn answer_login_info(
+    command_receiver: &mut mpsc::Receiver<OrderPlantCommand>,
+    response: Result<Vec<RithmicResponse>, RithmicError>,
+) {
+    match next_command(command_receiver).await {
+        OrderPlantCommand::GetLoginInfo { response_sender } => {
+            let _ = response_sender.send(response);
+        }
+        _ => panic!("login must fetch the login info that scopes get_account_list"),
+    }
+}
+
+/// Neither failure shape may fail the login or leave a scope behind.
+#[tokio::test]
+async fn login_succeeds_and_stays_unscoped_when_the_login_info_fails() {
+    for response in [
+        Ok(vec![login_info_response(Some(
+            RithmicError::RequestRejected(RithmicRequestError {
+                rp_code: vec!["5".to_string(), "denied".to_string()],
+                code: Some("5".to_string()),
+                message: Some("denied".to_string()),
+            }),
+        ))]),
+        Err(RithmicError::EmptyResponse),
+    ] {
+        let (handle, mut command_receiver) = test_handle();
+
+        let driver = async {
+            drive_login_to_login_info(&mut command_receiver).await;
+            answer_login_info(&mut command_receiver, response).await;
+        };
+
+        let (login, ()) = tokio::join!(handle.login(), driver);
+        assert!(login.is_ok(), "a failed login info must not fail the login");
+
+        assert!(
+            handle.login_scope.get().is_none(),
+            "a failed login info must not scope"
+        );
+    }
+}
+
+/// The scope belongs to the connection, not to the handle that logged in — the
+/// README's multi-account flow takes a further handle per account after logging in
+/// on one, and those must be scoped too.
+#[tokio::test]
+async fn every_handle_from_one_plant_shares_the_login_scope() {
+    let (sender, mut command_receiver) = mpsc::channel(4);
+    let (subscription_sender, _keep_open) = broadcast::channel(4);
+
+    let plant = RithmicOrderPlant {
+        connection_handle: tokio::spawn(async {}),
+        sender,
+        subscription_sender,
+        login_scope: Arc::new(OnceLock::new()),
+    };
+
+    let logs_in = plant.get_handle(&test_account());
+    let never_logs_in = plant.get_handle(&RithmicAccount::new("FCM_B", "IB_B", "ACCOUNT_B"));
+
+    let driver = async {
+        drive_login_to_login_info(&mut command_receiver).await;
+        answer_login_info(&mut command_receiver, Ok(vec![login_info_response(None)])).await;
+    };
+
+    let (login, ()) = tokio::join!(logs_in.login(), driver);
+    assert!(login.is_ok());
+
+    let scope = never_logs_in
+        .login_scope
+        .get()
+        .expect("a handle that never logged in must still be scoped");
+
+    assert_eq!(scope.fcm_id.as_deref(), Some("FCM_LOGIN"));
+    assert_eq!(scope.ib_id.as_deref(), Some("IB_LOGIN"));
+    assert_eq!(scope.user_type, LoginUserType::Ib);
+}
+
+/// A plant actor whose connection has logged in, as `login()` would leave it.
+async fn scoped_plant_with_wire() -> (OrderPlant, mpsc::Sender<OrderPlantCommand>, TcpStream) {
+    let (plant, sender, client) = plant_with_wire().await;
+
+    plant
+        .login_scope
+        .set(LoginScope::from_login_info(&login_info()).expect("an IB login is expressible"))
+        .expect("a fresh cell is empty");
+
+    (plant, sender, client)
+}
+
+/// Feeds one command to the actor and decodes the request it put on the wire.
+async fn sent_request<M: prost::Message + Default>(
+    plant: &mut OrderPlant,
+    client: &mut TcpStream,
+    build: impl FnOnce(Responder) -> OrderPlantCommand,
+) -> M {
+    let (response_sender, _rx) = oneshot::channel();
+    plant.handle_command(build(response_sender)).await;
+
+    M::decode(&*read_wire_request(client).await).expect("the actor serialized this request")
+}
+
+fn bracket_order() -> RithmicBracketOrder {
+    RithmicBracketOrder {
+        action: crate::rti::request_bracket_order::TransactionType::Buy,
+        duration: crate::rti::request_bracket_order::Duration::Day,
+        exchange: "CME".to_string(),
+        localid: "bracket-1".to_string(),
+        price_type: crate::rti::request_bracket_order::PriceType::Limit,
+        price: Some(5000.0),
+        profit_ticks: 20,
+        quantity: 1,
+        stop_ticks: 10,
+        symbol: "ESM6".to_string(),
+    }
+}
+
+/// 302 and 304 name no account, so the login scopes them outright; 330 and 346 name
+/// one and take only the user type.
+#[tokio::test]
+async fn a_logged_in_actor_scopes_every_request_that_carries_a_user_type() {
+    let (mut plant, _sender, mut client) = scoped_plant_with_wire().await;
+
+    let account_list: crate::rti::RequestAccountList =
+        sent_request(&mut plant, &mut client, |response_sender| {
+            OrderPlantCommand::AccountList { response_sender }
+        })
+        .await;
+
+    assert_eq!(account_list.fcm_id.as_deref(), Some("FCM_LOGIN"));
+    assert_eq!(account_list.ib_id.as_deref(), Some("IB_LOGIN"));
+    assert_eq!(
+        account_list.user_type,
+        Some(crate::rti::request_account_list::UserType::Ib.into())
+    );
+
+    let rms_info: crate::rti::RequestAccountRmsInfo =
+        sent_request(&mut plant, &mut client, |response_sender| {
+            OrderPlantCommand::GetAccountRmsInfo {
+                account: test_account(),
+                response_sender,
+            }
+        })
+        .await;
+
+    assert_eq!(rms_info.fcm_id.as_deref(), Some("FCM_LOGIN"));
+    assert_eq!(rms_info.ib_id.as_deref(), Some("IB_LOGIN"));
+    assert_eq!(
+        rms_info.user_type,
+        Some(crate::rti::request_account_rms_info::UserType::Ib.into())
+    );
+
+    let bracket: crate::rti::RequestBracketOrder =
+        sent_request(&mut plant, &mut client, |response_sender| {
+            OrderPlantCommand::PlaceBracketOrder {
+                bracket_order: bracket_order(),
+                account: test_account(),
+                response_sender,
+            }
+        })
+        .await;
+
+    assert_eq!(bracket.fcm_id.as_deref(), Some("FCM_A"));
+    assert_eq!(bracket.account_id.as_deref(), Some("ACCOUNT_A"));
+    assert_eq!(
+        bracket.user_type,
+        Some(crate::rti::request_bracket_order::UserType::Ib.into())
+    );
+
+    let cancel_all: crate::rti::RequestCancelAllOrders =
+        sent_request(&mut plant, &mut client, |response_sender| {
+            OrderPlantCommand::CancelAllOrders {
+                account: test_account(),
+                response_sender,
+            }
+        })
+        .await;
+
+    assert_eq!(cancel_all.account_id.as_deref(), Some("ACCOUNT_A"));
+    assert_eq!(
+        cancel_all.user_type,
+        Some(crate::rti::request_cancel_all_orders::UserType::Ib.into())
+    );
 }

--- a/src/plants/test_support.rs
+++ b/src/plants/test_support.rs
@@ -184,6 +184,36 @@ pub(crate) async fn assert_wire_wrote(client: &mut TcpStream, expectation: &str)
     assert!(matches!(read, Ok(Ok(n)) if n > 0), "{expectation}");
 }
 
+/// Reads one frame the plant wrote and returns the protobuf inside it, so a test can
+/// assert on the request itself rather than just on bytes having moved.
+pub(crate) async fn read_wire_request(client: &mut TcpStream) -> Vec<u8> {
+    let mut header = [0u8; 2];
+    tokio::time::timeout(WIRE_WRITE_TIMEOUT, client.read_exact(&mut header))
+        .await
+        .expect("timed out waiting for the request to reach the wire")
+        .expect("the connection closed before the request arrived");
+
+    assert_eq!(header[0], 0x82, "expected one final binary frame");
+    assert_eq!(header[1] & 0x80, 0, "a server frame must not be masked");
+
+    let len = match header[1] & 0x7f {
+        126 => {
+            let mut extended = [0u8; 2];
+            client.read_exact(&mut extended).await.unwrap();
+            u16::from_be_bytes(extended) as usize
+        }
+        127 => panic!("a request larger than 64 KiB is not something a plant sends"),
+        len => len as usize,
+    };
+
+    let mut payload = vec![0u8; len];
+    client.read_exact(&mut payload).await.unwrap();
+
+    assert!(payload.len() >= 4, "a request carries a length header");
+
+    payload.split_off(4)
+}
+
 /// Resolves a response channel the way every plant handle method does: a
 /// dropped responder becomes `ConnectionClosed`. Fails rather than hangs.
 pub(crate) async fn awaited_caller_outcome(


### PR DESCRIPTION
## Issue

`request_account_list` built template 302 from hardcoded values — `fcm_id: None`, `ib_id: None`, `user_type: Trader` — discarding everything the session knew about itself, so FCM- and IB-scoped logins listed no accounts.

The same hardcoded `USER_TYPE = 3` reached three more templates: 304 (account RMS info), 330 (bracket order) and 346 (cancel all orders).

## Solution

`login()` retrieves the login info (template 300) once and keeps the `fcm_id`, `ib_id` and `user_type` it grants as a `LoginScope`, which scopes every later request that carries a user type.

| Template | Names an account? | Takes from the login |
| --- | --- | --- |
| 302 `RequestAccountList` | no | `fcm_id`, `ib_id`, `user_type` |
| 304 `RequestAccountRmsInfo` | no | `fcm_id`, `ib_id`, `user_type` |
| 330 `RequestBracketOrder` | yes | `user_type` only |
| 346 `RequestCancelAllOrders` | yes | `user_type` only |

302 and 304 carry no `account_id` (see `rapi/0.89.0.0/proto/request_account_rms_info.proto`), so they are queries the login scopes outright; the account a handle holds is only the fallback for a connection that retained no scope. 330 and 346 keep naming the account you passed and take only the user type.

### Design notes

- **The scope belongs to the connection, not to a handle.** It lives on `RithmicOrderPlant` behind an `Arc<OnceLock<_>>`, shared with every handle `get_handle` returns and read by the actor. The README's multi-account flow logs in on one handle and takes a further handle per account, so a per-handle scope would have left every later handle unscoped — the very bug this fixes.
- **`LoginScope::from_login_info` is the only constructor,** and returns `None` for a user type the requests cannot express. `Admin` is absent from the 302 and 304 protos entirely, so a scope only half the requests could use would be worse than none. A scope that exists is always sendable, and the senders are plain field copies.
- **Retrieval failure is non-fatal.** The login already succeeded, so the plant still connects and the requests go out with their pre-fix bytes. A rejection arrives as `Ok` with `error` set rather than as `Err`, so both shapes are handled, and the warning repeats where the wider list is actually produced rather than only at login time.
- **User types map by name, not by cast.** The four request protos each declare their own `UserType`; a `macro_rules!` generates one accessor per request, following the same pattern `src/api/rp_code.rs` already uses. The numbers agree today, so a cast would silently keep sending the old one if a proto were ever renumbered.

### Corroboration

`SampleOrder.py:568-609` — Rithmic's own reference client — requests template 300, checks `rp_code[0] == '0'`, then forwards `fcm_id`, `ib_id` and `user_type` straight into template 302, and never calls the account list unscoped.

Templates 302/303 are listed under **§1.3 Templates Specific to Order Plant Infrastructure** in the R|Protocol reference guide (`rapi/0.89.0.0/doc/Reference_Guide.pdf`), not in §1.1 (shared across plants) nor in the ticker, history or PnL sections. There is no account list to scope on the other three plants, so `PlantCore` is untouched.

Template 304 is not called in any of the vendored samples, so its login-scoping rests on the proto shape alone rather than on observed behaviour.

### Behavioural change for existing callers

Not confined to FCM and IB logins. A plain `Trader` login whose login info carries an `fcm_id` and an `ib_id` **now sends them on 302 and 304**, so `get_account_list` and `get_account_rms_info` may return fewer accounts than before. `get_account_rms_info` in particular now covers what the login reaches rather than what the handle's account names. Documented in `CHANGELOG.md` under `[Unreleased] → Fixed`.

Nothing here has been exercised against a live Rithmic session.

### Tests

`test_support::read_wire_request` decodes a frame the actor wrote, so the plant tests assert on the serialized request rather than only on bytes having moved. Eight tests added:

- `a_logged_in_actor_scopes_every_request_that_carries_a_user_type` — actor to wire, all four templates. Mutating any one actor arm to pass `None` fails it.
- `every_handle_from_one_plant_shares_the_login_scope` — a handle that never logged in is still scoped.
- `login_succeeds_and_stays_unscoped_when_the_login_info_fails` — both failure shapes leave the login intact and no scope behind.
- `account_requests_take_only_the_user_type_from_the_scope` — 330 and 346 must not take the login's ids, only its user type.
- `account_rms_info_carries_the_scope_over_the_account` — the login wins over the account passed in.
- `account_list_carries_the_scope`, plus the two `LoginScope::from_login_info` cases (each expressible type; `Admin`/out-of-range/absent rejected).

### Compatibility

Non-breaking. `RithmicSenderApi`, `LoginScope` and `LoginUserType` are `pub(crate)`. The only public changes are rustdoc, the scoped bytes above, and one round trip at login.
