### PR TITLE
fix(plants): retain connection-health events broadcast before the first handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,19 @@ Public struct fields and a method signature change, so this lands in a major rel
   Rithmic to reject the trailing stop with rp_code 1112).
 - **`request_account_rms_updates` sent `update_bits: None`**, so `auto_liq_threshold_current_value`
   never streamed even when subscribed.
+- **Connection-health events broadcast between `connect()` and the first `get_handle()` are no
+  longer dropped.** Every plant created its broadcast channel with
+  `let (sub_tx, _sub_rx) = channel(..)`, dropping the initial receiver, so until a handle existed
+  the receiver count was zero and every `send` returned `SendError` with the value discarded rather
+  than buffered. A socket that died in that window left the consumer waiting on a stream that would
+  never produce anything. Each plant now parks that receiver and hands it to the first
+  `get_handle()` caller, which sees everything broadcast since `connect()`. Order and exchange
+  notifications are not affected either way: `login()` is a handle method, so a handle already
+  exists before any can arrive. Handles after the first still start at the stream tail, so an
+  application using several accounts should take every handle before calling `login()`. Backlog
+  stays bounded by the requested channel capacity rounded up to a power of two; an over-capacity
+  backlog surfaces as `RecvError::Lagged` on the first receive, as it does for any lagging
+  subscriber.
 
 ## [2.0.0]
 

--- a/src/plants/history_plant.rs
+++ b/src/plants/history_plant.rs
@@ -7,7 +7,10 @@ use crate::{
     api::{receiver_api::RithmicResponse, rithmic_command_types::LoginConfig},
     config::RithmicConfig,
     error::RithmicError,
-    plants::core::{PlantCore, SelectResult},
+    plants::{
+        core::{PlantCore, SelectResult},
+        subscription::InitialReceiver,
+    },
     request_handler::RithmicRequest,
     rti::{
         messages::RithmicMessage, request_login::SysInfraType, request_tick_bar_update,
@@ -186,6 +189,7 @@ pub struct RithmicHistoryPlant {
     pub(crate) connection_handle: JoinHandle<()>,
     sender: mpsc::Sender<HistoryPlantCommand>,
     subscription_sender: broadcast::Sender<RithmicResponse>,
+    initial_receiver: InitialReceiver,
 }
 
 impl RithmicHistoryPlant {
@@ -205,7 +209,7 @@ impl RithmicHistoryPlant {
         strategy: ConnectStrategy,
     ) -> Result<RithmicHistoryPlant, RithmicError> {
         let (req_tx, req_rx) = mpsc::channel::<HistoryPlantCommand>(32);
-        let (sub_tx, _sub_rx) = broadcast::channel::<RithmicResponse>(20_000);
+        let (sub_tx, sub_rx) = broadcast::channel::<RithmicResponse>(20_000);
         let mut history_plant = HistoryPlant::new(req_rx, sub_tx.clone(), config, strategy).await?;
 
         let connection_handle = tokio::spawn(async move {
@@ -216,6 +220,7 @@ impl RithmicHistoryPlant {
             connection_handle,
             sender: req_tx,
             subscription_sender: sub_tx,
+            initial_receiver: InitialReceiver::new(sub_rx),
         })
     }
 }
@@ -230,10 +235,16 @@ impl RithmicHistoryPlant {
     ///
     /// The handle provides methods to load historical ticks, time bars, and subscribe to bar updates.
     /// Multiple handles can be created from the same plant.
+    ///
+    /// The first handle receives everything broadcast since [`connect`](Self::connect),
+    /// including updates emitted before this call. Later handles start at the
+    /// current end of the stream.
     pub fn get_handle(&self) -> RithmicHistoryPlantHandle {
         RithmicHistoryPlantHandle {
             sender: self.sender.clone(),
-            subscription_receiver: self.subscription_sender.subscribe(),
+            subscription_receiver: self
+                .initial_receiver
+                .take_or_subscribe(&self.subscription_sender),
             subscription_sender: self.subscription_sender.clone(),
         }
     }
@@ -1009,5 +1020,61 @@ mod tests {
             rx.await.unwrap(),
             Err(RithmicError::ConnectionClosed)
         ));
+    }
+
+    fn health_event(request_id: &str) -> RithmicResponse {
+        RithmicResponse {
+            request_id: request_id.to_string(),
+            message: RithmicMessage::HeartbeatTimeout,
+            error: None,
+            is_update: true,
+            has_more: false,
+            multi_response: false,
+            source: "history_plant".to_string(),
+        }
+    }
+
+    // Every asserted message is already buffered when the assertion runs, so
+    // this uses `try_recv`: a lost message shows up as `Empty` instead of
+    // parking the suite on a message that will never arrive.
+    #[tokio::test]
+    async fn first_handle_receives_updates_broadcast_before_it_existed() {
+        let (sender, command_receiver) = mpsc::channel(4);
+        let (sub_tx, sub_rx) = broadcast::channel(16);
+
+        let plant = RithmicHistoryPlant {
+            connection_handle: tokio::spawn(async move {
+                let _keep_open = command_receiver;
+            }),
+            sender,
+            subscription_sender: sub_tx.clone(),
+            initial_receiver: InitialReceiver::new(sub_rx),
+        };
+
+        // Emitted during the window between connect() and the first get_handle().
+        sub_tx
+            .send(health_event("early"))
+            .expect("send must reach the parked receiver");
+
+        let mut first = plant.get_handle();
+        let mut second = plant.get_handle();
+
+        sub_tx.send(health_event("late")).unwrap();
+
+        assert_eq!(
+            first.subscription_receiver.try_recv().unwrap().request_id,
+            "early"
+        );
+        assert_eq!(
+            first.subscription_receiver.try_recv().unwrap().request_id,
+            "late"
+        );
+
+        // Handles after the first subscribe at the tail, as broadcast normally does.
+        assert_eq!(
+            second.subscription_receiver.try_recv().unwrap().request_id,
+            "late"
+        );
+        assert!(second.subscription_receiver.try_recv().is_err());
     }
 }

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -17,7 +17,7 @@ use crate::{
     error::RithmicError,
     plants::{
         core::{PlantCore, SelectResult},
-        subscription::SubscriptionFilter,
+        subscription::{InitialReceiver, SubscriptionFilter},
     },
     request_handler::RithmicRequest,
     rti::{
@@ -324,6 +324,7 @@ pub struct RithmicOrderPlant {
     pub(crate) connection_handle: JoinHandle<()>,
     sender: mpsc::Sender<OrderPlantCommand>,
     subscription_sender: broadcast::Sender<RithmicResponse>,
+    initial_receiver: InitialReceiver,
 }
 
 impl RithmicOrderPlant {
@@ -345,7 +346,7 @@ impl RithmicOrderPlant {
         strategy: ConnectStrategy,
     ) -> Result<RithmicOrderPlant, RithmicError> {
         let (req_tx, req_rx) = mpsc::channel::<OrderPlantCommand>(64);
-        let (sub_tx, _sub_rx) = broadcast::channel(10_000);
+        let (sub_tx, sub_rx) = broadcast::channel(10_000);
         let mut order_plant = OrderPlant::new(req_rx, sub_tx.clone(), config, strategy).await?;
 
         let connection_handle = tokio::spawn(async move {
@@ -356,6 +357,7 @@ impl RithmicOrderPlant {
             connection_handle,
             sender: req_tx,
             subscription_sender: sub_tx,
+            initial_receiver: InitialReceiver::new(sub_rx),
         })
     }
 }
@@ -370,6 +372,16 @@ impl RithmicOrderPlant {
     ///
     /// The handle provides methods to place orders, subscribe to updates, and manage positions.
     /// Multiple handles can be created from the same plant for different accounts.
+    ///
+    /// # Take every handle before logging in
+    ///
+    /// Only the first handle carries the backlog broadcast since
+    /// [`connect`](Self::connect); every later handle starts at the current end
+    /// of the stream, and the first handle filters that backlog down to its own
+    /// account. An application trading several accounts must therefore call
+    /// `get_handle` for all of them before `login()`, otherwise the accounts
+    /// whose handles are taken later miss every notification broadcast up to
+    /// that point.
     pub fn get_handle(&self, account: &RithmicAccount) -> RithmicOrderPlantHandle {
         let account = Arc::new(account.clone());
         let account_for_filter = Arc::clone(&account);
@@ -379,7 +391,8 @@ impl RithmicOrderPlant {
             sender: self.sender.clone(),
             subscription_receiver: SubscriptionFilter::new(
                 account_for_filter,
-                self.subscription_sender.subscribe(),
+                self.initial_receiver
+                    .take_or_subscribe(&self.subscription_sender),
             ),
         }
     }
@@ -2341,5 +2354,84 @@ mod tests {
             call.await.expect("call task panicked"),
             Err(RithmicError::ConnectionClosed)
         ));
+    }
+
+    fn test_plant() -> (RithmicOrderPlant, broadcast::Sender<RithmicResponse>) {
+        let (sender, command_receiver) = mpsc::channel(4);
+        let (sub_tx, sub_rx) = broadcast::channel(16);
+
+        let plant = RithmicOrderPlant {
+            connection_handle: tokio::spawn(async move {
+                let _keep_open = command_receiver;
+            }),
+            sender,
+            subscription_sender: sub_tx.clone(),
+            initial_receiver: InitialReceiver::new(sub_rx),
+        };
+
+        (plant, sub_tx)
+    }
+
+    fn notification(basket_id: &str) -> RithmicResponse {
+        RithmicResponse {
+            request_id: basket_id.to_string(),
+            message: RithmicMessage::RithmicOrderNotification(
+                crate::rti::RithmicOrderNotification {
+                    template_id: 351,
+                    account_id: Some("ACCOUNT_A".to_string()),
+                    basket_id: Some(basket_id.to_string()),
+                    ..crate::rti::RithmicOrderNotification::default()
+                },
+            ),
+            error: None,
+            is_update: true,
+            has_more: false,
+            multi_response: false,
+            source: "order_plant".to_string(),
+        }
+    }
+
+    /// Every message asserted on below is already buffered by the time the
+    /// assertion runs, so a wait means it was dropped. The timeout turns that
+    /// into a failure instead of a hung suite.
+    async fn next_soon(filter: &mut SubscriptionFilter) -> RithmicResponse {
+        tokio::time::timeout(std::time::Duration::from_secs(5), filter.recv())
+            .await
+            .expect("the message must already be buffered")
+            .expect("the subscription stream must stay open")
+    }
+
+    #[tokio::test]
+    async fn first_handle_receives_notifications_broadcast_before_it_existed() {
+        let (plant, sub_tx) = test_plant();
+        let account = RithmicAccount::new("FCM_A", "IB_A", "ACCOUNT_A");
+
+        // Emitted during the window between connect() and the first get_handle().
+        sub_tx
+            .send(notification("early"))
+            .expect("send must reach the parked receiver");
+
+        let mut first = plant.get_handle(&account);
+        let mut second = plant.get_handle(&account);
+
+        sub_tx.send(notification("late")).unwrap();
+
+        assert_eq!(
+            next_soon(&mut first.subscription_receiver).await.request_id,
+            "early"
+        );
+        assert_eq!(
+            next_soon(&mut first.subscription_receiver).await.request_id,
+            "late"
+        );
+
+        // Handles after the first subscribe at the tail, so "early" is not
+        // replayed and the first thing this handle sees is "late".
+        assert_eq!(
+            next_soon(&mut second.subscription_receiver)
+                .await
+                .request_id,
+            "late"
+        );
     }
 }

--- a/src/plants/pnl_plant.rs
+++ b/src/plants/pnl_plant.rs
@@ -11,7 +11,7 @@ use crate::{
     error::RithmicError,
     plants::{
         core::{PlantCore, SelectResult},
-        subscription::SubscriptionFilter,
+        subscription::{InitialReceiver, SubscriptionFilter},
     },
     request_handler::RithmicRequest,
     rti::{messages::RithmicMessage, request_login::SysInfraType, request_pn_l_position_updates},
@@ -117,6 +117,7 @@ pub struct RithmicPnlPlant {
     pub(crate) connection_handle: tokio::task::JoinHandle<()>,
     sender: mpsc::Sender<PnlPlantCommand>,
     subscription_sender: broadcast::Sender<RithmicResponse>,
+    initial_receiver: InitialReceiver,
 }
 
 impl RithmicPnlPlant {
@@ -136,7 +137,7 @@ impl RithmicPnlPlant {
         strategy: ConnectStrategy,
     ) -> Result<RithmicPnlPlant, RithmicError> {
         let (req_tx, req_rx) = mpsc::channel::<PnlPlantCommand>(64);
-        let (sub_tx, _sub_rx) = broadcast::channel(10_000);
+        let (sub_tx, sub_rx) = broadcast::channel(10_000);
         let mut pnl_plant = PnlPlant::new(req_rx, sub_tx.clone(), config, strategy).await?;
 
         let connection_handle = tokio::spawn(async move {
@@ -147,6 +148,7 @@ impl RithmicPnlPlant {
             connection_handle,
             sender: req_tx,
             subscription_sender: sub_tx,
+            initial_receiver: InitialReceiver::new(sub_rx),
         })
     }
 }
@@ -161,6 +163,16 @@ impl RithmicPnlPlant {
     ///
     /// The handle provides methods to subscribe to PnL updates and retrieve position snapshots.
     /// Multiple handles can be created from the same plant for different accounts.
+    ///
+    /// # Take every handle before logging in
+    ///
+    /// Only the first handle carries the backlog broadcast since
+    /// [`connect`](Self::connect); every later handle starts at the current end
+    /// of the stream, and the first handle filters that backlog down to its own
+    /// account. An application tracking several accounts must therefore call
+    /// `get_handle` for all of them before `login()`, otherwise the accounts
+    /// whose handles are taken later miss every update broadcast up to that
+    /// point.
     pub fn get_handle(&self, account: &RithmicAccount) -> RithmicPnlPlantHandle {
         let account = Arc::new(account.clone());
         let account_for_filter = Arc::clone(&account);
@@ -170,7 +182,8 @@ impl RithmicPnlPlant {
             sender: self.sender.clone(),
             subscription_receiver: SubscriptionFilter::new(
                 account_for_filter,
-                self.subscription_sender.subscribe(),
+                self.initial_receiver
+                    .take_or_subscribe(&self.subscription_sender),
             ),
         }
     }
@@ -561,5 +574,76 @@ impl RithmicPnlPlantHandle {
             .into_iter()
             .next()
             .ok_or(RithmicError::EmptyResponse)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn health_event(request_id: &str) -> RithmicResponse {
+        RithmicResponse {
+            request_id: request_id.to_string(),
+            message: RithmicMessage::HeartbeatTimeout,
+            error: None,
+            is_update: true,
+            has_more: false,
+            multi_response: false,
+            source: "pnl_plant".to_string(),
+        }
+    }
+
+    /// Every message asserted on below is already buffered by the time the
+    /// assertion runs, so a wait means it was dropped. The timeout turns that
+    /// into a failure instead of a hung suite.
+    async fn next_soon(filter: &mut SubscriptionFilter) -> RithmicResponse {
+        tokio::time::timeout(std::time::Duration::from_secs(5), filter.recv())
+            .await
+            .expect("the message must already be buffered")
+            .expect("the subscription stream must stay open")
+    }
+
+    #[tokio::test]
+    async fn first_handle_receives_updates_broadcast_before_it_existed() {
+        let (sender, command_receiver) = mpsc::channel(4);
+        let (sub_tx, sub_rx) = broadcast::channel(16);
+
+        let plant = RithmicPnlPlant {
+            connection_handle: tokio::spawn(async move {
+                let _keep_open = command_receiver;
+            }),
+            sender,
+            subscription_sender: sub_tx.clone(),
+            initial_receiver: InitialReceiver::new(sub_rx),
+        };
+        let account = RithmicAccount::new("FCM_A", "IB_A", "ACCOUNT_A");
+
+        // Emitted during the window between connect() and the first get_handle().
+        sub_tx
+            .send(health_event("early"))
+            .expect("send must reach the parked receiver");
+
+        let mut first = plant.get_handle(&account);
+        let mut second = plant.get_handle(&account);
+
+        sub_tx.send(health_event("late")).unwrap();
+
+        assert_eq!(
+            next_soon(&mut first.subscription_receiver).await.request_id,
+            "early"
+        );
+        assert_eq!(
+            next_soon(&mut first.subscription_receiver).await.request_id,
+            "late"
+        );
+
+        // Handles after the first subscribe at the tail, so "early" is not
+        // replayed and the first thing this handle sees is "late".
+        assert_eq!(
+            next_soon(&mut second.subscription_receiver)
+                .await
+                .request_id,
+            "late"
+        );
     }
 }

--- a/src/plants/subscription.rs
+++ b/src/plants/subscription.rs
@@ -1,8 +1,48 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, PoisonError};
 
 use tokio::sync::broadcast;
 
 use crate::{api::RithmicResponse, config::RithmicAccount, rti::messages::RithmicMessage};
+
+/// Parks the `Receiver` that `broadcast::channel` returns alongside the sender
+/// until the first plant handle claims it.
+///
+/// That receiver starts at position zero and is never read, so it still yields
+/// every message the sender has buffered since the plant connected. Handing it
+/// to the first `get_handle()` caller makes those messages visible to that
+/// handle; later callers get a fresh `subscribe()`, which starts at the channel
+/// tail. Parking it also keeps the receiver count at one, so `send` does not
+/// fail — and drop the value instead of buffering it — while no handle exists.
+///
+/// Backlog is bounded by the requested channel capacity rounded up to a power
+/// of two: the ring is preallocated at that size and sends overwrite the oldest
+/// slot, so a claimed receiver that has fallen further behind than the ring
+/// gets `RecvError::Lagged` and resumes at the oldest retained message.
+#[derive(Debug)]
+pub(crate) struct InitialReceiver {
+    receiver: Mutex<Option<broadcast::Receiver<RithmicResponse>>>,
+}
+
+impl InitialReceiver {
+    pub(crate) fn new(receiver: broadcast::Receiver<RithmicResponse>) -> Self {
+        Self {
+            receiver: Mutex::new(Some(receiver)),
+        }
+    }
+
+    /// Claim the parked receiver, or subscribe at the channel tail once it is
+    /// already claimed.
+    pub(crate) fn take_or_subscribe(
+        &self,
+        sender: &broadcast::Sender<RithmicResponse>,
+    ) -> broadcast::Receiver<RithmicResponse> {
+        self.receiver
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .take()
+            .unwrap_or_else(|| sender.subscribe())
+    }
+}
 
 /// Filters a shared plant subscription stream down to a single account.
 ///
@@ -79,7 +119,7 @@ fn response_account_id(response: &RithmicResponse) -> Option<&str> {
 mod tests {
     use tokio::sync::broadcast;
 
-    use super::SubscriptionFilter;
+    use super::{InitialReceiver, SubscriptionFilter};
     use crate::{
         api::RithmicResponse,
         config::RithmicAccount,
@@ -191,5 +231,80 @@ mod tests {
             response.message,
             RithmicMessage::ResponseAcceptAgreement(_)
         ));
+    }
+
+    fn tagged(request_id: &str) -> RithmicResponse {
+        RithmicResponse {
+            request_id: request_id.to_string(),
+            ..response(RithmicMessage::ResponseAcceptAgreement(
+                ResponseAcceptAgreement::default(),
+            ))
+        }
+    }
+
+    // Everything these tests assert on is already buffered when the assertion
+    // runs, so they use `try_recv`: a lost message shows up as `Empty` instead
+    // of parking the suite on a message that will never arrive.
+
+    #[test]
+    fn parked_receiver_replays_messages_sent_before_it_was_claimed() {
+        let (sender, receiver) = broadcast::channel(16);
+        let parked = InitialReceiver::new(receiver);
+
+        sender.send(tagged("before")).unwrap();
+
+        let mut first = parked.take_or_subscribe(&sender);
+
+        assert_eq!(first.try_recv().unwrap().request_id, "before");
+    }
+
+    #[test]
+    fn claims_after_the_first_start_at_the_stream_tail() {
+        let (sender, receiver) = broadcast::channel(16);
+        let parked = InitialReceiver::new(receiver);
+
+        sender.send(tagged("before")).unwrap();
+
+        let mut first = parked.take_or_subscribe(&sender);
+        let mut second = parked.take_or_subscribe(&sender);
+
+        sender.send(tagged("after")).unwrap();
+
+        assert_eq!(first.try_recv().unwrap().request_id, "before");
+        assert_eq!(first.try_recv().unwrap().request_id, "after");
+        // The second claim subscribed at the tail, so "before" is not replayed.
+        assert_eq!(second.try_recv().unwrap().request_id, "after");
+        assert!(second.try_recv().is_err());
+    }
+
+    #[test]
+    fn sends_succeed_while_the_receiver_is_still_parked() {
+        let (sender, receiver) = broadcast::channel(16);
+        let _parked = InitialReceiver::new(receiver);
+
+        assert_eq!(sender.receiver_count(), 1);
+        assert!(sender.send(tagged("unclaimed")).is_ok());
+    }
+
+    #[test]
+    fn backlog_beyond_capacity_lags_the_parked_receiver() {
+        // Capacity bounds the backlog: the ring keeps the newest `capacity`
+        // messages — rounded up to a power of two, already the case for 2 — and
+        // the claimed receiver resumes at the oldest retained one.
+        let (sender, receiver) = broadcast::channel(2);
+        let parked = InitialReceiver::new(receiver);
+
+        for i in 0..4 {
+            sender.send(tagged(&i.to_string())).unwrap();
+        }
+
+        let mut first = parked.take_or_subscribe(&sender);
+
+        assert!(matches!(
+            first.try_recv(),
+            Err(broadcast::error::TryRecvError::Lagged(2))
+        ));
+        assert_eq!(first.try_recv().unwrap().request_id, "2");
+        assert_eq!(first.try_recv().unwrap().request_id, "3");
     }
 }

--- a/src/plants/ticker_plant.rs
+++ b/src/plants/ticker_plant.rs
@@ -7,7 +7,10 @@ use crate::{
     api::{receiver_api::RithmicResponse, rithmic_command_types::LoginConfig},
     config::RithmicConfig,
     error::RithmicError,
-    plants::core::{PlantCore, SelectResult},
+    plants::{
+        core::{PlantCore, SelectResult},
+        subscription::InitialReceiver,
+    },
     request_handler::RithmicRequest,
     rti::{
         messages::RithmicMessage,
@@ -277,6 +280,7 @@ pub struct RithmicTickerPlant {
     pub(crate) connection_handle: tokio::task::JoinHandle<()>,
     sender: mpsc::Sender<TickerPlantCommand>,
     subscription_sender: broadcast::Sender<RithmicResponse>,
+    initial_receiver: InitialReceiver,
 }
 
 impl RithmicTickerPlant {
@@ -311,7 +315,7 @@ impl RithmicTickerPlant {
         strategy: ConnectStrategy,
     ) -> Result<RithmicTickerPlant, RithmicError> {
         let (req_tx, req_rx) = mpsc::channel::<TickerPlantCommand>(64);
-        let (sub_tx, _sub_rx) = broadcast::channel(10_000);
+        let (sub_tx, sub_rx) = broadcast::channel(10_000);
         let mut ticker_plant = TickerPlant::new(req_rx, sub_tx.clone(), config, strategy).await?;
 
         let connection_handle = tokio::spawn(async move {
@@ -322,6 +326,7 @@ impl RithmicTickerPlant {
             connection_handle,
             sender: req_tx,
             subscription_sender: sub_tx,
+            initial_receiver: InitialReceiver::new(sub_rx),
         })
     }
 }
@@ -336,11 +341,17 @@ impl RithmicTickerPlant {
     ///
     /// The handle provides methods to subscribe to market data and receive updates.
     /// Multiple handles can be created from the same plant.
+    ///
+    /// The first handle receives everything broadcast since [`connect`](Self::connect),
+    /// including updates emitted before this call. Later handles start at the
+    /// current end of the stream.
     pub fn get_handle(&self) -> RithmicTickerPlantHandle {
         RithmicTickerPlantHandle {
             sender: self.sender.clone(),
             subscription_sender: self.subscription_sender.clone(),
-            subscription_receiver: self.subscription_sender.subscribe(),
+            subscription_receiver: self
+                .initial_receiver
+                .take_or_subscribe(&self.subscription_sender),
         }
     }
 }
@@ -1968,5 +1979,61 @@ mod tests {
             rx.await.unwrap(),
             Err(RithmicError::ConnectionClosed)
         ));
+    }
+
+    fn health_event(request_id: &str) -> RithmicResponse {
+        RithmicResponse {
+            request_id: request_id.to_string(),
+            message: RithmicMessage::HeartbeatTimeout,
+            error: None,
+            is_update: true,
+            has_more: false,
+            multi_response: false,
+            source: "ticker_plant".to_string(),
+        }
+    }
+
+    // Every asserted message is already buffered when the assertion runs, so
+    // this uses `try_recv`: a lost message shows up as `Empty` instead of
+    // parking the suite on a message that will never arrive.
+    #[tokio::test]
+    async fn first_handle_receives_updates_broadcast_before_it_existed() {
+        let (sender, command_receiver) = mpsc::channel(4);
+        let (sub_tx, sub_rx) = broadcast::channel(16);
+
+        let plant = RithmicTickerPlant {
+            connection_handle: tokio::spawn(async move {
+                let _keep_open = command_receiver;
+            }),
+            sender,
+            subscription_sender: sub_tx.clone(),
+            initial_receiver: InitialReceiver::new(sub_rx),
+        };
+
+        // Emitted during the window between connect() and the first get_handle().
+        sub_tx
+            .send(health_event("early"))
+            .expect("send must reach the parked receiver");
+
+        let mut first = plant.get_handle();
+        let mut second = plant.get_handle();
+
+        sub_tx.send(health_event("late")).unwrap();
+
+        assert_eq!(
+            first.subscription_receiver.try_recv().unwrap().request_id,
+            "early"
+        );
+        assert_eq!(
+            first.subscription_receiver.try_recv().unwrap().request_id,
+            "late"
+        );
+
+        // Handles after the first subscribe at the tail, as broadcast normally does.
+        assert_eq!(
+            second.subscription_receiver.try_recv().unwrap().request_id,
+            "late"
+        );
+        assert!(second.subscription_receiver.try_recv().is_err());
     }
 }


### PR DESCRIPTION
## The defect

Every plant created its broadcast channel and discarded the receiver in the same breath:

```rust
let (sub_tx, _sub_rx) = broadcast::channel(10_000);
```

`get_handle()` then subscribed fresh each time. Until the first handle existed the receiver count was zero, and a tokio broadcast send with no receivers **discards the message** rather than buffering it. Anything broadcast between `connect()` and the first `get_handle()` went nowhere.

## The fix

The plant parks the receiver created alongside the channel and hands that same object to the first `get_handle()` caller; later callers subscribe normally. Because that receiver has never been read, it still sits at its creation position, so the first handle sees everything buffered since connect. All four plants are treated identically.

Parking it has a second effect worth noting: the receiver count is never zero, so sends during the window are buffered instead of failing outright.

## What this actually delivers

Being precise here, because the first draft of this description overstated it and the reviewer corrected the claim rather than the code.

**Fixed:** connection-health events and synthetic heartbeat-timeout updates emitted in the connect-to-first-handle window. Previously a socket that died in that gap left the consumer waiting on a stream that would never produce anything — the failure was invisible rather than merely late.

**Not fixed, and not claimed:** order notifications at startup. `login()` is a method on the *handle*, not the plant, so a handle must already exist before login can happen. Order and exchange notifications therefore cannot arrive in the window this closes. A reader should not have to infer that, so it is stated in the CHANGELOG too.

## Limitation — please read before merging

There is **one** parked receiver per plant. The first `get_handle(&account)` caller consumes it *and* wraps it in a filter that discards responses belonging to other accounts. The order plant supports multiple accounts on one connection.

So in this flow:

1. take handle A
2. `login()`
3. subscribe
4. take handle B

handle B starts at the current end of the stream and **misses everything for account B since login**.

Applications trading multiple accounts must take every handle before calling `login()`. That is now documented as a **constraint** in the order and PnL `get_handle` rustdoc, under its own heading, rather than as a passing nicety. A fuller fix is tracked separately.

## Verification

The mechanism was checked against tokio 1.53.1's **source**, not its documentation — which matters, because the behaviour being relied on is not something the docs promise:

- The receiver returned by the channel constructor starts at position zero, and only a receive advances it. So an unread parked receiver still yields the whole backlog.
- `subscribe` and `resubscribe` have byte-identical bodies, and both start at the current tail. Handing out the original object is therefore the **only** mechanism tokio exposes that transfers position — there is no API-level alternative that would have worked.
- Overflow is a bounded overwrite yielding a lagged error, never unbounded growth. A parked receiver cannot block or wedge a sender.
- The hand-off is a synchronous take, so no lock is held across an await, and concurrent callers are serialised with exactly one receiving the parked receiver. The lock is also poison-tolerant, so a panic elsewhere cannot turn this into a second failure.

One detail worth carrying into review: the retained-message bound is the requested capacity **rounded up to a power of two**, since that is what tokio actually allocates. An over-capacity backlog surfaces as a lagged error on the first receive, exactly as it does for any lagging subscriber.

## Testing

Tests use a non-blocking receive throughout, deliberately: everything asserted on is already buffered when the assertion runs, so a lost message surfaces as an empty channel rather than parking the suite on a message that will never arrive. That choice is what makes a regression here fail fast instead of hanging CI.

Coverage includes the ordering contract directly — first handle sees both the pre-handle and post-handle message, second handle sees only the later one and nothing more.

## Compatibility

Non-breaking. The added field is private and crate-internal, and no public signature changed. The only visible difference is that the first handle now receives a backlog it previously never saw.

## Environment notes for reviewers

`src/raw-proto/` and `rapi/` are gitignored and absent from the working container, and `protoc` is not installed. Work was done against the checked-in prost-generated `src/rti.rs`, which the audit confirmed has zero drift from the protos.
