### PR TITLE
test: pin update-template routing for the order and PnL plants

### DIFF
--- a/src/plants/order_plant/tests.rs
+++ b/src/plants/order_plant/tests.rs
@@ -9,7 +9,12 @@ use crate::{
     },
     plants::test_support::{
         self, Responder, assert_close_still_sent, assert_rejected_after_close,
-        assert_sent_while_open, assert_wire_silent, read_wire_request, test_account,
+        assert_sent_while_open, assert_update_routed_to_subscribers, assert_wire_silent,
+        read_wire_request, test_account,
+    },
+    rti::{
+        AccountListUpdates, AccountRmsUpdates, BracketUpdates, ExchangeOrderNotification,
+        RithmicOrderNotification, TradeRoute, UpdateEasyToBorrowList,
     },
 };
 
@@ -456,4 +461,162 @@ async fn a_logged_in_actor_scopes_every_request_that_carries_a_user_type() {
         cancel_all.user_type,
         Some(crate::rti::request_cancel_all_orders::UserType::Ib.into())
     );
+}
+
+/// Every template the order plant receives unsolicited, i.e. every one the
+/// receiver API marks `is_update`, belongs on the subscription broadcast and
+/// must never reach the request handler.
+mod update_routing {
+    use super::*;
+
+    /// Template 350 — trade route availability.
+    #[tokio::test]
+    async fn trade_route_reaches_subscribers() {
+        assert_update_routed_to_subscribers(
+            "order_plant",
+            TradeRoute {
+                template_id: 350,
+                exchange: Some("CME".to_string()),
+                trade_route: Some("globex".to_string()),
+                ..TradeRoute::default()
+            },
+            |message| {
+                matches!(
+                    message,
+                    RithmicMessage::TradeRoute(update)
+                        if update.trade_route.as_deref() == Some("globex")
+                )
+            },
+        )
+        .await;
+    }
+
+    /// Template 351 — Rithmic-side order notification.
+    #[tokio::test]
+    async fn rithmic_order_notification_reaches_subscribers() {
+        assert_update_routed_to_subscribers(
+            "order_plant",
+            RithmicOrderNotification {
+                template_id: 351,
+                account_id: Some("ACCOUNT_A".to_string()),
+                basket_id: Some("basket-1".to_string()),
+                ..RithmicOrderNotification::default()
+            },
+            |message| {
+                matches!(
+                    message,
+                    RithmicMessage::RithmicOrderNotification(update)
+                        if update.basket_id.as_deref() == Some("basket-1")
+                )
+            },
+        )
+        .await;
+    }
+
+    /// Template 352 — exchange-side order notification.
+    #[tokio::test]
+    async fn exchange_order_notification_reaches_subscribers() {
+        assert_update_routed_to_subscribers(
+            "order_plant",
+            ExchangeOrderNotification {
+                template_id: 352,
+                account_id: Some("ACCOUNT_A".to_string()),
+                exchange_order_id: Some("exch-1".to_string()),
+                ..ExchangeOrderNotification::default()
+            },
+            |message| {
+                matches!(
+                    message,
+                    RithmicMessage::ExchangeOrderNotification(update)
+                        if update.exchange_order_id.as_deref() == Some("exch-1")
+                )
+            },
+        )
+        .await;
+    }
+
+    /// Template 353 — bracket target/stop updates.
+    #[tokio::test]
+    async fn bracket_updates_reach_subscribers() {
+        assert_update_routed_to_subscribers(
+            "order_plant",
+            BracketUpdates {
+                template_id: 353,
+                account_id: Some("ACCOUNT_A".to_string()),
+                target_ticks: Some(8),
+                ..BracketUpdates::default()
+            },
+            |message| {
+                matches!(
+                    message,
+                    RithmicMessage::BracketUpdates(update) if update.target_ticks == Some(8)
+                )
+            },
+        )
+        .await;
+    }
+
+    /// Template 354 — account list updates.
+    #[tokio::test]
+    async fn account_list_updates_reach_subscribers() {
+        assert_update_routed_to_subscribers(
+            "order_plant",
+            AccountListUpdates {
+                template_id: 354,
+                account_id: Some("ACCOUNT_A".to_string()),
+                ..AccountListUpdates::default()
+            },
+            |message| {
+                matches!(
+                    message,
+                    RithmicMessage::AccountListUpdates(update)
+                        if update.account_id.as_deref() == Some("ACCOUNT_A")
+                )
+            },
+        )
+        .await;
+    }
+
+    /// Template 355 — easy-to-borrow list updates.
+    #[tokio::test]
+    async fn update_easy_to_borrow_list_reaches_subscribers() {
+        assert_update_routed_to_subscribers(
+            "order_plant",
+            UpdateEasyToBorrowList {
+                template_id: 355,
+                symbol: Some("ESM6".to_string()),
+                ..UpdateEasyToBorrowList::default()
+            },
+            |message| {
+                matches!(
+                    message,
+                    RithmicMessage::UpdateEasyToBorrowList(update)
+                        if update.symbol.as_deref() == Some("ESM6")
+                )
+            },
+        )
+        .await;
+    }
+
+    /// Template 356 — account RMS updates, including auto-liquidation.
+    #[tokio::test]
+    async fn account_rms_updates_reach_subscribers() {
+        assert_update_routed_to_subscribers(
+            "order_plant",
+            AccountRmsUpdates {
+                template_id: 356,
+                account_id: Some("ACCOUNT_A".to_string()),
+                auto_liq_threshold_current_value: Some("1000".to_string()),
+                ..AccountRmsUpdates::default()
+            },
+            |message| {
+                matches!(
+                    message,
+                    RithmicMessage::AccountRmsUpdates(update)
+                        if update.auto_liq_threshold_current_value.as_deref() == Some("1000")
+                )
+            },
+        )
+        .await;
+    }
 }

--- a/src/plants/pnl_plant/tests.rs
+++ b/src/plants/pnl_plant/tests.rs
@@ -1,9 +1,13 @@
 use tokio::net::TcpStream;
 
 use super::*;
-use crate::plants::test_support::{
-    self, Responder, assert_close_still_sent, assert_rejected_after_close, assert_sent_while_open,
-    assert_wire_silent, test_account,
+use crate::{
+    plants::test_support::{
+        self, Responder, assert_close_still_sent, assert_rejected_after_close,
+        assert_sent_while_open, assert_update_routed_to_subscribers, assert_wire_silent,
+        test_account,
+    },
+    rti::{AccountPnLPositionUpdate, InstrumentPnLPositionUpdate},
 };
 
 async fn plant_with_wire() -> (PnlPlant, mpsc::Sender<PnlPlantCommand>, TcpStream) {
@@ -125,4 +129,53 @@ async fn disconnect_sends_close_even_when_logout_fails() {
         call.await.expect("call task panicked"),
         Err(RithmicError::SendFailed)
     ));
+}
+
+/// Every template the PnL plant receives unsolicited belongs on the
+/// subscription broadcast and must never reach the request handler.
+mod update_routing {
+    use super::*;
+
+    /// Template 450 — instrument-level P&L update.
+    #[tokio::test]
+    async fn instrument_pnl_position_update_reaches_subscribers() {
+        assert_update_routed_to_subscribers(
+            "pnl_plant",
+            InstrumentPnLPositionUpdate {
+                template_id: 450,
+                account_id: Some("ACCOUNT_A".to_string()),
+                symbol: Some("ESM6".to_string()),
+                ..InstrumentPnLPositionUpdate::default()
+            },
+            |message| {
+                matches!(
+                    message,
+                    RithmicMessage::InstrumentPnLPositionUpdate(update)
+                        if update.symbol.as_deref() == Some("ESM6")
+                )
+            },
+        )
+        .await;
+    }
+
+    /// Template 451 — account-level P&L update.
+    #[tokio::test]
+    async fn account_pnl_position_update_reaches_subscribers() {
+        assert_update_routed_to_subscribers(
+            "pnl_plant",
+            AccountPnLPositionUpdate {
+                template_id: 451,
+                account_id: Some("ACCOUNT_A".to_string()),
+                ..AccountPnLPositionUpdate::default()
+            },
+            |message| {
+                matches!(
+                    message,
+                    RithmicMessage::AccountPnLPositionUpdate(update)
+                        if update.account_id.as_deref() == Some("ACCOUNT_A")
+                )
+            },
+        )
+        .await;
+    }
 }

--- a/src/plants/test_support.rs
+++ b/src/plants/test_support.rs
@@ -8,7 +8,10 @@ use tokio::{
     net::{TcpListener, TcpStream},
     sync::{broadcast, mpsc, oneshot},
 };
-use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, tungstenite::protocol::Role};
+use tokio_tungstenite::{
+    MaybeTlsStream, WebSocketStream,
+    tungstenite::{Message, protocol::Role},
+};
 
 use crate::{
     api::{
@@ -19,7 +22,8 @@ use crate::{
     error::RithmicError,
     ping_manager::PingManager,
     plants::core::PlantCore,
-    request_handler::RithmicRequestHandler,
+    request_handler::{RithmicRequest, RithmicRequestHandler},
+    rti::messages::RithmicMessage,
     ws::{PING_TIMEOUT_SECS, PlantActor, get_heartbeat_interval, get_ping_interval},
 };
 
@@ -212,6 +216,72 @@ pub(crate) async fn read_wire_request(client: &mut TcpStream) -> Vec<u8> {
     assert!(payload.len() >= 4, "a request carries a length header");
 
     payload.split_off(4)
+}
+
+/// Prefixes an encoded message with the 4-byte big-endian length header that
+/// precedes every Rithmic frame on the wire.
+pub(crate) fn framed<M: prost::Message>(message: &M) -> Vec<u8> {
+    let mut payload = Vec::new();
+    message.encode(&mut payload).unwrap();
+
+    let mut frame = (payload.len() as u32).to_be_bytes().to_vec();
+    frame.extend(payload);
+    frame
+}
+
+/// Feeds one unsolicited update frame through the same decode-and-route call a
+/// plant's `run` loop makes for an inbound binary message, and asserts what an
+/// update template must hold: it reaches the subscription channel intact, it
+/// carries no request id or error, it does not stop the actor, and it leaves a
+/// registered request oneshot pending.
+///
+/// The oneshot is registered under the *empty* request id the update itself
+/// carries. Routing that handed updates to the request handler would therefore
+/// resolve it, rather than find no responder and leave the assertion satisfied
+/// by accident.
+pub(crate) async fn assert_update_routed_to_subscribers<M: prost::Message>(
+    source: &str,
+    update: M,
+    is_expected: fn(&RithmicMessage) -> bool,
+) {
+    // `_client` holds the client half of the socket open for the whole test.
+    let (mut core, _client) = core_with_wire(source).await;
+    let mut subscription = core.subscription_sender.subscribe();
+
+    let (responder, mut pending) = oneshot::channel();
+    core.request_handler.register_request(RithmicRequest {
+        request_id: String::new(),
+        responder,
+    });
+
+    let stop = core
+        .handle_rithmic_message(Ok(Message::Binary(framed(&update).into())))
+        .await;
+
+    assert!(!stop, "an update must not stop the actor");
+
+    let response = subscription
+        .try_recv()
+        .unwrap_or_else(|e| panic!("update did not reach the subscription channel: {e:?}"));
+
+    assert!(
+        is_expected(&response.message),
+        "unexpected message on the subscription channel: {:?}",
+        response.message
+    );
+    assert_eq!(
+        response.request_id, "",
+        "an unsolicited update answers no request and must carry no request id"
+    );
+    assert!(
+        response.error.is_none(),
+        "an update must not carry an error: {:?}",
+        response.error
+    );
+    assert!(
+        matches!(pending.try_recv(), Err(oneshot::error::TryRecvError::Empty)),
+        "an update must not resolve a registered request oneshot"
+    );
 }
 
 /// Resolves a response channel the way every plant handle method does: a


### PR DESCRIPTION
## The issue

`PlantCore::handle_response` routes every decoded message one of two ways on a single boolean, `is_update`: unsolicited updates go to the subscription broadcast, everything else goes to the request handler to resolve a caller's pending future. That boolean is set by hand, per template, in the receiver API's decode match. Nothing in the suite pinned the split.

To confirm the gap, `handle_response` was changed to hand every update to the request handler *in addition to* the subscription channel. **All 216 tests on `main` passed.**

The consumer-visible effect of getting this wrong is silent loss. An update carries an empty request id, and no production request registers under one, so an update that reaches the request handler finds no responder, logs `No responder found for response`, and is dropped. The connection stays up and everything else keeps flowing — a mis-marked 352 is simply a fill that never arrives on the subscription stream, and a mis-marked 356 is an auto-liquidation notice that never arrives.

A second, narrower gap sits under it: flipping `is_update` to `false` on all nine update arms trips only two existing tests (`trade_route_decodes_as_update`, `update_easy_to_borrow_list_decodes_as_update`). Templates 351–354, 356, 450 and 451 had no guard at either level.

## The solution

Nine tests pinning every template the receiver API marks `is_update` on these two plants:

| Plant | Templates |
|---|---|
| Order | 350 trade route · 351 order notification · 352 exchange order notification · 353 bracket updates · 354 account list · 355 easy-to-borrow list · 356 account RMS |
| PnL | 450 instrument P&L · 451 account P&L |

Each test encodes a real message, length-prefixes it, and feeds it through the same `handle_rithmic_message` call the actor loop makes — not a hand-built response struct. It then asserts the update reaches the subscription broadcast with its payload intact, carries no request id and no error, does not stop the actor, and leaves a registered request oneshot pending.

That last assertion is what gives the test teeth. The oneshot is registered under the **empty** request id the update itself carries, so a double-routed update resolves it and fails the assertion. Registering a realistic id instead would leave the test green under exactly the regression it is meant to catch, because the handler would simply find no responder for that id.

Test-only: no production code is touched.

## Discrimination evidence

| Mutation | Result |
|---|---|
| Router also hands updates to the request handler | all nine fail |
| `is_update` flipped to `false` on all nine decode arms | all nine fail |
| Decode arms 350 and 353 swapped | exactly those two fail, the other seven stay green |

The third shows the tests localise a regression per template rather than failing as an undifferentiated block.

## Shared test support

`framed` and `assert_update_routed_to_subscribers` live in `src/plants/test_support.rs` alongside the existing plant helpers, so the ticker and history plants can pin their own update templates without another copy of the harness.

## Notes

- **No CHANGELOG entry.** `CHANGELOG.md` carries only user-facing sections and has no test-coverage bullets in its history; a change with no user-visible effect does not warrant breaking that convention.
- **The order plant already had tests.** The audit's claim that it had none was wrong — only the PnL plant genuinely had no test module. Both now have one.
