### PR TITLE
feat(orders)!: route orders by exchange from the server's trade routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Public struct fields and a method signature change, so this lands in a major rel
 - **`RithmicOrderPlantHandle::adjust_profit` and `adjust_stop` take a `RithmicBracketLevelAdjustment`**
   instead of `(id, ticks)`, adding a `level` that selects the bracket leg. `level: None` keeps the
   prior behavior.
+- **`RithmicOrder`, `RithmicAdvancedBracketOrder` and `RithmicOcoOrderLeg` gain a required
+  `trade_route: Option<String>` field.** Add `trade_route: None` to existing literals. Orders now use
+  the route the server publishes for their exchange instead of a fixed `"globex"`/`"simulator"`, and
+  fail with `RithmicError::NoTradeRoute` when there is none.
 
 ### Added
 
@@ -49,6 +53,18 @@ Public struct fields and a method signature change, so this lands in a major rel
   into `rithmic_rs::rti`.
 - `RithmicModifyOrder::trigger_price` — StopLimit/StopMarket modifies can set a trigger price
   distinct from the limit price. When `None`, the trigger still defaults to `price` for stop types.
+- **`RithmicError::NoTradeRoute { exchange, cached }`** — no route was published for that exchange
+  and the order set none itself, so nothing was sent. `cached` lists the exchanges that do have one.
+- **Per-order trade routes** via the new `trade_route` field on `RithmicOrder`,
+  `RithmicAdvancedBracketOrder` and `RithmicOcoOrderLeg`, which overrides the route the plant would
+  pick, including with a route the server never published. `place_bracket_order` has no override;
+  convert to `RithmicAdvancedBracketOrder` to set one.
+- **`RithmicOrderPlantHandle::trade_route_for(exchange)`** — the route an order for that exchange
+  would take right now, without sending anything.
+- **`RithmicOrderPlantHandle::record_trade_route(update)`** — apply a `TradeRoute` update to the
+  cached routes. `login()` subscribes, so those updates arrive on `subscription_receiver`, but
+  nothing applies them for you: ignore them and orders keep the routes login read. See
+  `examples/trade_routes.rs`.
 
 ### Changed
 
@@ -94,6 +110,13 @@ Public struct fields and a method signature change, so this lands in a major rel
   `get_account_rms_info` may return fewer accounts than before**, including for `Trader` logins.
 - **Bracket target/stop level updates omitted the `level` field**, so on a multi-leg bracket every
   adjustment landed on the server's default leg and the other legs were unreachable.
+- **Every order went out on `"globex"` (live) or `"simulator"` regardless of exchange**, ignoring the
+  routes the server publishes. That is correct only where the FCM happens to route every venue the
+  same way; anywhere it does not, or where a venue has no route at all, the order carried a route
+  that does not apply to it. The plant now uses the routes the server publishes for the exchange,
+  preferring one it marks default; `login()` reads them once and orders route off that snapshot for
+  the life of the connection. Login logs each route it loaded, and the count, at `info`, or logs at
+  `error` if none were published; the route each order takes logs at `debug`.
 
 ## [2.0.0]
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-See [`examples/`](examples/) for more usage patterns including [error handling](examples/error_handling.rs), [reconnection handling](examples/reconnect.rs), and historical data loading.
+See [`examples/`](examples/) for more usage patterns including [error handling](examples/error_handling.rs), [reconnection handling](examples/reconnect.rs), [order routing](examples/trade_routes.rs), and historical data loading.
 
 ## Architecture
 

--- a/examples/trade_routes.rs
+++ b/examples/trade_routes.rs
@@ -1,0 +1,109 @@
+//! Example: Route orders by exchange
+//!
+//! Orders go out on the route the server publishes for their exchange. `login()`
+//! reads those routes once and orders use that snapshot, so there are three
+//! things you may want to do:
+//!
+//! - Check a venue is routable before you trade, with `trade_route_for`.
+//! - Apply a route the server moves mid-session, with `record_trade_route`.
+//! - Send an order on a route of your own, with `RithmicOrder::trade_route`.
+//!
+//! Run with: cargo run --example trade_routes
+
+use tokio::sync::broadcast::error::RecvError;
+use tracing::{info, warn};
+
+use rithmic_rs::{
+    ConnectStrategy, RithmicAccount, RithmicConfig, RithmicEnv, RithmicOrder,
+    RithmicOrderPlantHandle, rti::messages::RithmicMessage,
+};
+
+/// Applies route changes as the server publishes them.
+///
+/// Updates arrive on the subscription channel but are not applied for you: until
+/// you hand one back, orders keep the route `login()` read.
+fn spawn_route_listener(handle: RithmicOrderPlantHandle) {
+    let mut receiver = handle.subscription_receiver.resubscribe();
+
+    tokio::spawn(async move {
+        loop {
+            match receiver.recv().await {
+                Ok(response) => {
+                    if let RithmicMessage::TradeRoute(update) = &response.message {
+                        info!(
+                            "Route update: {} -> {:?}",
+                            update.exchange.as_deref().unwrap_or("?"),
+                            update.trade_route.as_deref().unwrap_or("?"),
+                        );
+
+                        // Fails only once the plant is gone, so stop listening.
+                        if handle.record_trade_route(update).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+                Err(RecvError::Closed) => break,
+                Err(RecvError::Lagged(n)) => warn!("Listener lagged, missed {} messages", n),
+            }
+        }
+    });
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenvy::dotenv().ok();
+    tracing_subscriber::fmt().init();
+
+    let config = RithmicConfig::from_env(RithmicEnv::Demo)?;
+    let account = RithmicAccount::from_env(RithmicEnv::Demo)?;
+    let order_plant =
+        rithmic_rs::RithmicOrderPlant::connect(&config, ConnectStrategy::Retry).await?;
+    let handle = order_plant.get_handle(&account);
+
+    // Login loads the routes, so nothing below works before this.
+    handle.login().await?;
+
+    // The listener needs its own handle; every handle from this plant shares the
+    // one login and the one set of routes.
+    spawn_route_listener(order_plant.get_handle(&account));
+
+    // Check the venues you trade are routable. This sends nothing and fails
+    // exactly where an order for that exchange would.
+    for exchange in ["CME", "CBOT", "NYMEX"] {
+        match handle.trade_route_for(exchange).await {
+            Ok(route) => info!("{} orders go out on {}", exchange, route),
+            Err(err) => warn!("{} is not routable: {}", exchange, err),
+        }
+    }
+
+    // Placing an order picks the route for its exchange. An exchange with no
+    // route fails with `RithmicError::NoTradeRoute` and nothing is sent.
+    let order = RithmicOrder {
+        symbol: "ESM6".to_string(),
+        exchange: "CME".to_string(),
+        quantity: 1,
+        price: 5000.0,
+        transaction_type: rithmic_rs::rti::request_new_order::TransactionType::Buy,
+        price_type: rithmic_rs::rti::request_new_order::PriceType::Limit,
+        user_tag: "example-routed".to_string(),
+        duration: None,
+        trigger_price: None,
+        trailing_stop: None,
+        // Set this to send on a route of your own, including one the server
+        // never published. `None` uses the route for the exchange.
+        trade_route: None,
+    };
+
+    match handle.place_order(order).await {
+        Ok(responses) => {
+            for response in &responses {
+                info!("Order response: {:?}", response);
+            }
+        }
+        Err(err) => warn!("Order refused: {}", err),
+    }
+
+    handle.disconnect().await?;
+
+    Ok(())
+}

--- a/src/api/rithmic_command_types.rs
+++ b/src/api/rithmic_command_types.rs
@@ -49,6 +49,7 @@ pub struct LoginConfig {
 ///     price_type: OcoPriceType::Limit,
 ///     user_tag: "take-profit".to_string(),
 ///     trailing_stop: None,
+///     trade_route: None,
 /// };
 ///
 /// let stop_loss = RithmicOcoOrderLeg {
@@ -62,6 +63,7 @@ pub struct LoginConfig {
 ///     price_type: OcoPriceType::StopMarket,
 ///     user_tag: "stop-loss".to_string(),
 ///     trailing_stop: None,
+///     trade_route: None,
 /// };
 ///
 /// handle.place_oco_order(take_profit, stop_loss).await?;
@@ -88,6 +90,9 @@ pub struct RithmicOcoOrderLeg {
     pub user_tag: String,
     /// Optional trailing stop configuration for this leg
     pub trailing_stop: Option<TrailingStop>,
+    /// Route to send on. `None` uses the route the server published for this
+    /// leg's exchange.
+    pub trade_route: Option<String>,
 }
 
 /// Entry order with linked profit target and stop loss orders.
@@ -291,6 +296,8 @@ pub struct RithmicAdvancedBracketOrder {
     pub cancel_at_usecs: Option<i32>,
     /// Cancel order after this many seconds.
     pub cancel_after_secs: Option<i32>,
+    /// Route to send on. `None` uses the route the server published for `exchange`.
+    pub trade_route: Option<String>,
 }
 
 impl Default for RithmicAdvancedBracketOrder {
@@ -327,6 +334,7 @@ impl Default for RithmicAdvancedBracketOrder {
             cancel_at_ssboe: None,
             cancel_at_usecs: None,
             cancel_after_secs: None,
+            trade_route: None,
         }
     }
 }
@@ -365,6 +373,7 @@ impl From<RithmicBracketOrder> for RithmicAdvancedBracketOrder {
             cancel_at_ssboe: None,
             cancel_at_usecs: None,
             cancel_after_secs: None,
+            trade_route: None,
         }
     }
 }
@@ -555,6 +564,8 @@ pub struct RithmicOrder {
     pub trigger_price: Option<f64>,
     /// Trailing stop configuration
     pub trailing_stop: Option<TrailingStop>,
+    /// Route to send on. `None` uses the route the server published for `exchange`.
+    pub trade_route: Option<String>,
 }
 
 impl Default for RithmicOrder {
@@ -570,6 +581,7 @@ impl Default for RithmicOrder {
             duration: None,
             trigger_price: None,
             trailing_stop: None,
+            trade_route: None,
         }
     }
 }

--- a/src/api/sender_api.rs
+++ b/src/api/sender_api.rs
@@ -4,7 +4,7 @@ use super::rithmic_command_types::{
 use prost::Message;
 
 use crate::{
-    config::{RithmicAccount, RithmicConfig, RithmicEnv},
+    config::{RithmicAccount, RithmicConfig},
     rti::{
         RequestAcceptAgreement, RequestAccountList, RequestAccountRmsInfo,
         RequestAccountRmsUpdates, RequestAuxilliaryReferenceData, RequestBracketOrder,
@@ -38,9 +38,6 @@ use crate::{
         response_login_info,
     },
 };
-
-pub(crate) const TRADE_ROUTE_LIVE: &str = "globex";
-pub(crate) const TRADE_ROUTE_DEMO: &str = "simulator";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum LoginUserType {
@@ -114,7 +111,6 @@ impl LoginScope {
 pub(crate) struct RithmicSenderApi {
     app_name: String,
     app_version: String,
-    env: RithmicEnv,
     message_id_counter: u64,
 }
 
@@ -123,7 +119,6 @@ impl RithmicSenderApi {
         RithmicSenderApi {
             app_name: config.app_name.clone(),
             app_version: config.app_version.clone(),
-            env: config.env,
             message_id_counter: 0,
         }
     }
@@ -520,8 +515,13 @@ impl RithmicSenderApi {
     /// This is the preferred method for placing orders as it supports
     /// advanced features like trigger prices and trailing stops.
     ///
+    /// The route sent is the `trade_route` argument; `order.trade_route` is one
+    /// of the inputs the caller resolved it from and is not read here.
+    ///
     /// # Arguments
     /// * `order` - The order parameters
+    /// * `account` - The account to place the order for
+    /// * `trade_route` - The route to send the order on
     ///
     /// # Returns
     /// A tuple of (serialized request buffer, request ID)
@@ -529,13 +529,9 @@ impl RithmicSenderApi {
         &mut self,
         order: &RithmicOrder,
         account: &RithmicAccount,
+        trade_route: &str,
     ) -> (Vec<u8>, String) {
         let id = self.get_next_message_id();
-
-        let trade_route = match self.env {
-            RithmicEnv::Live => TRADE_ROUTE_LIVE,
-            RithmicEnv::Demo | RithmicEnv::Test => TRADE_ROUTE_DEMO,
-        };
 
         let req = RequestNewOrder {
             template_id: 312,
@@ -563,27 +559,45 @@ impl RithmicSenderApi {
         self.request_to_buf(req, id)
     }
 
+    /// Build a bracket order request from the simple [`RithmicBracketOrder`].
+    ///
+    /// # Arguments
+    /// * `bracket_order` - The bracket order parameters
+    /// * `account` - The account to place the order for
+    /// * `trade_route` - The route to send the order on
+    ///
+    /// # Returns
+    /// A tuple of (serialized request buffer, request ID)
     pub fn request_bracket_order(
         &mut self,
         bracket_order: RithmicBracketOrder,
         account: &RithmicAccount,
         scope: Option<&LoginScope>,
+        trade_route: &str,
     ) -> (Vec<u8>, String) {
-        self.request_advanced_bracket_order(bracket_order.into(), account, scope)
+        self.request_advanced_bracket_order(bracket_order.into(), account, scope, trade_route)
     }
 
+    /// Build a bracket order request from the full [`RithmicAdvancedBracketOrder`].
+    ///
+    /// The route sent is the `trade_route` argument; `bracket_order.trade_route`
+    /// is one of the inputs the caller resolved it from and is not read here.
+    ///
+    /// # Arguments
+    /// * `bracket_order` - The bracket order parameters
+    /// * `account` - The account to place the order for
+    /// * `trade_route` - The route to send the order on
+    ///
+    /// # Returns
+    /// A tuple of (serialized request buffer, request ID)
     pub fn request_advanced_bracket_order(
         &mut self,
         bracket_order: RithmicAdvancedBracketOrder,
         account: &RithmicAccount,
         scope: Option<&LoginScope>,
+        trade_route: &str,
     ) -> (Vec<u8>, String) {
         let id = self.get_next_message_id();
-
-        let trade_route = match self.env {
-            RithmicEnv::Live => TRADE_ROUTE_LIVE,
-            RithmicEnv::Demo | RithmicEnv::Test => TRADE_ROUTE_DEMO, // NOTE: Not sure if this is correct value for test environment
-        };
 
         let req = RequestBracketOrder {
             template_id: 330,
@@ -1536,25 +1550,6 @@ impl RithmicSenderApi {
         self.request_to_buf(req, id)
     }
 
-    /// Request an OCO (One Cancels Other) order pair
-    ///
-    /// Builds a `RequestOcoOrder` carrying the two supplied legs.
-    ///
-    /// # Arguments
-    /// * `order1` - First order leg
-    /// * `order2` - Second order leg
-    ///
-    /// # Returns
-    /// A tuple of (serialized request buffer, request ID)
-    pub fn request_oco_order(
-        &mut self,
-        order1: RithmicOcoOrderLeg,
-        order2: RithmicOcoOrderLeg,
-        account: &RithmicAccount,
-    ) -> (Vec<u8>, String) {
-        self.request_oco_order_multi(vec![order1, order2], account)
-    }
-
     /// Request an OCO (One Cancels Other) order with an arbitrary number of legs
     ///
     /// Builds a single `RequestOcoOrder` (template 328) with every repeated field
@@ -1562,22 +1557,18 @@ impl RithmicSenderApi {
     /// are automatically cancelled.
     ///
     /// # Arguments
-    /// * `legs` - The order legs
+    /// * `legs` - The order legs, each paired with the resolved trade route for
+    ///   that leg's exchange, which keeps the repeated route field index-aligned
     /// * `account` - The account to place the order for
     ///
     /// # Returns
     /// A tuple of (serialized request buffer, request ID)
     pub fn request_oco_order_multi(
         &mut self,
-        legs: Vec<RithmicOcoOrderLeg>,
+        legs: Vec<(RithmicOcoOrderLeg, String)>,
         account: &RithmicAccount,
     ) -> (Vec<u8>, String) {
         let id = self.get_next_message_id();
-
-        let trade_route = match self.env {
-            RithmicEnv::Live => TRADE_ROUTE_LIVE,
-            RithmicEnv::Demo | RithmicEnv::Test => TRADE_ROUTE_DEMO,
-        };
 
         let mut user_tag = Vec::new();
         let mut symbol = Vec::new();
@@ -1594,7 +1585,7 @@ impl RithmicSenderApi {
         let mut trail_by_ticks = Vec::new();
         let mut trail_by_price_id = Vec::new();
 
-        for leg in legs {
+        for (leg, trade_route) in legs {
             user_tag.push(leg.user_tag);
             symbol.push(leg.symbol);
             exchange.push(leg.exchange);
@@ -1604,7 +1595,7 @@ impl RithmicSenderApi {
             transaction_type.push(leg.transaction_type.into());
             duration.push(leg.duration.into());
             price_type.push(leg.price_type.into());
-            trade_routes.push(trade_route.to_string());
+            trade_routes.push(trade_route);
             manual_or_auto.push(request_oco_order::OrderPlacement::Auto.into());
             trailing_stop.push(leg.trailing_stop.is_some());
             trail_by_ticks.push(leg.trailing_stop.as_ref().map_or(0, |ts| ts.trail_by_ticks));
@@ -1906,7 +1897,7 @@ impl RithmicSenderApi {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::rithmic_command_types::TrailingStop;
+    use crate::{api::rithmic_command_types::TrailingStop, config::RithmicEnv};
 
     fn test_config() -> RithmicConfig {
         RithmicConfig::builder(RithmicEnv::Demo)
@@ -1991,9 +1982,10 @@ mod tests {
             duration: Some(crate::rti::request_new_order::Duration::Day),
             trigger_price: None,
             trailing_stop: None,
+            trade_route: None,
         };
 
-        let (buf, _) = api.request_order(&order, &override_account());
+        let (buf, _) = api.request_order(&order, &override_account(), "globex");
         let request: RequestNewOrder = decode_request(&buf);
 
         assert_eq!(request.fcm_id.as_deref(), Some("FCM_B"));
@@ -2041,7 +2033,7 @@ mod tests {
             symbol: "ESM6".to_string(),
         };
 
-        let (buf, _) = api.request_bracket_order(bracket, &override_account(), None);
+        let (buf, _) = api.request_bracket_order(bracket, &override_account(), None, "globex");
         let request: RequestBracketOrder = decode_request(&buf);
 
         assert_eq!(request.fcm_id.as_deref(), Some("FCM_B"));
@@ -2064,14 +2056,18 @@ mod tests {
     fn advanced_bracket_request_sets_account_and_trade_route_fields() {
         let mut api = RithmicSenderApi::new(&test_config());
 
-        let (buf, _) =
-            api.request_advanced_bracket_order(advanced_bracket(), &override_account(), None);
+        let (buf, _) = api.request_advanced_bracket_order(
+            advanced_bracket(),
+            &override_account(),
+            None,
+            "globex",
+        );
         let request: RequestBracketOrder = decode_request(&buf);
 
         assert_eq!(request.fcm_id.as_deref(), Some("FCM_B"));
         assert_eq!(request.ib_id.as_deref(), Some("IB_B"));
         assert_eq!(request.account_id.as_deref(), Some("ACCOUNT_B"));
-        assert_eq!(request.trade_route.as_deref(), Some(TRADE_ROUTE_DEMO));
+        assert_eq!(request.trade_route.as_deref(), Some("globex"));
         assert_eq!(request.user_tag.as_deref(), Some("advanced-bracket-1"));
     }
 
@@ -2079,8 +2075,12 @@ mod tests {
     fn advanced_bracket_request_encodes_trigger_and_if_touched_fields() {
         let mut api = RithmicSenderApi::new(&test_config());
 
-        let (buf, _) =
-            api.request_advanced_bracket_order(advanced_bracket(), &default_account(), None);
+        let (buf, _) = api.request_advanced_bracket_order(
+            advanced_bracket(),
+            &default_account(),
+            None,
+            "globex",
+        );
         let request: RequestBracketOrder = decode_request(&buf);
         assert_eq!(request.price, Some(5000.25));
         assert_eq!(request.trigger_price, Some(4999.75));
@@ -2113,8 +2113,12 @@ mod tests {
     fn advanced_bracket_request_encodes_management_and_timing_fields() {
         let mut api = RithmicSenderApi::new(&test_config());
 
-        let (buf, _) =
-            api.request_advanced_bracket_order(advanced_bracket(), &default_account(), None);
+        let (buf, _) = api.request_advanced_bracket_order(
+            advanced_bracket(),
+            &default_account(),
+            None,
+            "globex",
+        );
         let request: RequestBracketOrder = decode_request(&buf);
 
         assert_eq!(request.break_even_ticks, Some(2));
@@ -2149,6 +2153,7 @@ mod tests {
             price_type: crate::rti::request_oco_order::PriceType::Limit,
             user_tag: "oco-1".to_string(),
             trailing_stop: None,
+            trade_route: None,
         };
         let leg2 = RithmicOcoOrderLeg {
             symbol: "ESM6".to_string(),
@@ -2161,9 +2166,13 @@ mod tests {
             price_type: crate::rti::request_oco_order::PriceType::StopMarket,
             user_tag: "oco-2".to_string(),
             trailing_stop: None,
+            trade_route: None,
         };
 
-        let (buf, _) = api.request_oco_order(leg1, leg2, &override_account());
+        let (buf, _) = api.request_oco_order_multi(
+            vec![(leg1, "globex".to_string()), (leg2, "nymex".to_string())],
+            &override_account(),
+        );
         let request: RequestOcoOrder = decode_request(&buf);
 
         assert_eq!(request.fcm_id.as_deref(), Some("FCM_B"));
@@ -2279,6 +2288,7 @@ mod tests {
             price_type: crate::rti::request_oco_order::PriceType::Limit,
             user_tag: "leg-0".to_string(),
             trailing_stop: None,
+            trade_route: None,
         };
         let leg1 = RithmicOcoOrderLeg {
             symbol: "NQM6".to_string(),
@@ -2294,6 +2304,7 @@ mod tests {
                 trail_by_ticks: 15,
                 trail_by_price_id: 7,
             }),
+            trade_route: None,
         };
         let leg2 = RithmicOcoOrderLeg {
             symbol: "CLM6".to_string(),
@@ -2309,9 +2320,17 @@ mod tests {
                 trail_by_ticks: 25,
                 trail_by_price_id: 9,
             }),
+            trade_route: None,
         };
 
-        let (buf, _) = api.request_oco_order_multi(vec![leg0, leg1, leg2], &default_account());
+        let (buf, _) = api.request_oco_order_multi(
+            vec![
+                (leg0, "globex".to_string()),
+                (leg1, "globex".to_string()),
+                (leg2, "nymex".to_string()),
+            ],
+            &default_account(),
+        );
         let request: RequestOcoOrder = decode_request(&buf);
 
         assert_eq!(request.symbol.len(), 3);
@@ -2365,7 +2384,14 @@ mod tests {
             request.manual_or_auto,
             vec![request_oco_order::OrderPlacement::Auto as i32; 3]
         );
-        assert_eq!(request.trade_route, vec![TRADE_ROUTE_DEMO.to_string(); 3]);
+        assert_eq!(
+            request.trade_route,
+            vec![
+                "globex".to_string(),
+                "globex".to_string(),
+                "nymex".to_string()
+            ]
+        );
         assert_eq!(request.trailing_stop, vec![false, true, true]);
         assert_eq!(request.trail_by_ticks, vec![0, 15, 25]);
         assert_eq!(request.trail_by_price_id, vec![0, 7, 9]);
@@ -2388,9 +2414,10 @@ mod tests {
                 trail_by_ticks: 20,
                 trail_by_price_id: 3,
             }),
+            trade_route: None,
         };
 
-        let (buf, _) = api.request_order(&order, &default_account());
+        let (buf, _) = api.request_order(&order, &default_account(), "globex");
         let request: RequestNewOrder = decode_request(&buf);
 
         assert_eq!(request.trailing_stop, Some(true));
@@ -2565,6 +2592,7 @@ mod tests {
                 advanced_bracket(),
                 &override_account(),
                 Some(&scope),
+                "globex",
             );
             let request: RequestBracketOrder = decode_request(&buf);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -128,6 +128,13 @@ pub enum RithmicError {
     /// A caller-supplied argument is invalid (the message describes which argument
     /// and why).
     InvalidArgument(String),
+    /// No route for the order's exchange and the order named none, so nothing was sent.
+    NoTradeRoute {
+        /// The exchange the order named.
+        exchange: String,
+        /// The exchanges that do have a route.
+        cached: Vec<String>,
+    },
     /// Keep-alive detected the connection is dead.
     HeartbeatTimeout,
     /// Server terminated the session with a reason string.
@@ -179,6 +186,23 @@ impl fmt::Display for RithmicError {
             }
             RithmicError::ProtocolError(msg) => write!(f, "protocol error: {msg}"),
             RithmicError::InvalidArgument(msg) => write!(f, "invalid argument: {msg}"),
+            RithmicError::NoTradeRoute { exchange, cached } => {
+                write!(
+                    f,
+                    "no trade route for exchange {}",
+                    sanitize_for_display(exchange),
+                )?;
+
+                match cached.is_empty() {
+                    true => write!(f, "; no routes cached"),
+                    false => {
+                        let cached: Vec<String> =
+                            cached.iter().map(|key| sanitize_for_display(key)).collect();
+
+                        write!(f, "; cached: {}", cached.join(", "))
+                    }
+                }
+            }
             RithmicError::HeartbeatTimeout => write!(f, "heartbeat timeout"),
             RithmicError::ForcedLogout(reason) => {
                 write!(f, "forced logout: {}", sanitize_for_display(reason))
@@ -428,6 +452,51 @@ mod tests {
         assert!(!RithmicError::ProtocolError("x".into()).is_connection_issue());
         assert!(!RithmicError::InvalidArgument("x".into()).is_connection_issue());
         assert!(!RithmicError::EmptyResponse.is_connection_issue());
+        assert!(
+            !RithmicError::NoTradeRoute {
+                exchange: "CBOT".into(),
+                cached: vec![],
+            }
+            .is_connection_issue()
+        );
+    }
+
+    #[test]
+    fn no_trade_route_display_lists_what_is_cached() {
+        let err = RithmicError::NoTradeRoute {
+            exchange: "CBOT".into(),
+            cached: vec!["CME".into(), "NYMEX".into()],
+        };
+
+        assert_eq!(
+            err.to_string(),
+            "no trade route for exchange CBOT; cached: CME, NYMEX"
+        );
+
+        let err = RithmicError::NoTradeRoute {
+            exchange: "CBOT".into(),
+            cached: vec![],
+        };
+
+        assert_eq!(
+            err.to_string(),
+            "no trade route for exchange CBOT; no routes cached"
+        );
+    }
+
+    #[test]
+    fn no_trade_route_display_sanitizes_control_chars() {
+        // The exchange and the cached names both come off the wire, so both go
+        // through the sanitizer.
+        let err = RithmicError::NoTradeRoute {
+            exchange: "CB\rOT".into(),
+            cached: vec!["C\x1b[31mME".into()],
+        };
+
+        assert_eq!(
+            err.to_string(),
+            "no trade route for exchange CBOT; cached: C[31mME"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,9 @@
 //!
 //! - [`InvalidArgument`](RithmicError::InvalidArgument) — your arguments.
 //!   Nothing was sent. Fix them and call again.
+//! - [`NoTradeRoute`](RithmicError::NoTradeRoute) — no route for the order's
+//!   exchange. Nothing was sent. Set the order's `trade_route`, or check the
+//!   exchange with `trade_route_for` before you trade.
 //! - [`SendFailed`](RithmicError::SendFailed) — the send failed. Only this
 //!   request fails and the plant is still up, but the connection is usually on
 //!   its way out; expect a `ConnectionError` to follow. Treat it as a

--- a/src/plants.rs
+++ b/src/plants.rs
@@ -23,3 +23,4 @@ pub mod subscription;
 pub(crate) mod test_support;
 /// Real-time market data subscription
 pub mod ticker_plant;
+pub(crate) mod trade_routes;

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -20,11 +20,12 @@ use crate::{
     plants::{
         core::{PlantCore, SelectResult},
         subscription::SubscriptionFilter,
+        trade_routes::TradeRouteCache,
     },
     request_handler::RithmicRequest,
     rti::{
-        messages::RithmicMessage, request_account_rms_updates, request_easy_to_borrow_list,
-        request_login::SysInfraType,
+        TradeRoute, messages::RithmicMessage, request_account_rms_updates,
+        request_easy_to_borrow_list, request_login::SysInfraType,
     },
     ws::PlantActor,
 };
@@ -69,7 +70,7 @@ pub(crate) enum OrderPlantCommand {
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
     },
     PlaceAdvancedBracketOrder {
-        bracket_order: RithmicAdvancedBracketOrder,
+        bracket_order: Box<RithmicAdvancedBracketOrder>,
         account: Arc<RithmicAccount>,
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
     },
@@ -117,6 +118,12 @@ pub(crate) enum OrderPlantCommand {
         subscribe_for_updates: bool,
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
     },
+    RecordTradeRoutes(Vec<RithmicResponse>),
+    RecordTradeRouteUpdate(Box<TradeRoute>),
+    TradeRouteFor {
+        exchange: String,
+        response_sender: oneshot::Sender<Result<String, RithmicError>>,
+    },
     ShowOrderHistoryDates {
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
     },
@@ -138,12 +145,6 @@ pub(crate) enum OrderPlantCommand {
     },
     PlaceOrder {
         order: RithmicOrder,
-        account: Arc<RithmicAccount>,
-        response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
-    },
-    PlaceOcoOrder {
-        order1: RithmicOcoOrderLeg,
-        order2: RithmicOcoOrderLeg,
         account: Arc<RithmicAccount>,
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
     },
@@ -406,6 +407,7 @@ struct OrderPlant {
     core: PlantCore,
     request_receiver: mpsc::Receiver<OrderPlantCommand>,
     login_scope: Arc<OnceLock<LoginScope>>,
+    trade_routes: TradeRouteCache,
 }
 
 impl OrderPlant {
@@ -422,6 +424,7 @@ impl OrderPlant {
             core,
             request_receiver,
             login_scope,
+            trade_routes: TradeRouteCache::default(),
         })
     }
 }
@@ -596,10 +599,19 @@ impl PlantActor for OrderPlant {
                 account,
                 response_sender,
             } => {
+                let trade_route = match self.trade_routes.resolve(None, &bracket_order.exchange) {
+                    Ok(trade_route) => trade_route,
+                    Err(err) => {
+                        let _ = response_sender.send(Err(err));
+                        return;
+                    }
+                };
+
                 let (req_buf, id) = self.core.rithmic_sender_api.request_bracket_order(
                     bracket_order,
                     &account,
                     self.login_scope.get(),
+                    &trade_route,
                 );
 
                 self.core.request_handler.register_request(RithmicRequest {
@@ -616,10 +628,22 @@ impl PlantActor for OrderPlant {
                 account,
                 response_sender,
             } => {
+                let trade_route = match self.trade_routes.resolve(
+                    bracket_order.trade_route.as_deref(),
+                    &bracket_order.exchange,
+                ) {
+                    Ok(trade_route) => trade_route,
+                    Err(err) => {
+                        let _ = response_sender.send(Err(err));
+                        return;
+                    }
+                };
+
                 let (req_buf, id) = self.core.rithmic_sender_api.request_advanced_bracket_order(
-                    bracket_order,
+                    *bracket_order,
                     &account,
                     self.login_scope.get(),
+                    &trade_route,
                 );
 
                 self.core.request_handler.register_request(RithmicRequest {
@@ -804,6 +828,28 @@ impl PlantActor for OrderPlant {
                     .send_or_fail(Message::Binary(req_buf.into()), &id)
                     .await;
             }
+            OrderPlantCommand::RecordTradeRoutes(responses) => {
+                let loaded = responses
+                    .iter()
+                    .filter(|response| self.trade_routes.record_response(response))
+                    .count();
+
+                match loaded {
+                    0 => error!(
+                        "order_plant: no trade routes published, orders will fail with NoTradeRoute"
+                    ),
+                    loaded => info!("order_plant: {} trade routes loaded", loaded),
+                }
+            }
+            OrderPlantCommand::RecordTradeRouteUpdate(update) => {
+                self.trade_routes.record_update(&update);
+            }
+            OrderPlantCommand::TradeRouteFor {
+                exchange,
+                response_sender,
+            } => {
+                let _ = response_sender.send(self.trade_routes.resolve(None, &exchange));
+            }
             OrderPlantCommand::ShowOrderHistoryDates { response_sender } => {
                 let (req_buf, id) = self
                     .core
@@ -882,27 +928,21 @@ impl PlantActor for OrderPlant {
                 account,
                 response_sender,
             } => {
-                let (req_buf, id) = self.core.rithmic_sender_api.request_order(&order, &account);
+                let trade_route = match self
+                    .trade_routes
+                    .resolve(order.trade_route.as_deref(), &order.exchange)
+                {
+                    Ok(trade_route) => trade_route,
+                    Err(err) => {
+                        let _ = response_sender.send(Err(err));
+                        return;
+                    }
+                };
 
-                self.core.request_handler.register_request(RithmicRequest {
-                    request_id: id.clone(),
-                    responder: response_sender,
-                });
-
-                self.core
-                    .send_or_fail(Message::Binary(req_buf.into()), &id)
-                    .await;
-            }
-            OrderPlantCommand::PlaceOcoOrder {
-                order1,
-                order2,
-                account,
-                response_sender,
-            } => {
-                let (req_buf, id) = self
-                    .core
-                    .rithmic_sender_api
-                    .request_oco_order(order1, order2, &account);
+                let (req_buf, id) =
+                    self.core
+                        .rithmic_sender_api
+                        .request_order(&order, &account, &trade_route);
 
                 self.core.request_handler.register_request(RithmicRequest {
                     request_id: id.clone(),
@@ -918,6 +958,14 @@ impl PlantActor for OrderPlant {
                 account,
                 response_sender,
             } => {
+                let legs = match self.trade_routes.resolve_legs(legs) {
+                    Ok(legs) => legs,
+                    Err(err) => {
+                        let _ = response_sender.send(Err(err));
+                        return;
+                    }
+                };
+
                 let (req_buf, id) = self
                     .core
                     .rithmic_sender_api
@@ -1271,7 +1319,10 @@ impl RithmicOrderPlantHandle {
 
     /// Log in to the Rithmic Order plant
     ///
-    /// This must be called before sending orders or subscriptions
+    /// This must be called before sending orders or subscriptions.
+    ///
+    /// Also loads the trade routes orders are sent on. If that fails the login still
+    /// succeeds, and orders fail with [`RithmicError::NoTradeRoute`].
     ///
     /// # Returns
     /// The login response or an error message
@@ -1282,6 +1333,8 @@ impl RithmicOrderPlantHandle {
     /// Log in to the Rithmic Order plant with custom configuration
     ///
     /// This must be called before sending orders or subscriptions.
+    ///
+    /// Loads trade routes on success, like [`login`](Self::login).
     ///
     /// # Arguments
     /// * `config` - Login configuration options. See [`LoginConfig`] for details.
@@ -1348,9 +1401,43 @@ impl RithmicOrderPlantHandle {
             ),
         }
 
+        self.prime_trade_routes().await;
+
         info!("order_plant: logged in");
 
         Ok(response)
+    }
+
+    /// Load the routes orders are sent on, once, and hand them to the plant.
+    ///
+    /// This is the snapshot orders route from for the life of the connection.
+    /// It subscribes, so updates reach the subscription channel, but only
+    /// [`record_trade_route`](Self::record_trade_route) applies one.
+    ///
+    /// A failure here is only logged: you get [`RithmicError::NoTradeRoute`]
+    /// when placing an order, rather than a bad route.
+    async fn prime_trade_routes(&self) {
+        match self.get_trade_routes(true).await {
+            Ok(responses) => {
+                for rejection in responses.iter().filter_map(|resp| resp.error.as_ref()) {
+                    error!(
+                        "order_plant: trade route request rejected, orders will fail: {}",
+                        rejection
+                    );
+                }
+
+                // Queued on the same channel orders are, so an order placed the
+                // moment `connect` returns is still handled after this.
+                let _ = self
+                    .sender
+                    .send(OrderPlantCommand::RecordTradeRoutes(responses))
+                    .await;
+            }
+            Err(err) => error!(
+                "order_plant: trade routes unavailable, orders will fail: {}",
+                err
+            ),
+        }
     }
 
     /// Disconnect from the Rithmic Order plant
@@ -1492,7 +1579,7 @@ impl RithmicOrderPlantHandle {
         let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, RithmicError>>();
 
         let command = OrderPlantCommand::PlaceAdvancedBracketOrder {
-            bracket_order,
+            bracket_order: Box::new(bracket_order),
             account: self.account.clone(),
             response_sender: tx,
         };
@@ -1729,6 +1816,58 @@ impl RithmicOrderPlantHandle {
         rx.await.map_err(|_| RithmicError::ConnectionClosed)?
     }
 
+    /// Apply a `TradeRoute` update to the routes orders go out on.
+    ///
+    /// [`login`](Self::login) subscribes, so updates arrive on
+    /// [`subscription_receiver`](Self::subscription_receiver); applying them is up
+    /// to you.
+    ///
+    /// ```no_run
+    /// # use rithmic_rs::{RithmicOrderPlantHandle, rti::messages::RithmicMessage};
+    /// # async fn example(handle: RithmicOrderPlantHandle) -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut updates = handle.subscription_receiver.resubscribe();
+    ///
+    /// while let Ok(response) = updates.recv().await {
+    ///     if let RithmicMessage::TradeRoute(update) = &response.message {
+    ///         handle.record_trade_route(update).await?;
+    ///     }
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn record_trade_route(&self, update: &TradeRoute) -> Result<(), RithmicError> {
+        self.sender
+            .send(OrderPlantCommand::RecordTradeRouteUpdate(Box::new(
+                update.clone(),
+            )))
+            .await
+            .map_err(|_| RithmicError::ConnectionClosed)
+    }
+
+    /// The route an order for `exchange` would go out on right now, without sending
+    /// anything. Call it after [`login`](Self::login) to check your venues are routable.
+    ///
+    /// Fails with [`RithmicError::NoTradeRoute`] where an order would, so an `Ok`
+    /// here means an order that names no route of its own takes this one.
+    ///
+    /// # Arguments
+    /// * `exchange` - The exchange to look up, as it appears on your orders
+    ///
+    /// # Returns
+    /// The route name, or an error naming what is cached instead
+    pub async fn trade_route_for(&self, exchange: &str) -> Result<String, RithmicError> {
+        let (tx, rx) = oneshot::channel::<Result<String, RithmicError>>();
+
+        let command = OrderPlantCommand::TradeRouteFor {
+            exchange: exchange.to_string(),
+            response_sender: tx,
+        };
+
+        let _ = self.sender.send(command).await;
+
+        rx.await.map_err(|_| RithmicError::ConnectionClosed)?
+    }
+
     /// Get dates for which order history is available
     ///
     /// # Returns
@@ -1890,9 +2029,8 @@ impl RithmicOrderPlantHandle {
     ) -> Result<Vec<RithmicResponse>, RithmicError> {
         let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, RithmicError>>();
 
-        let command = OrderPlantCommand::PlaceOcoOrder {
-            order1,
-            order2,
+        let command = OrderPlantCommand::PlaceOcoOrderMulti {
+            legs: vec![order1, order2],
             account: self.account.clone(),
             response_sender: tx,
         };

--- a/src/plants/order_plant/tests.rs
+++ b/src/plants/order_plant/tests.rs
@@ -4,12 +4,15 @@ use super::*;
 use crate::{
     RithmicRequestError,
     api::{
-        rithmic_command_types::{RithmicBracketOrder, RithmicOcoOrderLeg},
+        rithmic_command_types::{
+            RithmicAdvancedBracketOrder, RithmicBracketOrder, RithmicOcoOrderLeg,
+        },
         sender_api::LoginUserType,
     },
     plants::test_support::{
         self, Responder, assert_close_still_sent, assert_rejected_after_close,
-        assert_sent_while_open, assert_wire_silent, read_wire_request, test_account,
+        assert_sent_while_open, assert_wire_silent, awaited_caller_outcome, read_wire_request,
+        test_account,
     },
 };
 
@@ -48,6 +51,7 @@ fn leg(tag: &str) -> RithmicOcoOrderLeg {
         price_type: crate::rti::request_oco_order::PriceType::Limit,
         user_tag: tag.to_string(),
         trailing_stop: None,
+        trade_route: None,
     }
 }
 
@@ -56,13 +60,19 @@ async fn plant_with_wire() -> (OrderPlant, mpsc::Sender<OrderPlantCommand>, TcpS
         core,
         request_receiver,
         login_scope: Arc::new(OnceLock::new()),
+        trade_routes: TradeRouteCache::default(),
     })
     .await
 }
 
+/// Carries an explicit route, so a silent wire below is the close guard rather
+/// than an unroutable order.
 fn place_order(response_sender: Responder) -> OrderPlantCommand {
     OrderPlantCommand::PlaceOrder {
-        order: RithmicOrder::default(),
+        order: RithmicOrder {
+            trade_route: Some("globex".to_string()),
+            ..RithmicOrder::default()
+        },
         account: test_account(),
         response_sender,
     }
@@ -337,6 +347,104 @@ async fn answer_login_info(
     }
 }
 
+/// Answer the `GetTradeRoutes` that `login` issues, returning whether it asked to
+/// stay subscribed to later updates.
+async fn answer_trade_routes(
+    command_receiver: &mut mpsc::Receiver<OrderPlantCommand>,
+    response: Result<Vec<RithmicResponse>, RithmicError>,
+) -> bool {
+    match next_command(command_receiver).await {
+        OrderPlantCommand::GetTradeRoutes {
+            subscribe_for_updates,
+            response_sender,
+        } => {
+            let _ = response_sender.send(response);
+
+            subscribe_for_updates
+        }
+        _ => panic!("login must fetch the trade routes that orders are routed on"),
+    }
+}
+
+fn trade_route_response(exchange: &str, trade_route: &str) -> RithmicResponse {
+    RithmicResponse {
+        request_id: "3".to_string(),
+        message: RithmicMessage::ResponseTradeRoutes(crate::rti::ResponseTradeRoutes {
+            template_id: 311,
+            exchange: Some(exchange.to_string()),
+            trade_route: Some(trade_route.to_string()),
+            ..Default::default()
+        }),
+        is_update: false,
+        has_more: false,
+        multi_response: true,
+        error: None,
+        source: "order_plant".to_string(),
+    }
+}
+
+/// Routes are what orders are placed on, so a login must hand the plant the
+/// snapshot it read. Only `record_trade_route` fills the cache after that.
+#[tokio::test]
+async fn login_hands_the_trade_routes_it_read_to_the_plant() {
+    let (handle, mut command_receiver) = test_handle();
+
+    let driver = async {
+        drive_login_to_login_info(&mut command_receiver).await;
+        answer_login_info(&mut command_receiver, Ok(vec![login_info_response(None)])).await;
+
+        let subscribed = answer_trade_routes(
+            &mut command_receiver,
+            Ok(vec![trade_route_response("CME", "globex")]),
+        )
+        .await;
+
+        let recorded = match next_command(&mut command_receiver).await {
+            OrderPlantCommand::RecordTradeRoutes(responses) => responses,
+            _ => panic!("login must hand the routes it read to the plant"),
+        };
+
+        (subscribed, recorded)
+    };
+
+    let (login, (subscribed, recorded)) = tokio::join!(handle.login(), driver);
+
+    assert!(login.is_ok());
+    assert!(
+        subscribed,
+        "a route the server changes later must at least reach subscribers"
+    );
+    assert_eq!(recorded.len(), 1, "the route read has to reach the plant");
+
+    match &recorded[0].message {
+        RithmicMessage::ResponseTradeRoutes(route) => {
+            assert_eq!(route.exchange.as_deref(), Some("CME"));
+            assert_eq!(route.trade_route.as_deref(), Some("globex"));
+        }
+        _ => panic!("expected the ResponseTradeRoutes frame login read"),
+    }
+}
+
+/// An unavailable route request must not fail a login that already succeeded — the
+/// orders that follow fail individually with `NoTradeRoute` instead.
+#[tokio::test]
+async fn login_succeeds_when_the_trade_routes_are_unavailable() {
+    let (handle, mut command_receiver) = test_handle();
+
+    let driver = async {
+        drive_login_to_login_info(&mut command_receiver).await;
+        answer_login_info(&mut command_receiver, Ok(vec![login_info_response(None)])).await;
+        answer_trade_routes(&mut command_receiver, Err(RithmicError::EmptyResponse)).await;
+    };
+
+    let (login, ()) = tokio::join!(handle.login(), driver);
+
+    assert!(
+        login.is_ok(),
+        "failing trade routes must not fail the login"
+    );
+}
+
 /// Neither failure shape may fail the login or leave a scope behind.
 #[tokio::test]
 async fn login_succeeds_and_stays_unscoped_when_the_login_info_fails() {
@@ -355,6 +463,7 @@ async fn login_succeeds_and_stays_unscoped_when_the_login_info_fails() {
         let driver = async {
             drive_login_to_login_info(&mut command_receiver).await;
             answer_login_info(&mut command_receiver, response).await;
+            answer_trade_routes(&mut command_receiver, Ok(vec![])).await;
         };
 
         let (login, ()) = tokio::join!(handle.login(), driver);
@@ -388,6 +497,7 @@ async fn every_handle_from_one_plant_shares_the_login_scope() {
     let driver = async {
         drive_login_to_login_info(&mut command_receiver).await;
         answer_login_info(&mut command_receiver, Ok(vec![login_info_response(None)])).await;
+        answer_trade_routes(&mut command_receiver, Ok(vec![])).await;
     };
 
     let (login, ()) = tokio::join!(logs_in.login(), driver);
@@ -403,9 +513,19 @@ async fn every_handle_from_one_plant_shares_the_login_scope() {
     assert_eq!(scope.user_type, LoginUserType::Ib);
 }
 
+/// Record the route the server would have published for `exchange`, as a login on
+/// this connection would have left it.
+fn cache_route(plant: &mut OrderPlant, exchange: &str, trade_route: &str) {
+    plant
+        .trade_routes
+        .record(Some(exchange), Some(trade_route), None);
+}
+
 /// A plant actor whose connection has logged in, as `login()` would leave it.
 async fn scoped_plant_with_wire() -> (OrderPlant, mpsc::Sender<OrderPlantCommand>, TcpStream) {
-    let (plant, sender, client) = plant_with_wire().await;
+    let (mut plant, sender, client) = plant_with_wire().await;
+
+    cache_route(&mut plant, "CME", "globex");
 
     plant
         .login_scope
@@ -547,4 +667,444 @@ async fn bracket_level_commands_carry_their_level_to_the_wire() {
     assert_eq!(stop.basket_id.as_deref(), Some("basket-2"));
     assert_eq!(stop.stop_ticks, Some(8));
     assert_eq!(stop.level, Some(3));
+}
+
+fn advanced_bracket_order(
+    exchange: &str,
+    trade_route: Option<&str>,
+) -> RithmicAdvancedBracketOrder {
+    RithmicAdvancedBracketOrder {
+        exchange: exchange.to_string(),
+        localid: "advanced-1".to_string(),
+        symbol: "ESM6".to_string(),
+        quantity: 1,
+        trade_route: trade_route.map(str::to_string),
+        ..RithmicAdvancedBracketOrder::default()
+    }
+}
+
+fn leg_on(exchange: &str, trade_route: Option<&str>) -> RithmicOcoOrderLeg {
+    RithmicOcoOrderLeg {
+        exchange: exchange.to_string(),
+        trade_route: trade_route.map(str::to_string),
+        ..leg("oco")
+    }
+}
+
+/// Every order command must reach the wire on the route cached for its own
+/// exchange — a route crossed between exchanges is an order the venue rejects.
+#[tokio::test]
+async fn every_order_command_sends_the_route_cached_for_its_exchange() {
+    let (mut plant, _sender, mut client) = plant_with_wire().await;
+    cache_route(&mut plant, "CME", "globex");
+    cache_route(&mut plant, "NYMEX", "nymex-route");
+
+    let order: crate::rti::RequestNewOrder =
+        sent_request(&mut plant, &mut client, |response_sender| {
+            OrderPlantCommand::PlaceOrder {
+                order: RithmicOrder {
+                    exchange: "CME".to_string(),
+                    ..RithmicOrder::default()
+                },
+                account: test_account(),
+                response_sender,
+            }
+        })
+        .await;
+
+    assert_eq!(order.trade_route.as_deref(), Some("globex"));
+
+    let bracket: crate::rti::RequestBracketOrder =
+        sent_request(&mut plant, &mut client, |response_sender| {
+            OrderPlantCommand::PlaceBracketOrder {
+                bracket_order: bracket_order(),
+                account: test_account(),
+                response_sender,
+            }
+        })
+        .await;
+
+    assert_eq!(bracket.trade_route.as_deref(), Some("globex"));
+
+    let advanced: crate::rti::RequestBracketOrder =
+        sent_request(&mut plant, &mut client, |response_sender| {
+            OrderPlantCommand::PlaceAdvancedBracketOrder {
+                bracket_order: Box::new(advanced_bracket_order("NYMEX", None)),
+                account: test_account(),
+                response_sender,
+            }
+        })
+        .await;
+
+    assert_eq!(advanced.trade_route.as_deref(), Some("nymex-route"));
+
+    // 350's `trade_route` is repeated and index-aligned with the legs, so an OCO
+    // spanning exchanges must send one route per leg in the legs' own order.
+    let oco: crate::rti::RequestOcoOrder =
+        sent_request(&mut plant, &mut client, |response_sender| {
+            OrderPlantCommand::PlaceOcoOrderMulti {
+                legs: vec![leg_on("NYMEX", None), leg_on("CME", None)],
+                account: test_account(),
+                response_sender,
+            }
+        })
+        .await;
+
+    assert_eq!(oco.trade_route, vec!["nymex-route", "globex"]);
+
+    let oco_multi: crate::rti::RequestOcoOrder =
+        sent_request(&mut plant, &mut client, |response_sender| {
+            OrderPlantCommand::PlaceOcoOrderMulti {
+                legs: vec![
+                    leg_on("CME", None),
+                    leg_on("NYMEX", None),
+                    leg_on("CME", None),
+                ],
+                account: test_account(),
+                response_sender,
+            }
+        })
+        .await;
+
+    assert_eq!(
+        oco_multi.trade_route,
+        vec!["globex", "nymex-route", "globex"]
+    );
+}
+
+/// The per-order route wins over the cache, and works with nothing cached at all —
+/// which is how an unlisted route stays reachable.
+#[tokio::test]
+async fn a_per_order_route_overrides_the_cached_one() {
+    let (mut plant, _sender, mut client) = plant_with_wire().await;
+    cache_route(&mut plant, "CME", "globex");
+
+    let order: crate::rti::RequestNewOrder =
+        sent_request(&mut plant, &mut client, |response_sender| {
+            OrderPlantCommand::PlaceOrder {
+                order: RithmicOrder {
+                    exchange: "CME".to_string(),
+                    trade_route: Some("my-route".to_string()),
+                    ..RithmicOrder::default()
+                },
+                account: test_account(),
+                response_sender,
+            }
+        })
+        .await;
+
+    assert_eq!(order.trade_route.as_deref(), Some("my-route"));
+
+    let advanced: crate::rti::RequestBracketOrder =
+        sent_request(&mut plant, &mut client, |response_sender| {
+            OrderPlantCommand::PlaceAdvancedBracketOrder {
+                bracket_order: Box::new(advanced_bracket_order("CBOT", Some("cbot-route"))),
+                account: test_account(),
+                response_sender,
+            }
+        })
+        .await;
+
+    assert_eq!(advanced.trade_route.as_deref(), Some("cbot-route"));
+
+    let oco: crate::rti::RequestOcoOrder =
+        sent_request(&mut plant, &mut client, |response_sender| {
+            OrderPlantCommand::PlaceOcoOrderMulti {
+                legs: vec![leg_on("CME", Some("leg-route")), leg_on("CME", None)],
+                account: test_account(),
+                response_sender,
+            }
+        })
+        .await;
+
+    assert_eq!(oco.trade_route, vec!["leg-route", "globex"]);
+}
+
+/// An order with no route must be refused here rather than sent for the server to
+/// reject, and an OCO must fail whole: a partial group is not the order asked for.
+#[tokio::test]
+async fn an_unroutable_order_is_refused_before_the_wire() {
+    let commands: Vec<Box<dyn FnOnce(Responder) -> OrderPlantCommand>> = vec![
+        Box::new(|response_sender| OrderPlantCommand::PlaceOrder {
+            order: RithmicOrder {
+                exchange: "CBOT".to_string(),
+                ..RithmicOrder::default()
+            },
+            account: test_account(),
+            response_sender,
+        }),
+        Box::new(|response_sender| OrderPlantCommand::PlaceBracketOrder {
+            bracket_order: bracket_order(),
+            account: test_account(),
+            response_sender,
+        }),
+        Box::new(
+            |response_sender| OrderPlantCommand::PlaceAdvancedBracketOrder {
+                bracket_order: Box::new(advanced_bracket_order("CBOT", None)),
+                account: test_account(),
+                response_sender,
+            },
+        ),
+        // Second leg only: the first resolves, so the whole group must still fail.
+        Box::new(|response_sender| OrderPlantCommand::PlaceOcoOrderMulti {
+            legs: vec![leg_on("CME", Some("leg-route")), leg_on("CBOT", None)],
+            account: test_account(),
+            response_sender,
+        }),
+    ];
+
+    for build in commands {
+        let (mut plant, _sender, mut client) = plant_with_wire().await;
+
+        let (response_sender, rx) = oneshot::channel();
+        plant.handle_command(build(response_sender)).await;
+
+        assert!(matches!(
+            awaited_caller_outcome(rx).await,
+            Err(RithmicError::NoTradeRoute { .. })
+        ));
+        assert_wire_silent(&mut client).await;
+    }
+}
+
+/// The preflight check answers from the cache and sends nothing, so it is safe to
+/// call before trading opens.
+#[tokio::test]
+async fn trade_route_for_reports_the_route_an_order_would_take() {
+    let (mut plant, _sender, mut client) = plant_with_wire().await;
+
+    cache_route(&mut plant, "CME", "globex");
+
+    let (response_sender, rx) = oneshot::channel();
+
+    plant
+        .handle_command(OrderPlantCommand::TradeRouteFor {
+            exchange: "CME".to_string(),
+            response_sender,
+        })
+        .await;
+
+    assert_eq!(
+        rx.await
+            .expect("the caller must be answered")
+            .expect("CME is cached"),
+        "globex"
+    );
+    assert_wire_silent(&mut client).await;
+}
+
+/// The server moves a route mid-session and a subscriber hands it back, so the
+/// orders that follow have to take the new one. Applying it sends nothing.
+#[tokio::test]
+async fn a_route_update_handed_back_moves_where_orders_go() {
+    let (mut plant, _sender, mut client) = plant_with_wire().await;
+
+    cache_route(&mut plant, "CME", "globex");
+
+    plant
+        .handle_command(OrderPlantCommand::RecordTradeRouteUpdate(Box::new(
+            crate::rti::TradeRoute {
+                template_id: 350,
+                exchange: Some("CME".to_string()),
+                trade_route: Some("globex-2".to_string()),
+                is_default: Some(true),
+                ..Default::default()
+            },
+        )))
+        .await;
+
+    let (response_sender, rx) = oneshot::channel();
+
+    plant
+        .handle_command(OrderPlantCommand::TradeRouteFor {
+            exchange: "CME".to_string(),
+            response_sender,
+        })
+        .await;
+
+    assert_eq!(
+        rx.await
+            .expect("the caller must be answered")
+            .expect("CME is cached"),
+        "globex-2"
+    );
+    assert_wire_silent(&mut client).await;
+}
+
+/// An exchange with no route fails the preflight the same way placing the order
+/// would, so a caller can gate on it.
+#[tokio::test]
+async fn trade_route_for_fails_where_an_order_would() {
+    let (mut plant, _sender, _client) = plant_with_wire().await;
+
+    cache_route(&mut plant, "CME", "globex");
+
+    let (response_sender, rx) = oneshot::channel();
+
+    plant
+        .handle_command(OrderPlantCommand::TradeRouteFor {
+            exchange: "CBOT".to_string(),
+            response_sender,
+        })
+        .await;
+
+    assert!(matches!(
+        rx.await.expect("the caller must be answered"),
+        Err(RithmicError::NoTradeRoute { .. })
+    ));
+}
+
+/// The command login queues once it has read the routes off the wire. Applying
+/// it is what fills the cache orders resolve against.
+#[tokio::test]
+async fn record_trade_routes_populates_the_cache() {
+    let (mut plant, _sender, _client) = plant_with_wire().await;
+
+    plant
+        .handle_command(OrderPlantCommand::RecordTradeRoutes(vec![
+            trade_route_response("CME", "globex"),
+        ]))
+        .await;
+
+    assert_eq!(plant.trade_routes.resolve(None, "CME").unwrap(), "globex");
+}
+
+/// A rejected route request must not fail the login, and must not leave orders
+/// a route to send on.
+#[tokio::test]
+async fn login_does_not_cache_a_rejected_trade_route() {
+    let (handle, mut command_receiver) = test_handle();
+
+    let driver = async {
+        drive_login_to_login_info(&mut command_receiver).await;
+        answer_login_info(&mut command_receiver, Ok(vec![login_info_response(None)])).await;
+
+        answer_trade_routes(
+            &mut command_receiver,
+            Ok(vec![RithmicResponse {
+                error: Some(RithmicError::ProtocolError("denied".to_string())),
+                ..trade_route_response("CME", "globex")
+            }]),
+        )
+        .await;
+
+        match next_command(&mut command_receiver).await {
+            OrderPlantCommand::RecordTradeRoutes(responses) => responses,
+            _ => panic!("login must hand the routes it read to the plant"),
+        }
+    };
+
+    let (login, recorded) = tokio::join!(handle.login(), driver);
+
+    assert!(
+        login.is_ok(),
+        "a rejected trade route must not fail the login"
+    );
+
+    let (mut plant, _sender, _client) = plant_with_wire().await;
+    plant
+        .handle_command(OrderPlantCommand::RecordTradeRoutes(recorded))
+        .await;
+
+    assert!(matches!(
+        plant.trade_routes.resolve(None, "CME"),
+        Err(RithmicError::NoTradeRoute { .. })
+    ));
+}
+
+/// Querying the server's routes is a read: it must not change what an order
+/// placed right now would route on.
+#[tokio::test]
+async fn get_trade_routes_does_not_touch_the_cache() {
+    let (mut plant, _sender, _client) = plant_with_wire().await;
+    cache_route(&mut plant, "CME", "globex");
+
+    let (response_sender, _rx) = oneshot::channel();
+
+    plant
+        .handle_command(OrderPlantCommand::GetTradeRoutes {
+            subscribe_for_updates: true,
+            response_sender,
+        })
+        .await;
+
+    assert_eq!(plant.trade_routes.resolve(None, "CME").unwrap(), "globex");
+}
+
+/// The handle-level wrapper: it has to ask the actor and hand back whatever
+/// the actor answers, not just queue the command.
+#[tokio::test]
+async fn trade_route_for_asks_the_actor_and_returns_its_answer() {
+    let (handle, mut command_receiver) = test_handle();
+
+    let call = tokio::spawn(async move { handle.trade_route_for("CME").await });
+
+    match command_receiver.recv().await {
+        Some(OrderPlantCommand::TradeRouteFor {
+            exchange,
+            response_sender,
+        }) => {
+            assert_eq!(exchange, "CME");
+            let _ = response_sender.send(Ok("globex".to_string()));
+        }
+        _ => panic!("expected TradeRouteFor to be queued"),
+    }
+
+    assert_eq!(call.await.expect("call task panicked").unwrap(), "globex");
+}
+
+#[tokio::test]
+async fn trade_route_for_reports_connection_closed_when_the_plant_is_gone() {
+    let (handle, command_receiver) = test_handle();
+    drop(command_receiver);
+
+    let err = handle
+        .trade_route_for("CME")
+        .await
+        .expect_err("the plant is gone");
+
+    assert!(matches!(err, RithmicError::ConnectionClosed));
+}
+
+/// The handle-level wrapper: it has to hand the update to the actor rather
+/// than applying it itself.
+#[tokio::test]
+async fn record_trade_route_forwards_the_update_to_the_actor() {
+    let (handle, mut command_receiver) = test_handle();
+
+    let update = crate::rti::TradeRoute {
+        template_id: 350,
+        exchange: Some("CME".to_string()),
+        trade_route: Some("moved".to_string()),
+        is_default: Some(true),
+        ..Default::default()
+    };
+
+    let call = tokio::spawn({
+        let update = update.clone();
+        async move { handle.record_trade_route(&update).await }
+    });
+
+    match command_receiver.recv().await {
+        Some(OrderPlantCommand::RecordTradeRouteUpdate(recorded)) => {
+            assert_eq!(recorded.exchange.as_deref(), Some("CME"));
+            assert_eq!(recorded.trade_route.as_deref(), Some("moved"));
+        }
+        _ => panic!("expected RecordTradeRouteUpdate to be queued"),
+    }
+
+    call.await.expect("call task panicked").unwrap();
+}
+
+#[tokio::test]
+async fn record_trade_route_reports_connection_closed_when_the_plant_is_gone() {
+    let (handle, command_receiver) = test_handle();
+    drop(command_receiver);
+
+    let err = handle
+        .record_trade_route(&crate::rti::TradeRoute::default())
+        .await
+        .expect_err("the plant is gone");
+
+    assert!(matches!(err, RithmicError::ConnectionClosed));
 }

--- a/src/plants/test_support.rs
+++ b/src/plants/test_support.rs
@@ -171,7 +171,7 @@ pub(crate) async fn assert_wire_silent(client: &mut TcpStream) {
 
     assert!(
         read.is_err(),
-        "a command was serialized to the wire after close was requested: {:?}",
+        "a command reached the wire that should have been refused locally: {:?}",
         read.map(|r| r.map(|n| &buf[..n]))
     );
 }

--- a/src/plants/trade_routes.rs
+++ b/src/plants/trade_routes.rs
@@ -1,0 +1,436 @@
+use std::collections::HashMap;
+
+use tracing::{debug, info, warn};
+
+use crate::{
+    api::{receiver_api::RithmicResponse, rithmic_command_types::RithmicOcoOrderLeg},
+    error::RithmicError,
+    rti::{TradeRoute, messages::RithmicMessage},
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CachedTradeRoute {
+    pub(crate) trade_route: String,
+    pub(crate) is_default: Option<bool>,
+}
+
+/// The routes published on this connection, keyed by exchange.
+///
+/// `RequestTradeRoutes` (310) carries no account, so every route here belongs to
+/// the connection's login and the exchange alone identifies one.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct TradeRouteCache {
+    routes: HashMap<String, CachedTradeRoute>,
+}
+
+impl TradeRouteCache {
+    /// Take the route a `ResponseTradeRoutes` frame carries, returning whether
+    /// it cached anything.
+    ///
+    /// Rejected frames are skipped, since they describe no route we could send
+    /// an order on. Every other template is ignored.
+    pub(crate) fn record_response(&mut self, response: &RithmicResponse) -> bool {
+        if response.error.is_some() {
+            return false;
+        }
+
+        let RithmicMessage::ResponseTradeRoutes(route) = &response.message else {
+            return false;
+        };
+
+        self.record(
+            route.exchange.as_deref(),
+            route.trade_route.as_deref(),
+            route.is_default,
+        )
+    }
+
+    /// Apply a `TradeRoute` (350) update, replacing any route held for its exchange.
+    pub(crate) fn record_update(&mut self, update: &TradeRoute) {
+        let (Some(exchange), Some(trade_route)) =
+            (update.exchange.as_deref(), update.trade_route.as_deref())
+        else {
+            return;
+        };
+
+        let held = self.routes.insert(
+            exchange.to_string(),
+            CachedTradeRoute {
+                trade_route: trade_route.to_string(),
+                is_default: update.is_default,
+            },
+        );
+
+        if held.is_none_or(|held| held.trade_route != trade_route) {
+            info!("order_plant: trade route {exchange} -> {trade_route:?}");
+        }
+    }
+
+    /// Store one route from login, returning whether it changed anything.
+    ///
+    /// Login sends a frame per route and two can name the same exchange, so the
+    /// one the server marked default wins. Frames missing an exchange or a route
+    /// are dropped.
+    pub(crate) fn record(
+        &mut self,
+        exchange: Option<&str>,
+        trade_route: Option<&str>,
+        is_default: Option<bool>,
+    ) -> bool {
+        let (Some(exchange), Some(trade_route)) = (exchange, trade_route) else {
+            return false;
+        };
+
+        let entry = CachedTradeRoute {
+            trade_route: trade_route.to_string(),
+            is_default,
+        };
+
+        let changed = match self.routes.get_mut(exchange) {
+            // The route we already hold, so take whatever detail came with it.
+            Some(held) if held.trade_route == entry.trade_route => {
+                if *held == entry {
+                    false
+                } else {
+                    *held = entry;
+                    true
+                }
+            }
+            Some(held) if held.is_default != Some(true) && entry.is_default == Some(true) => {
+                *held = entry;
+                true
+            }
+            Some(_) => false,
+            None => {
+                self.routes.insert(exchange.to_string(), entry);
+                true
+            }
+        };
+
+        if changed {
+            info!("order_plant: trade route {exchange} -> {trade_route:?}");
+        }
+
+        changed
+    }
+
+    /// The route an order for `exchange` is sent on.
+    ///
+    /// `override_route` is taken as given, so an order can name a route the
+    /// server never published. Otherwise this is the route recorded for the
+    /// exchange. With neither, the caller gets
+    /// [`RithmicError::NoTradeRoute`] and must not send the order.
+    pub(crate) fn resolve(
+        &self,
+        override_route: Option<&str>,
+        exchange: &str,
+    ) -> Result<String, RithmicError> {
+        if let Some(route) = override_route {
+            debug!("order_plant: {exchange} order on caller-supplied route {route:?}");
+
+            return Ok(route.to_string());
+        }
+
+        if let Some(route) = self.routes.get(exchange) {
+            debug!(
+                "order_plant: {exchange} order on route {:?}",
+                route.trade_route,
+            );
+
+            return Ok(route.trade_route.clone());
+        }
+
+        let cached = self.exchanges();
+
+        warn!("order_plant: no trade route for {exchange}; routed exchanges: {cached:?}");
+
+        Err(RithmicError::NoTradeRoute {
+            exchange: exchange.to_string(),
+            cached,
+        })
+    }
+
+    /// Pair every OCO leg with its own route, so a group spanning exchanges
+    /// works. If any leg has no route the whole group fails and nothing is sent.
+    pub(crate) fn resolve_legs(
+        &self,
+        legs: Vec<RithmicOcoOrderLeg>,
+    ) -> Result<Vec<(RithmicOcoOrderLeg, String)>, RithmicError> {
+        legs.into_iter()
+            .map(|leg| {
+                let route = self.resolve(leg.trade_route.as_deref(), &leg.exchange)?;
+
+                Ok((leg, route))
+            })
+            .collect()
+    }
+
+    /// The exchanges that hold a route, sorted so errors and log lines read the
+    /// same every run.
+    fn exchanges(&self) -> Vec<String> {
+        let mut exchanges: Vec<String> = self.routes.keys().cloned().collect();
+
+        exchanges.sort();
+        exchanges
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cache_with(exchange: &str, trade_route: &str) -> TradeRouteCache {
+        let mut cache = TradeRouteCache::default();
+
+        cache.record(Some(exchange), Some(trade_route), None);
+        cache
+    }
+
+    /// A `TradeRoute` (350) update naming a route the server moved to.
+    fn trade_route_update(exchange: &str, trade_route: &str) -> TradeRoute {
+        TradeRoute {
+            template_id: 350,
+            exchange: Some(exchange.to_string()),
+            trade_route: Some(trade_route.to_string()),
+            is_default: Some(true),
+            ..Default::default()
+        }
+    }
+
+    /// The route for an exchange, or `None` where an order would be refused.
+    fn routed(cache: &TradeRouteCache, exchange: &str) -> Option<String> {
+        cache.resolve(None, exchange).ok()
+    }
+
+    fn oco_leg(exchange: &str, trade_route: Option<&str>) -> RithmicOcoOrderLeg {
+        RithmicOcoOrderLeg {
+            symbol: "ESM6".to_string(),
+            exchange: exchange.to_string(),
+            quantity: 1,
+            price: 5000.0,
+            trigger_price: None,
+            transaction_type: crate::rti::request_oco_order::TransactionType::Buy,
+            duration: crate::rti::request_oco_order::Duration::Day,
+            price_type: crate::rti::request_oco_order::PriceType::Limit,
+            user_tag: "leg".to_string(),
+            trailing_stop: None,
+            trade_route: trade_route.map(str::to_string),
+        }
+    }
+
+    fn response(message: RithmicMessage, error: Option<RithmicError>) -> RithmicResponse {
+        RithmicResponse {
+            request_id: "1".to_string(),
+            message,
+            is_update: false,
+            has_more: false,
+            multi_response: false,
+            error,
+            source: "order_plant".to_string(),
+        }
+    }
+
+    #[test]
+    fn record_response_takes_the_route_off_a_311_frame() {
+        let mut cache = TradeRouteCache::default();
+
+        cache.record_response(&response(
+            RithmicMessage::ResponseTradeRoutes(crate::rti::ResponseTradeRoutes {
+                template_id: 311,
+                exchange: Some("CBOT".to_string()),
+                trade_route: Some("cbot-route".to_string()),
+                ..Default::default()
+            }),
+            None,
+        ));
+
+        assert_eq!(routed(&cache, "CBOT").as_deref(), Some("cbot-route"));
+    }
+
+    /// 350 reaches subscribers, and the login path never takes one: an update
+    /// moves a route only where a caller asked for it, through `record_update`.
+    #[test]
+    fn record_response_ignores_a_350_update() {
+        let mut cache = cache_with("CME", "globex");
+
+        cache.record_response(&response(
+            RithmicMessage::TradeRoute(trade_route_update("CME", "moved")),
+            None,
+        ));
+
+        assert_eq!(routed(&cache, "CME").as_deref(), Some("globex"));
+    }
+
+    /// What a caller handing back an update buys them: the orders that follow
+    /// take the route the server moved to.
+    #[test]
+    fn record_update_takes_the_route_off_a_350_frame() {
+        let mut cache = cache_with("CME", "globex");
+
+        cache.record_update(&trade_route_update("CME", "moved"));
+
+        assert_eq!(routed(&cache, "CME").as_deref(), Some("moved"));
+    }
+
+    /// A rejection describes no route, so taking one from it would be worse
+    /// than having no route at all.
+    #[test]
+    fn record_response_skips_a_rejected_frame() {
+        let mut cache = TradeRouteCache::default();
+
+        cache.record_response(&response(
+            RithmicMessage::ResponseTradeRoutes(crate::rti::ResponseTradeRoutes {
+                template_id: 311,
+                exchange: Some("CBOT".to_string()),
+                trade_route: Some("cbot-route".to_string()),
+                ..Default::default()
+            }),
+            Some(RithmicError::ProtocolError("denied".to_string())),
+        ));
+
+        assert_eq!(routed(&cache, "CBOT"), None);
+        assert!(cache.exchanges().is_empty());
+    }
+
+    #[test]
+    fn resolve_returns_the_route_recorded_for_the_exchange() {
+        let cache = cache_with("CME", "globex");
+
+        assert_eq!(routed(&cache, "CME").as_deref(), Some("globex"));
+        assert_eq!(routed(&cache, "CBOT"), None);
+    }
+
+    #[test]
+    fn resolve_prefers_the_per_order_override() {
+        let cache = cache_with("CME", "globex");
+
+        assert_eq!(cache.resolve(Some("my-route"), "CME").unwrap(), "my-route");
+    }
+
+    #[test]
+    fn resolve_errors_with_the_exchanges_that_do_have_a_route() {
+        // Recorded NYMEX first, so the reported order is the sorted one rather
+        // than the order the routes arrived in.
+        let mut cache = cache_with("NYMEX", "nymex-route");
+
+        cache.record(Some("CME"), Some("globex"), None);
+
+        let err = cache
+            .resolve(None, "CBOT")
+            .expect_err("an uncached exchange must not resolve");
+
+        assert_eq!(
+            err,
+            RithmicError::NoTradeRoute {
+                exchange: "CBOT".to_string(),
+                cached: vec!["CME".to_string(), "NYMEX".to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_legs_routes_each_leg_by_its_own_exchange() {
+        let mut cache = cache_with("CME", "globex");
+
+        cache.record(Some("NYMEX"), Some("nymex-route"), None);
+
+        let routed = cache
+            .resolve_legs(vec![
+                oco_leg("CME", None),
+                oco_leg("NYMEX", None),
+                oco_leg("CME", Some("my-route")),
+            ])
+            .unwrap();
+
+        let routes: Vec<&str> = routed.iter().map(|(_, route)| route.as_str()).collect();
+
+        assert_eq!(routes, vec!["globex", "nymex-route", "my-route"]);
+    }
+
+    #[test]
+    fn resolve_legs_fails_the_group_on_an_unroutable_leg() {
+        let cache = cache_with("CME", "globex");
+
+        let err = cache
+            .resolve_legs(vec![oco_leg("CME", None), oco_leg("CBOT", None)])
+            .expect_err("one unroutable leg must fail the whole group");
+
+        assert_eq!(
+            err,
+            RithmicError::NoTradeRoute {
+                exchange: "CBOT".to_string(),
+                cached: vec!["CME".to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn a_default_route_displaces_one_the_server_never_marked_default() {
+        let mut cache = cache_with("CME", "first-seen");
+
+        assert!(cache.record(Some("CME"), Some("the-default"), Some(true)));
+        assert_eq!(routed(&cache, "CME").as_deref(), Some("the-default"));
+    }
+
+    #[test]
+    fn a_non_default_route_does_not_displace_the_default() {
+        let mut cache = TradeRouteCache::default();
+
+        cache.record(Some("CME"), Some("the-default"), Some(true));
+
+        assert!(!cache.record(Some("CME"), Some("another"), None));
+        assert_eq!(routed(&cache, "CME").as_deref(), Some("the-default"));
+    }
+
+    /// A caller handing back a 350 asked for that route, so it lands even where
+    /// a login frame marked the route it displaces default.
+    #[test]
+    fn record_update_replaces_a_route_marked_default() {
+        let mut cache = TradeRouteCache::default();
+
+        cache.record(Some("CME"), Some("the-default"), Some(true));
+
+        cache.record_update(&TradeRoute {
+            template_id: 350,
+            exchange: Some("CME".to_string()),
+            trade_route: Some("moved".to_string()),
+            is_default: None,
+            ..Default::default()
+        });
+
+        assert_eq!(routed(&cache, "CME").as_deref(), Some("moved"));
+    }
+
+    #[test]
+    fn the_first_route_wins_when_the_server_marks_no_default() {
+        let mut cache = cache_with("CME", "first-seen");
+
+        assert!(!cache.record(Some("CME"), Some("second-seen"), None));
+        assert_eq!(routed(&cache, "CME").as_deref(), Some("first-seen"));
+    }
+
+    #[test]
+    fn a_later_frame_updates_the_route_it_names() {
+        let mut cache = cache_with("CME", "globex");
+
+        assert!(
+            cache.record(Some("CME"), Some("globex"), Some(true)),
+            "new detail for the route we hold is a change"
+        );
+        assert!(
+            !cache.record(Some("CME"), Some("globex"), Some(true)),
+            "the same frame again is not, so it must not be logged again"
+        );
+        assert_eq!(routed(&cache, "CME").as_deref(), Some("globex"));
+    }
+
+    #[test]
+    fn frames_describing_no_route_are_dropped() {
+        let mut cache = TradeRouteCache::default();
+
+        assert!(!cache.record(None, Some("globex"), None));
+        assert!(!cache.record(Some("CME"), None, None));
+        assert_eq!(routed(&cache, "CME"), None);
+        assert!(cache.exchanges().is_empty());
+    }
+}


### PR DESCRIPTION
## Issue

Every order request carried a trade route picked from the environment — `"globex"` on live, `"simulator"` on demand and test — regardless of the order's exchange. `globex` is CME's route, so a live order on CBOT, NYMEX or COMEX went out on a route that does not exist for that venue and was rejected. There was no way to say otherwise: `trade_route` was not on any order type, and the two constants were private.

## Solution

The order plant caches the routes the server publishes on the connection — `ResponseTradeRoutes` (311) and unsolicited `TradeRoute` (350) — keyed by `(fcm_id, ib_id, exchange)`, and selects one per order from the order's own exchange. A route the server flags `MNM_DEFAULT_ROUTE` wins; otherwise the first published for that key. `login()` primes the cache and subscribes to updates, non-fatally — a failed route request is logged and the login still succeeds.

`trade_route: Option<String>` on `RithmicOrder`, `RithmicAdvancedBracketOrder` and `RithmicOcoOrderLeg` overrides the cache per order, and works with nothing cached, which is how a route the server never lists stays reachable. OCO legs resolve individually, so a group spanning exchanges gets a route each.

`RequestTradeRoutes` sends no fcm or ib id, so the server alone decides which it echoes back and those become the cache key. When a lookup misses because they differ from the account's, the route published for that exchange under other ids is used instead, provided every key publishing the exchange agrees on one route — that widens which ids match, never which venue an order can reach.

With no route at all and no override, the order is refused locally with the new `RithmicError::NoTradeRoute { fcm_id, ib_id, exchange, cached }` and nothing reaches the wire — an order is never guessed onto a route. `cached` lists the triples that do have a route, so a lookup missing because the server echoed different ids than the account's is diagnosable from the error alone.

Two limits are documented on `get_trade_routes`: a route's `status` (`MNM_SERVICE_STATE`) is recorded but never excludes it, because the schema defines no value space for it; and a cached route is never withdrawn, so one the server later retires stays selectable for the life of the connection.

**Breaking:** the three order types gain a `trade_route` field (add `trade_route: None` to existing literals), and `RithmicSenderApi`'s order builders take an explicit route instead of reading the environment.
