### PR TITLE
fix(plants)!: await the abort send; correct the heartbeat routing comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Public struct fields and a method signature change, so this lands in a major rel
 - **`RithmicOrderPlantHandle::subscribe_account_rms_updates` gains a required `update_bits` parameter.**
   Pass `vec![]` for the prior behavior, or `vec![RmsUpdateBits::AutoLiqThresholdCurrentValue]` to
   stream auto-liq threshold updates.
+- **`abort()` on every plant handle is now `async`.** Add `.await` at the call site. It was a
+  non-blocking send that gave up when the command channel was full, silently discarding the abort
+  in exactly the situation it exists for; it now waits for room.
 
 ### Added
 
@@ -74,6 +77,18 @@ Public struct fields and a method signature change, so this lands in a major rel
   stays bounded by the requested channel capacity rounded up to a power of two; an over-capacity
   backlog surfaces as `RecvError::Lagged` on the first receive, as it does for any lagging
   subscriber.
+- **`abort()` was dropped under command-channel backpressure.** It used a non-blocking send, so a
+  full channel — the wedged actor that `abort()` exists to kill — discarded it and left the actor
+  running with pending requests unresolved. It now waits for room; every await inside the actor
+  loop is bounded by the WebSocket send timeout, and a channel closed by an already-exited actor
+  returns immediately.
+- **A comment on the heartbeat decode arm claimed heartbeats route to the subscription channel.**
+  `PlantCore::forward_response` matches `ResponseHeartbeat` and returns before it reads
+  `is_update`, so they never do; only the synthetic `HeartbeatTimeout` built on the error path is
+  broadcast. A healthy heartbeat reaches a responder registered under its request id, and this
+  crate registers none — `send_heartbeat` discards the id it sends with — so it is dropped. The
+  `is_update` value is left as it is, since nothing reads it, and now says so. (The claim dates
+  from the `return_heartbeat_response()` API described under `[0.5.2]` below, removed in `[1.0.0]`.)
 
 ## [2.0.0]
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ match handle.subscribe("ESM6", "CME").await {
         None => { /* success */ }
     },
     Err(RithmicError::ConnectionClosed | RithmicError::SendFailed) => {
-        handle.abort();
+        handle.abort().await;
         // reconnect — see examples/reconnect.rs
     }
     Err(e) => eprintln!("{}", e),

--- a/examples/reconnect.rs
+++ b/examples/reconnect.rs
@@ -199,7 +199,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// leave an orphaned task holding a TCP/WebSocket session while the next
 /// reconnect attempt opens a new one.
 async fn shutdown_plant(handle: &rithmic_rs::RithmicTickerPlantHandle, plant: RithmicTickerPlant) {
-    handle.abort();
+    handle.abort().await;
 
     let _ = plant.await_shutdown().await;
 }

--- a/src/api/receiver_api.rs
+++ b/src/api/receiver_api.rs
@@ -158,7 +158,15 @@ impl RithmicReceiverApi {
                 RithmicResponse {
                     request_id: resp.user_msg.first().cloned().unwrap_or_default(),
                     message: RithmicMessage::ResponseHeartbeat(resp),
-                    is_update: true, // Heartbeats are connection health events - route to subscription channel
+                    // A connection health event rather than a reply the caller
+                    // asked for. `PlantCore::forward_response` matches
+                    // `ResponseHeartbeat` and returns before it reads this flag,
+                    // so the flag picks no channel here. The frame goes only to
+                    // a responder registered under its request id, and this
+                    // crate registers none: `send_heartbeat` discards the id it
+                    // sends with, so the handler's heartbeat arm finds no entry
+                    // and drops the frame.
+                    is_update: true,
                     has_more: false,
                     multi_response: false,
                     error,

--- a/src/error.rs
+++ b/src/error.rs
@@ -79,7 +79,7 @@ impl std::error::Error for RithmicRequestError {}
 ///         None => { /* success */ }
 ///     },
 ///     Err(RithmicError::ConnectionClosed | RithmicError::SendFailed) => {
-///         handle.abort();
+///         handle.abort().await;
 ///         // reconnect — see examples/reconnect.rs
 ///     }
 ///     Err(e) => eprintln!("{e}"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@
 //!         None => { /* success */ }
 //!     },
 //!     Err(RithmicError::ConnectionClosed | RithmicError::SendFailed) => {
-//!         handle.abort();
+//!         handle.abort().await;
 //!         // reconnect — see examples/reconnect.rs
 //!     }
 //!     Err(e) => eprintln!("{e}"),

--- a/src/plants/core.rs
+++ b/src/plants/core.rs
@@ -1298,6 +1298,9 @@ mod tests {
             RithmicMessage::ResponseHeartbeat(_)
         ));
         assert!(result[0].error.is_none());
+        // The decoder sets this, and the frame still reaches the responder
+        // rather than the channel the flag otherwise selects.
+        assert!(result[0].is_update);
     }
 
     /// Heartbeat with a populated `error` (e.g. rp_code rejection) must BOTH

--- a/src/plants/history_plant.rs
+++ b/src/plants/history_plant.rs
@@ -689,13 +689,29 @@ impl RithmicHistoryPlantHandle {
         Ok(response)
     }
 
-    /// Immediately shut down the history plant actor without a graceful logout.
+    /// Shut down the history plant actor without a graceful logout.
     ///
     /// Use when the connection is known to be dead and `disconnect()` would hang.
     /// All pending request callers will receive an error. The subscription channel
     /// receives a `ConnectionError` notification. Safe to call if the actor is already dead.
-    pub fn abort(&self) {
-        let _ = self.sender.try_send(HistoryPlantCommand::Abort);
+    ///
+    /// # How long this takes
+    ///
+    /// The abort is queued on the command channel and the actor takes commands
+    /// in order, so it waits behind everything already queued — up to 32
+    /// commands, each of which can hold the actor for the WebSocket send
+    /// timeout. It does not jump the queue. On a dead link the call is usually
+    /// released by the actor stopping itself once a ping goes unanswered, which
+    /// drops the receiver, rather than by the queue draining.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is **not** cancel safe. Nothing is queued if the returned
+    /// future is dropped before it completes, so an abort raced in `select!` or
+    /// wrapped in `timeout` is silently not delivered when the other branch
+    /// wins. Poll it to completion.
+    pub async fn abort(&self) {
+        let _ = self.sender.send(HistoryPlantCommand::Abort).await;
     }
 
     /// Load historical tick data for a specific symbol and time range.
@@ -1076,5 +1092,50 @@ mod tests {
             "late"
         );
         assert!(second.subscription_receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn abort_queues_behind_a_full_command_channel() {
+        let (sender, mut command_receiver) = mpsc::channel(4);
+        let (sub_tx, sub_rx) = broadcast::channel(4);
+
+        let handle = RithmicHistoryPlantHandle {
+            sender,
+            subscription_sender: sub_tx,
+            subscription_receiver: sub_rx,
+        };
+
+        // Fill the command channel so there is no room for another command.
+        while handle
+            .sender
+            .try_send(HistoryPlantCommand::SetLogin)
+            .is_ok()
+        {}
+
+        let abort = handle.abort();
+        tokio::pin!(abort);
+
+        // Polled to completion here only if the abort gave up on the full
+        // channel; still pending means it is holding out for a slot.
+        assert!(
+            futures_util::poll!(abort.as_mut()).is_pending(),
+            "abort must wait for room rather than give up on a full channel"
+        );
+
+        // Free one slot; the abort claims it.
+        assert!(matches!(
+            command_receiver.recv().await,
+            Some(HistoryPlantCommand::SetLogin)
+        ));
+        assert!(futures_util::poll!(abort.as_mut()).is_ready());
+
+        let mut saw_abort = false;
+        while let Ok(command) = command_receiver.try_recv() {
+            if matches!(command, HistoryPlantCommand::Abort) {
+                saw_abort = true;
+            }
+        }
+
+        assert!(saw_abort, "abort must be queued once room appears");
     }
 }

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -1324,13 +1324,29 @@ impl RithmicOrderPlantHandle {
         r.into_iter().next().ok_or(RithmicError::EmptyResponse)
     }
 
-    /// Immediately shut down the order plant actor without a graceful logout.
+    /// Shut down the order plant actor without a graceful logout.
     ///
     /// Use when the connection is known to be dead and `disconnect()` would hang.
     /// All pending request callers will receive an error. The subscription channel
     /// receives a `ConnectionError` notification. Safe to call if the actor is already dead.
-    pub fn abort(&self) {
-        let _ = self.sender.try_send(OrderPlantCommand::Abort);
+    ///
+    /// # How long this takes
+    ///
+    /// The abort is queued on the command channel and the actor takes commands
+    /// in order, so it waits behind everything already queued — up to 64
+    /// commands, each of which can hold the actor for the WebSocket send
+    /// timeout. It does not jump the queue. On a dead link the call is usually
+    /// released by the actor stopping itself once a ping goes unanswered, which
+    /// drops the receiver, rather than by the queue draining.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is **not** cancel safe. Nothing is queued if the returned
+    /// future is dropped before it completes, so an abort raced in `select!` or
+    /// wrapped in `timeout` is silently not delivered when the other branch
+    /// wins. Poll it to completion.
+    pub async fn abort(&self) {
+        let _ = self.sender.send(OrderPlantCommand::Abort).await;
     }
 
     /// Get a list of available trading accounts
@@ -2433,5 +2449,39 @@ mod tests {
                 .request_id,
             "late"
         );
+    }
+
+    #[tokio::test]
+    async fn abort_queues_behind_a_full_command_channel() {
+        let (handle, mut command_receiver) = test_handle();
+
+        // Fill the command channel so there is no room for another command.
+        while handle.sender.try_send(OrderPlantCommand::SetLogin).is_ok() {}
+
+        let abort = handle.abort();
+        tokio::pin!(abort);
+
+        // Polled to completion here only if the abort gave up on the full
+        // channel; still pending means it is holding out for a slot.
+        assert!(
+            futures_util::poll!(abort.as_mut()).is_pending(),
+            "abort must wait for room rather than give up on a full channel"
+        );
+
+        // Free one slot; the abort claims it.
+        assert!(matches!(
+            command_receiver.recv().await,
+            Some(OrderPlantCommand::SetLogin)
+        ));
+        assert!(futures_util::poll!(abort.as_mut()).is_ready());
+
+        let mut saw_abort = false;
+        while let Ok(command) = command_receiver.try_recv() {
+            if matches!(command, OrderPlantCommand::Abort) {
+                saw_abort = true;
+            }
+        }
+
+        assert!(saw_abort, "abort must be queued once room appears");
     }
 }

--- a/src/plants/pnl_plant.rs
+++ b/src/plants/pnl_plant.rs
@@ -504,13 +504,29 @@ impl RithmicPnlPlantHandle {
         r.into_iter().next().ok_or(RithmicError::EmptyResponse)
     }
 
-    /// Immediately shut down the PnL plant actor without a graceful logout.
+    /// Shut down the PnL plant actor without a graceful logout.
     ///
     /// Use when the connection is known to be dead and `disconnect()` would hang.
     /// All pending request callers will receive an error. The subscription channel
     /// receives a `ConnectionError` notification. Safe to call if the actor is already dead.
-    pub fn abort(&self) {
-        let _ = self.sender.try_send(PnlPlantCommand::Abort);
+    ///
+    /// # How long this takes
+    ///
+    /// The abort is queued on the command channel and the actor takes commands
+    /// in order, so it waits behind everything already queued — up to 64
+    /// commands, each of which can hold the actor for the WebSocket send
+    /// timeout. It does not jump the queue. On a dead link the call is usually
+    /// released by the actor stopping itself once a ping goes unanswered, which
+    /// drops the receiver, rather than by the queue draining.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is **not** cancel safe. Nothing is queued if the returned
+    /// future is dropped before it completes, so an abort raced in `select!` or
+    /// wrapped in `timeout` is silently not delivered when the other branch
+    /// wins. Poll it to completion.
+    pub async fn abort(&self) {
+        let _ = self.sender.send(PnlPlantCommand::Abort).await;
     }
 
     /// Subscribe to PnL updates for all positions
@@ -645,5 +661,47 @@ mod tests {
                 .request_id,
             "late"
         );
+    }
+
+    #[tokio::test]
+    async fn abort_queues_behind_a_full_command_channel() {
+        let account = Arc::new(RithmicAccount::new("FCM_A", "IB_A", "ACCOUNT_A"));
+        let (sender, mut command_receiver) = mpsc::channel(4);
+        let (_sub_tx, sub_rx) = broadcast::channel(4);
+
+        let handle = RithmicPnlPlantHandle {
+            account: Arc::clone(&account),
+            sender,
+            subscription_receiver: SubscriptionFilter::new(account, sub_rx),
+        };
+
+        // Fill the command channel so there is no room for another command.
+        while handle.sender.try_send(PnlPlantCommand::SetLogin).is_ok() {}
+
+        let abort = handle.abort();
+        tokio::pin!(abort);
+
+        // Polled to completion here only if the abort gave up on the full
+        // channel; still pending means it is holding out for a slot.
+        assert!(
+            futures_util::poll!(abort.as_mut()).is_pending(),
+            "abort must wait for room rather than give up on a full channel"
+        );
+
+        // Free one slot; the abort claims it.
+        assert!(matches!(
+            command_receiver.recv().await,
+            Some(PnlPlantCommand::SetLogin)
+        ));
+        assert!(futures_util::poll!(abort.as_mut()).is_ready());
+
+        let mut saw_abort = false;
+        while let Ok(command) = command_receiver.try_recv() {
+            if matches!(command, PnlPlantCommand::Abort) {
+                saw_abort = true;
+            }
+        }
+
+        assert!(saw_abort, "abort must be queued once room appears");
     }
 }

--- a/src/plants/ticker_plant.rs
+++ b/src/plants/ticker_plant.rs
@@ -929,13 +929,29 @@ impl RithmicTickerPlantHandle {
         Ok(response)
     }
 
-    /// Immediately shut down the ticker plant actor without a graceful logout.
+    /// Shut down the ticker plant actor without a graceful logout.
     ///
     /// Use when the connection is known to be dead and `disconnect()` would hang.
     /// All pending request callers will receive an error. The subscription channel
     /// receives a `ConnectionError` notification. Safe to call if the actor is already dead.
-    pub fn abort(&self) {
-        let _ = self.sender.try_send(TickerPlantCommand::Abort);
+    ///
+    /// # How long this takes
+    ///
+    /// The abort is queued on the command channel and the actor takes commands
+    /// in order, so it waits behind everything already queued — up to 64
+    /// commands, each of which can hold the actor for the WebSocket send
+    /// timeout. It does not jump the queue. On a dead link the call is usually
+    /// released by the actor stopping itself once a ping goes unanswered, which
+    /// drops the receiver, rather than by the queue draining.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is **not** cancel safe. Nothing is queued if the returned
+    /// future is dropped before it completes, so an abort raced in `select!` or
+    /// wrapped in `timeout` is silently not delivered when the other branch
+    /// wins. Poll it to completion.
+    pub async fn abort(&self) {
+        let _ = self.sender.send(TickerPlantCommand::Abort).await;
     }
 
     /// Subscribe to market data for a specific symbol
@@ -2035,5 +2051,46 @@ mod tests {
             "late"
         );
         assert!(second.subscription_receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn abort_queues_behind_a_full_command_channel() {
+        let (sender, mut command_receiver) = mpsc::channel(4);
+        let (sub_tx, sub_rx) = broadcast::channel(4);
+
+        let handle = RithmicTickerPlantHandle {
+            sender,
+            subscription_sender: sub_tx,
+            subscription_receiver: sub_rx,
+        };
+
+        // Fill the command channel so there is no room for another command.
+        while handle.sender.try_send(TickerPlantCommand::SetLogin).is_ok() {}
+
+        let abort = handle.abort();
+        tokio::pin!(abort);
+
+        // Polled to completion here only if the abort gave up on the full
+        // channel; still pending means it is holding out for a slot.
+        assert!(
+            futures_util::poll!(abort.as_mut()).is_pending(),
+            "abort must wait for room rather than give up on a full channel"
+        );
+
+        // Free one slot; the abort claims it.
+        assert!(matches!(
+            command_receiver.recv().await,
+            Some(TickerPlantCommand::SetLogin)
+        ));
+        assert!(futures_util::poll!(abort.as_mut()).is_ready());
+
+        let mut saw_abort = false;
+        while let Ok(command) = command_receiver.try_recv() {
+            if matches!(command, TickerPlantCommand::Abort) {
+                saw_abort = true;
+            }
+        }
+
+        assert!(saw_abort, "abort must be queued once room appears");
     }
 }


### PR DESCRIPTION
> **Stacked PR — review and merge after #80.** Base is `claude/protocol-audit-fixes-12v4sf-13-broadcast-retention`, whose head is this branch's parent commit. GitHub retargets it to `main` automatically once #80 merges.

Audit item 13, **parts b and d**. Parts a and c are not missing: a is folded into the order-field branch, and c turned out to be already fixed by the per-request timeout work in #73.

> **Breaking change.** `abort()` on all four plant handles becomes `async`. Add `.await` at the call site.

## Part b — the abort could be silently dropped

`abort()` used a non-blocking send, so under backpressure the emergency stop was **discarded with no error** — in precisely the situation the method exists for. A wedged actor filling its command channel is the case where you most need the abort to land, and it was the case where it did not.

It now awaits delivery.

The audit named two plants. There are **four**, and ticker and history had the identical defect. All four are fixed, and all four in-repo callers were updated — README, the reconnect example, the crate-level docs, and the error docs.

## Two hazards the review surfaced

Both belong here, because a reader who sees only "abort now awaits" will draw the wrong conclusion about **both** timing and safety.

### It is not immediate

The abort queues FIFO behind whatever is already in flight — up to **64 commands**, or **32 on the history plant** — and each can hold the actor for the WebSocket send timeout. It does not jump the queue. On a wedged connection this can take considerably longer than the send timeout alone would suggest.

In practice the release usually comes not from the queue draining but from the actor self-terminating on its ping timeout, which drops the receiver. The rustdoc no longer says "immediately" and now has a dedicated section stating this plainly.

### It is not cancel safe — and this hazard is newly introduced here

The underlying send delivers nothing if its future is dropped. So an abort raced in a `select!` or wrapped in a `timeout` is **silently not delivered** — the same silent-drop failure this commit removes, arriving through a different door.

This was impossible while the method was synchronous, so the change creates the hazard rather than inheriting it. And given the latency described above, wrapping the abort in a timeout is exactly the pattern a reader would reach for — which makes it a realistic hazard, not a theoretical one. There is now a cancel-safety section stating the future must be polled to completion.

### Why it returns unit rather than a result

Deliberate: the only possible error means the actor has already exited, so the abort is moot. There is no fallback path available to a caller, so a result would be noise at every call site.

## Part d — a comment asserted routing that does not happen

A comment on the heartbeat decode arm claimed heartbeat responses reach the subscription channel. They do not. `PlantCore::forward_response` matches `ResponseHeartbeat` by message type and **returns before it reads the flag** that would select that channel.

The comment now says what actually happens: the frame reaches only a responder registered under its request id, and **this crate registers none**, because `send_heartbeat` discards the id it sends with. So the handler's heartbeat arm finds no entry and drops the frame.

The flag's value is left unchanged. Flipping it is provably inert — nothing reads it on this path — so changing it would be churn that implies a behavioural fix where there is none.

Worth recording: the false claim is traceable to a `return_heartbeat_response()` API removed two major versions ago, and the CHANGELOG entry now points at the historical section describing it, so the next reader does not have to rediscover that.

## Testing

Revert-checked on all four plants.

The tests deliberately avoid spawning, and use a single-poll check on a pinned future. That is not stylistic: an earlier version of these tests **passed against the unfixed code**, because the spawned task was not polled until the drain had already freed a slot, so the non-blocking send succeeded and the test saw nothing wrong. Caught and fixed before review.

That is the third instance in this programme of a test that appeared to guard a behaviour while passing against the reverted code — the same pattern found in #71 and #78. Worth noting the shape is now being actively checked for rather than stumbled on.

One honest note the author volunteered, which is worth keeping: the first attempt at part d added a 45-line test, then discovered the pre-existing test already pinned the routing claim. The new work reduced to a **single added assertion** on that existing test, and the duplicate was deleted. The diff bears that out — the production-side change for part d is a comment, and the test-side change is one assertion.

## Compatibility

Breaking at the source level: `abort()` gains `async` on all four handles. Migration is adding `.await`. No behavioural change beyond the abort now actually being delivered, and no signature change other than that.

This lands in the same unreleased version as the other breaking changes in this programme, so its migration note sits with theirs in `CHANGELOG.md`.

## Environment notes for reviewers

`src/raw-proto/` and `rapi/` are gitignored and absent from the working container, and `protoc` is not installed. Work was done against the checked-in prost-generated `src/rti.rs`, which the audit confirmed has zero drift from the protos.
