### PR TITLE
docs: rewrite the 3.0.0 changelog and add a migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,51 +7,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Order commands are now built with `::new()` and chained setters, and the command types are `#[non_exhaustive]`, so this ships as a major release.
+Order commands are now built with `::new()` and chained setters, the generated
+protobuf enums are replaced by crate-owned ones, and every order call takes a
+command struct. This ships as a major release.
+
+**[MIGRATING.md](MIGRATING.md) walks through the upgrade** with before/after code
+for each change below.
+
+### Changes that compile but alter live order flow
+
+These need no code change, so the compiler will not point at them. Read this list
+before the first run against a live account.
+
+- **Orders route off the exchange's published trade route** instead of a hardcoded
+  `"globex"`/`"simulator"`. With no route published and none set on the command,
+  the order is **not sent** — you get `RithmicError::NoTradeRoute`.
+- **`cancel_all_orders` is attributed `Auto`, not `Manual`.** Set
+  `.manual_or_auto(ManualOrAutoEntry::Manual)` to keep the old attribution.
+- **A target-only bracket now sends `TARGET_ONLY_STATIC`** rather than
+  `TargetAndStopStatic`, which 2.x sent whatever legs you supplied.
+- **`get_account_list` and `get_account_rms_info` may return fewer accounts,** now
+  that requests are scoped with the real login info instead of a hardcoded `Trader`
+  user type.
+- **Market orders no longer go out priced at `0.0`** — an unset price is omitted.
+- **An empty `user_tag` echoes back as `None`, not `Some("")`.**
 
 ### Breaking Changes
 
-- **The bundled protos are updated to R | Protocol API 0.89.0.0 (template version 5.42), and `RithmicMessage::AccountListUpdates` is removed.** Rithmic dropped `account_list_updates.proto` (template 354) from the proto pool; its release notes say to use the account RMS updates stream instead. Subscribe with `subscribe_account_rms_updates` and match `RithmicMessage::AccountRmsUpdates`. Rithmic also changed two enum fields on `UserAccountUpdate` to strings: `update_type` and `access_type` are now `Option<String>` (values like `add_account`, `modify_account`), and the generated `UpdateType`/`AccessType` enums no longer exist.
-- **Order command types are now their own builders and are `#[non_exhaustive]`.** `..Default::default()` no longer compiles on them outside this crate; use `new()` plus chained setters instead. There is no separate builder type: `new()` takes no arguments and returns the command with its defaults filled in, every field has a setter of the same name, and `build()` runs `validate()` and returns the command as `Result<_, RithmicError>`. The fields are still public, so direct assignment works too: `let mut order = RithmicOrder::new(); order.symbol = "ESH6".into();`.
+- **Order command types are their own builders and are `#[non_exhaustive]`.**
+  `..Default::default()` no longer compiles on them outside this crate. `new()`
+  takes no arguments, every field has a setter of the same name, and `build()`
+  runs `validate()` and returns `Result<_, RithmicError>`. The fields stay public,
+  so direct assignment still works — but the handles send what they are given, so a
+  command that skips `build()` skips validation and the derived `bracket_type`.
 
-  ```rust
-  // Before
-  let order = RithmicOrder { symbol: "ESM6".into(), quantity: 1, ..Default::default() };
-  // After
-  let order = RithmicOrder::new()
-      .symbol("ESM6")
-      .exchange("CME")
-      .quantity(1)
-      .transaction_type(OrderSide::Buy)
-      .price_type(OrderType::Limit)
-      .price(5000.0)
-      .build()?;
-  ```
+- **`RithmicConfig`, `RithmicAccount`, `LoginConfig`, `InstrumentInfo`,
+  `InstrumentInfoError`, `RithmicEnv`, `TrailingStop`, `RithmicIfTouchedTrigger`
+  and all 246 generated protobuf types are `#[non_exhaustive]`.** Rithmic added
+  fields to existing messages in 24 of its 35 template releases, so without this
+  every proto refresh would be a major bump here. Struct literals stop compiling
+  downstream, and matches on generated enums need a `_` arm.
 
-- **`RithmicAdvancedBracketOrder` is removed; `RithmicBracketOrder` now does everything it did.** One bracket type carries every venue-native field — trailing stops, break-even, timed release/cancel, if-touched entry. `place_advanced_bracket_order` is gone; call `place_bracket_order`. Migration notes:
-  - `profit_ticks`/`stop_ticks` are replaced by `target_quantity`/`target_ticks` and `stop_quantity`/`stop_ticks`, all `Vec<i32>`, one entry per exit leg.
-  - The single-value **setters** are renamed: `.profit_ticks(n)` is now `.target(n)` and `.stop_ticks(n)` is now `.stop(n)`. The *fields* `target_ticks`/`stop_ticks` keep their names, so reading `bracket.stop_ticks` still works.
-  - `.target(n)`/`.stop(n)` size their leg from the entry quantity at the moment they are called, so set `.quantity()` first — `build()` rejects the zero-sized leg you get in the other order. The plural `.targets(..)`/`.stops(..)` take explicit `(quantity, ticks)` pairs and can be called before or after `.quantity()`.
-  - `bracket_type` is now `Option<BracketType>`. Left unset, `build()` derives it from which exit legs are present (as async_rithmic does) and omits it from the request when there are none. This changes what a target-only bracket sends: `TARGET_ONLY_STATIC`, where `RithmicAdvancedBracketOrder` defaulted the field to `TargetAndStopStatic` and always sent it. Set `.bracket_type(..)` to override the derivation; `validate()` rejects a value that does not match the legs supplied.
-- **The `manual_or_auto` parameters are gone from handle methods.** Origination is now a field on the command struct, set with `.manual_or_auto(..)`. `exit_position_with_placement` and `cancel_all_orders_with_placement` are removed — they existed only to pass that argument.
-- **`cancel_all_orders` and `exit_position` now take command structs** (`RithmicCancelAllOrders`, `RithmicExitPosition`) instead of loose arguments, matching every other order call.
-- **`RithmicConfig`, `RithmicAccount`, `LoginConfig`, `InstrumentInfo`, `InstrumentInfoError`, `RithmicEnv`, `TrailingStop`, `RithmicIfTouchedTrigger` and all 246 generated protobuf types are now `#[non_exhaustive]`.** Rithmic added fields to existing messages in 24 of the 35 template releases in its change log, so without this attribute every proto refresh would be a major version bump here. Downstream, struct literals and `..Default::default()` stop compiling on these types: use `RithmicConfigBuilder::from_env(env)`, the `new()`/setters/`build()` chain, or `Default::default()` followed by field assignment. Matches on generated enums need a `_` arm. The struct variants `ConfigError::InvalidValue`, `RithmicError::NoTradeRoute`, `FillHistoryRange::Ssboe` and `FillHistoryRange::TradeDate` carry the attribute too, so their fields cannot be matched exhaustively or built as literals downstream.
-- **`price` on `RithmicOrder`, `RithmicOcoOrderLeg` and `RithmicModifyOrder` is now `Option<f64>`.** Wrap existing values in `Some(..)`; pass `None` for market orders, which previously went out with `price = 0.0`. A modify still restates the whole order, so set `price` to the order's current price when only the quantity is changing. An unset price is now left out of the request entirely — it can no longer reach the wire as `0.0` or stand in as a `0.0` trigger.
-- **Order command types gain a `manual_or_auto` field,** typed as the crate's own `ManualOrAutoEntry` enum and defaulting to `Auto`. The crate defines its own enum, with `From` conversions into each of the seven generated per-request `OrderPlacement` enums, because those have no `Default` — a struct holding one by value cannot derive `Default`.
-- **`RithmicOrder` gains `window_name`, `release_at_ssboe`/`release_at_usecs`, `cancel_at_ssboe`/`cancel_at_usecs`/`cancel_after_secs` and `if_touched`.** All are `Option` and left off the wire when unset, so an order that does not use them is unchanged on the wire.
-- **`cancel_all_orders` is now attributed as `Auto` instead of `Manual`,** which changes what the server records as the origination. Set `.manual_or_auto(ManualOrAutoEntry::Manual)` on the command to keep the old attribution.
-- **`TrailingStop` gains a required `trail_by_price_id: i32` and is built like the order commands:** `new()` takes no arguments, every field has a setter, and `build()` returns `Result<Self, RithmicError>` — `TrailingStop::new().trail_by_ticks(15).trail_by_price_id(7).build()?`. Rithmic rejects a zero price id with rp_code 1112, so `build()` refuses it before it reaches the wire, along with a zero `trail_by_ticks`. **`RithmicIfTouchedTrigger` follows the same pattern:** `new()` no longer takes positional arguments; its `price` is `Option<f64>`, and `build()` requires a symbol, an exchange and the price. A trigger sent without a price omits `if_touched_price` from the wire rather than sending `0.0`, which the default `GreaterThanEqualTo`/`TradePrice` condition would have fired on immediately. Neither type implements `Default` — the all-unset value is not a usable trailing stop or trigger, so `new()` is the only zero-argument constructor. `build()` is opt-in: `trailing_stop_by(ticks, price_id)` and direct field assignment still send exactly what they are given, unchanged from 2.0.0 except that an unset trigger price is now absent instead of `0.0`.
-- **`RithmicOrder`, `RithmicBracketOrder` and `RithmicOcoOrderLeg` gain a `trade_route: Option<String>` field.** Leave it `None` to keep the old behavior. Orders now use the route the server publishes for their exchange instead of a hardcoded `"globex"`/`"simulator"`, and fail with `RithmicError::NoTradeRoute` when there is none.
-- **`RithmicOcoOrderLeg` gains a `trailing_stop: Option<TrailingStop>` field and `RithmicModifyOrder` a `trigger_price: Option<f64>`.** Set them to `None` to keep the old behavior.
-- **`RithmicOrder::duration` is now `TimeInForce` instead of `Option<TimeInForce>`,** matching `RithmicBracketOrder` and `RithmicOcoOrderLeg`. Unwrap existing values. `None` was already sent as `Day`, which is `TimeInForce::default()`, so nothing changes on the wire.
-- **`RithmicConfig` gains a required `request_timeout: Duration` field.** Build the config with `RithmicConfig::builder(env)` or `RithmicConfigBuilder::from_env(env)` — the type is now `#[non_exhaustive]`, so struct literals no longer compile downstream anyway.
-- **`RithmicOrderPlantHandle::subscribe_account_rms_updates` gains a required `update_bits` parameter.** Pass `vec![]` for the old behavior.
-- **`RithmicOrderPlantHandle::adjust_target` (renamed from `adjust_profit`) and `adjust_stop` now take a `RithmicBracketLevelAdjustment`** instead of `(id, ticks)`. The struct adds a `level` field selecting which bracket leg to adjust; `level: None` keeps the old behavior.
-- **`RithmicHistoryPlantHandle::load_volume_profile_minute_bars` takes a `VolumeProfileMinuteBarsRequest`** instead of seven positional arguments, so future fields Rithmic adds to the request land as setters rather than signature changes. Build it with the same `new()`/setters/`build()` chain as the order commands; `build()` requires a symbol, an exchange, a bar period of at least one minute and a time window whose end does not precede its start.
-- **`RithmicModifyOrder::qty` is renamed to `quantity`,** field and setter. 1.0.0 made the same rename on `RithmicBracketOrder`; this was the last field spelling it the short way.
-- **An order placed with an empty `user_tag` now echoes back as `None` instead of `Some("")`,** because the field is no longer sent as `""`.
-- **The `ws` module is private.** `ConnectStrategy` was the only public item in it and stays available at the crate root; spell `rithmic_rs::ws::ConnectStrategy` as `rithmic_rs::ConnectStrategy`. The rest of the module was connection plumbing that was never meant as API.
-- **Seven handle method names change, covering ten methods** (`list_system_info` exists on all four plants). Each method is now named after the request it sends: the template's own verb where it has one, and `get_` only where the template name has none. Nothing was added or removed, and no signatures changed.
+- **Fourteen generated enum re-exports leave the crate root, replaced by
+  crate-owned enums.** The per-request generated enums named the same concepts but
+  were mutually incompatible, so one order could not be expressed against two
+  request types. Variant names are unchanged, so the arms port over — but the
+  crate-owned enums are `#[non_exhaustive]`, so every `match` needs a `_` arm it
+  did not need before, and `OrderType` carries six variants where `OcoPriceType`
+  had four. The prost-specific surface (`as i32`, `try_from`, `from_str_name`,
+  derived `Ord`) does not carry over; `as_str_name` does.
+
+  | removed | use instead |
+  |---|---|
+  | `BracketTransactionType`, `OcoTransactionType`, `NewOrderTransactionType` | `OrderSide` |
+  | `BracketPriceType`, `OcoPriceType`, `NewOrderPriceType`, `ModifyPriceType` | `OrderType` |
+  | `BracketDuration`, `OcoDuration`, `NewOrderDuration` | `TimeInForce` |
+  | `BracketCondition` | `OrderCondition` |
+  | `BracketPriceField` | `OrderPriceField` |
+
+  `BracketType` and `EasyToBorrowRequest` keep their names but now resolve to
+  crate-owned enums rather than `rti::request_bracket_order::BracketType` and
+  `rti::request_easy_to_borrow_list::Request` — the last raw generated types on the
+  curated surface, so a proto refresh can no longer change this crate's API.
+
+- **Seven handle method names change, covering ten methods** (`list_system_info`
+  exists on all four plants). Each is now named after the request it sends.
+  Nothing was added or removed, and no signatures changed except `adjust_target`,
+  which also takes a command struct (below).
 
   | old | new | handle |
   |---|---|---|
@@ -63,91 +85,277 @@ Order commands are now built with `::new()` and chained setters, and the command
   | `pnl_position_snapshots` | `get_pnl_position_snapshot` | pnl |
   | `adjust_profit` | `adjust_target` | order |
 
-  Notes: `list_exchange_permissions` already existed on the order plant — the ticker method was renamed to match it, and both remain, since they are two plants' handles onto the same request. `subscribe_order_book_summary`/`unsubscribe_order_book_summary` is a different request pair and is deliberately unchanged. `adjust_stop` was already named correctly. `RithmicSenderApi::request_depth_by_order_snapshot` keeps its name — every sender-api method is `request_*`, and only the handle method was renamed.
+- **`RithmicAdvancedBracketOrder` is removed; `RithmicBracketOrder` does everything
+  it did.** One bracket type now carries every venue-native field, and
+  `place_advanced_bracket_order` is gone — call `place_bracket_order`. On the plain
+  bracket, `profit_ticks: i32` and `stop_ticks: i32` become `target_ticks: Vec<i32>`
+  and `stop_ticks: Vec<i32>`, one entry per exit leg. An unset `bracket_type` is
+  derived from the legs present, which changes a target-only bracket to send
+  `TARGET_ONLY_STATIC`. See [MIGRATING.md](MIGRATING.md) §5.
 
-- **Fifteen generated enum re-exports are removed from the crate root,** replaced by crate-owned enums. The generated per-request enums were incompatible with each other despite naming the same concepts — the same order could not be expressed against two request types. `BracketType` keeps its name but now resolves to the crate's own enum instead of `rti::request_bracket_order::BracketType`: the variant names are unchanged, so matches keep compiling, but prost-specific uses (`as i32`, `try_from`) do not. `EasyToBorrowRequest` and `RmsUpdateBits` likewise keep their names but now resolve to crate-owned enums instead of `rti::request_easy_to_borrow_list::Request` and `rti::request_account_rms_updates::UpdateBits` — the last two raw generated types on the curated surface, so a proto refresh can no longer change the crate's own API. Variant names are unchanged there too; prost-specific uses (`as i32`, `try_from`, `from_str_name`) and the derived `Ord`/`PartialOrd` orderings do not carry over, while `as_str_name` does.
+- **`price` on `RithmicOrder`, `RithmicOcoOrderLeg` and `RithmicModifyOrder` is
+  `Option<f64>`.** Wrap existing values in `Some(..)` and pass `None` for market
+  orders, which previously went out at `0.0`. An unset price is now omitted
+  entirely, so it can no longer reach the wire as `0.0` or stand in as a `0.0`
+  trigger.
 
-  | removed | use instead |
+- **Order calls take command structs.** `cancel_all_orders()` takes a
+  `RithmicCancelAllOrders` and `exit_position(symbol, exchange)` takes a
+  `RithmicExitPosition`, matching every other order call. Origination moves onto
+  the command as a `.manual_or_auto(..)` field, defaulting to `Auto`.
+
+- **`adjust_target`/`adjust_stop` take a `RithmicBracketLevelAdjustment`** instead
+  of `(id, ticks)`, adding a `level` field that selects which bracket leg to
+  adjust — `level: None` keeps the old behavior. **`load_volume_profile_minute_bars`
+  takes a `VolumeProfileMinuteBarsRequest`** instead of seven positional arguments;
+  see [MIGRATING.md](MIGRATING.md) §6 for the call.
+
+- **`TrailingStop` and `RithmicIfTouchedTrigger` are built like the order
+  commands,** and neither implements `Default` — `TrailingStop` had one at 2.0.0.
+  `TrailingStop` gains a required `trail_by_price_id: i32`; `build()` refuses a
+  zero id (Rithmic rejects it with rp_code 1112) and a `trail_by_ticks` below one.
+  `RithmicIfTouchedTrigger::price` is `Option<f64>`, its `build()` requires a
+  symbol, an exchange and the price, and an unset price is omitted rather than sent
+  as `0.0` — which the default `GreaterThanEqualTo`/`TradePrice` condition would
+  have fired on immediately.
+
+- **`RithmicConfig` gains a required `request_timeout: Duration`.** Build it with
+  `RithmicConfig::builder(env)` or `RithmicConfigBuilder::from_env(env)` — the type
+  is `#[non_exhaustive]`, so struct literals no longer compile downstream anyway.
+
+- **`subscribe_account_rms_updates` gains a required `update_bits` parameter.**
+  Pass `vec![]` for the old behavior.
+
+- **The bundled protos move to R | Protocol API 0.89.0.0 (template version 5.42),
+  and `RithmicMessage::AccountListUpdates` is removed.** Rithmic dropped
+  `account_list_updates.proto` (template 354) and points to the account RMS updates
+  stream instead. `UserAccountUpdate::update_type` and `access_type` are now
+  `Option<String>`, and the generated `UpdateType`/`AccessType` enums are gone.
+
+- **The `ws` module is private.** `ConnectStrategy` was its only public item and
+  stays at the crate root: spell `rithmic_rs::ws::ConnectStrategy` as
+  `rithmic_rs::ConnectStrategy`.
+
+- **Smaller changes.** The first four are mechanical; the last two change what the
+  server sees and are repeated at the top of this section.
+
+  | change | what to do |
   |---|---|
-  | `BracketTransactionType`, `OcoTransactionType`, `NewOrderTransactionType` | `OrderSide` |
-  | `BracketPriceType`, `OcoPriceType`, `NewOrderPriceType`, `ModifyPriceType` | `OrderType` |
-  | `BracketDuration`, `OcoDuration`, `NewOrderDuration` | `TimeInForce` |
-  | `BracketCondition` | `OrderCondition` |
-  | `BracketPriceField` | `OrderPriceField` |
+  | `RithmicModifyOrder::qty` renamed to `quantity` | rename field and setter |
+  | `RithmicOrder::duration` is `TimeInForce`, not `Option<TimeInForce>` | unwrap; `None` already sent `Day`, so the wire is unchanged |
+  | `ConfigError::InvalidValue` is `#[non_exhaustive]` at the variant | destructuring `{ var, reason }` needs a `..` |
+  | new `Option` fields on the command types | leave `None` to keep old behavior |
+  | `cancel_all_orders` is attributed `Auto`, not `Manual` | set `.manual_or_auto(ManualOrAutoEntry::Manual)` to keep the old attribution |
+  | an empty `user_tag` echoes back as `None`, not `Some("")` | the field is no longer sent as `""` |
 
 ### Added
 
-- **`RithmicOrderPlantHandle::show_fill_history(range, max_record_count)`** — fetches the account's fill history (templates 3512/3513, new in template version 5.42), one response per fill. The new `FillHistoryRange` expresses the window in either format the request takes: seconds since the epoch (`FillHistoryRange::ssboe(start, finish)`) or trade dates as CCYYMMDD (`FillHistoryRange::trade_date(start, finish)`). A `max_record_count` above 10,000 is refused with `RithmicError::InvalidArgument`, since Rithmic rejects it.
-- **`RithmicOrderPlantHandle::get_user_info(user)`** — fetches a user's profile, entitlement status and session limits (templates 3510/3511); pass `None` for the logged-in user. The unsolicited **`RithmicMessage::UserInfoUpdate`** (template 357) carries user-level changes as they happen; it previously arrived as `UnknownTemplate`.
-- **`RithmicHistoryPlantHandle::load_ticks_all`, `load_tick_bars_all` and `load_time_bars_all`** — replay loaders that auto-paginate. Rithmic truncates a large replay and puts a `request_key` on its closing response; the existing loaders return that page as-is and leave `resume_bars` to the caller, while these follow each key until a page closes without one, returning every page's responses in order. Resumption uses the server's key rather than re-requesting from the last timestamp: same-timestamp ticks are routine (one aggressor filling several resting orders), so a timestamp restart would skip or duplicate the ticks at a page boundary. A `max_pages` cap (`None` = unbounded) bounds a runaway replay; when it cuts the replay short, the last returned response still carries its key — readable through the new **`RithmicResponse::resume_key()`** — so `resume_bars` can pick up where it stopped.
-- **`RithmicBracketOrder::operation_type`** and the `BracketOperationType` enum — the `order_operation_type` field Rithmic added to bracket requests in template version 5.37. It selects which event on one order of the bracket cancels the rest. Rithmic documents only the wire spellings (`AFOCCA`, `FOCCA`, `CCA`, `FCA`, `OCA`); the rustdoc on each variant carries async_rithmic's reading of them (`FCA` = "fill cancels all", and so on), attributed as such. When unset, the field stays off the wire as before — async_rithmic tried defaulting it to `OCA` and reverted after it broke bracket orders.
-- **The generated types pick up every field Rithmic added through template 5.42:** the contact, address, `order_copy_status` and per-plant session-count fields on `ResponseLoginInfo` (also on the new `ResponseGetUserInfo` and `UserInfoUpdate`); `loss_limit` and the account-creation timestamps on `ResponseAccountList`; `source_ssboe`/`source_usecs`/`source_nsecs` on `ExchangeOrderNotification`; `level_1_market_data`/`level_2_market_data` on `ResponseListExchangePermissions` (Rithmic deprecates `entitlement_flag` in favor of these, and the generated field now carries `#[deprecated]`); `min_qprice_change_precision` on `ResponseReferenceData`; `data_bar_seq_num` on `TickBar` and `ResponseTickBarReplay`; and `rms_updates_only` on `RequestPnLPositionUpdates`, which the PnL subscription leaves unset to keep streaming every update.
-- **`validate()` on `RithmicOrder`, `RithmicBracketOrder`, `RithmicModifyOrder`, `RithmicOcoOrder` and `RithmicOcoOrderLeg`** — checks that the command carries the prices its price type requires, returning `RithmicError::InvalidArgument` when it does not. The rules are async_rithmic's: `Limit`, `StopLimit` and `LimitIfTouched` need a price; the stop and if-touched types need a trigger; `Market` needs nothing. On `RithmicModifyOrder` the price may stand in for the trigger, since moving a stop by its price alone predates `trigger_price`. On `RithmicBracketOrder` the exit legs are also checked: quantities and tick distances must pair up, every leg's quantity must be positive, and a hand-set `bracket_type` must match the legs supplied. `build()` calls `validate()`, and it is also public, so a command assembled another way can be checked too. Market rules beyond this are deliberately not validated: Rithmic is the authority on what it accepts, and stricter rules compiled in here would refuse orders the server would have taken.
-- **`validate()` covers identity, not just prices.** `build()` on the order commands now also requires a symbol, an exchange and a positive quantity — and the `basket_id` on `RithmicModifyOrder`. The remaining command types gain a `validate()` of their own: `RithmicCancelOrder`, `RithmicModifyOrderReferenceData` and `RithmicBracketLevelAdjustment` require their basket id, `RithmicExitPosition` its symbol and exchange as a pair — or neither, which flattens the whole account — and `RithmicLinkOrders` at least two non-empty basket ids. Validation stays the consumer's call: `build()` runs it, and the handles send what they are given. An embedded `TrailingStop` or `RithmicIfTouchedTrigger` is likewise not re-validated — their `build()` is the opt-in strict path, since the field evidence on what Rithmic accepts is contradictory.
-- **`RithmicExitPosition` can flatten the whole account.** Its `symbol` and `exchange` are `Option<String>` and come as a pair: both set exits one instrument, neither set sends the fields absent, which template 3504 reads as "exit every position on the account". Previously the crate always sent the fields, so the account-wide form was inexpressible.
-- **Reconnect backoff is jittered.** Each retry delay is scaled by a random factor in [0.5, 1.5), so plants that lost the same connection no longer retry in lockstep against a recovering server. The schedule is otherwise unchanged — 500 ms more per attempt, capped at 60 seconds — with the jitter applied after the cap, so a long outage keeps its spread (delays range 30–90 s at the cap).
-- **`RithmicConfigBuilder::from_env(env)`** — a construction path for a type that lost struct-literal syntax. It pre-fills the builder from the same environment variables `RithmicConfig::from_env` reads, so a single field can be overridden.
-- **Crate-owned `ManualOrAutoEntry`, `OrderCondition` and `OrderPriceField`** at the crate root, joining `OrderSide`, `OrderType` and `TimeInForce`, which already existed at 2.0.0. They stand in for the removed generated re-exports (see the table under Breaking Changes). `ManualOrAutoEntry` is new outright — origination was never exposed before. `OrderCondition` defaults to `GreaterThanEqualTo` and `OrderPriceField` to `TradePrice`, the values `RithmicIfTouchedTrigger::new()` starts from.
-- **`Clone` on `RithmicOrderPlantHandle` and `RithmicPnlPlantHandle`** — the ticker and history handles already had it. A clone's `subscription_receiver` picks up the stream from the moment of the clone; it does not replay earlier updates.
-- **`SubscriptionFilter` is re-exported at the crate root** — it is the type of `subscription_receiver` on the order and PnL handles, previously reachable only as `rithmic_rs::plants::subscription::SubscriptionFilter`. `rithmic_rs::api` now also re-exports `BracketOperationType` and `FillHistoryRange` alongside the other order enums, and the new `VolumeProfileMinuteBarsRequest` is at the crate root with the other request types.
-- **Multi-leg OCO orders** — a `RithmicOcoOrder` now carries two or more `RithmicOcoOrderLeg`s instead of a fixed pair, and each leg can carry its own trailing stop via the new `RithmicOcoOrderLeg::trailing_stop`. Fewer than two legs is rejected, since Rithmic has nothing to cancel a lone leg against.
-- **Per-order trade routes** via the new `trade_route` field, which overrides the route the plant would pick — including a route the server never published.
-- **`RithmicOrderPlantHandle::trade_route_for(exchange)`** and **`record_trade_route(update)`** — the route an order would take right now, and a way to apply a `TradeRoute` update to the cache. Updates are not applied automatically; see `examples/trade_routes.rs`.
-- **`RithmicError::NoTradeRoute { exchange, cached }`** — returned when no route was published for the exchange and the order set none itself, so nothing was sent.
-- **`RithmicMessage::UnknownTemplate(UnknownTemplateMessage)`** — a frame whose `template_id` has no message definition in this crate, with the body kept as received. `RithmicMessage` is `#[non_exhaustive]`, so the new variant does not break existing matches.
-- **`UnknownTemplateMessage::decode_as<M>()`, `payload_hex()` and `from_payload_hex()`** — decode an unmapped template into your own `prost` type, or capture the full payload for replay in a test. `Ok` from `decode_as` is not proof the type was guessed right.
-- **`RithmicMessage::RequestHeartbeat(RequestHeartbeat)`** — the server's keep-alive (template 18), which previously arrived as `UnknownTemplate`. The library does not reply to it.
-- **`rithmic_rs::prost`** — re-exports the `prost` this crate's types are generated against. It is a public dependency, so a major bump of `prost` remains a breaking change here.
-- **`rithmic_rs::DEFAULT_REQUEST_TIMEOUT`**, `RithmicConfigBuilder::request_timeout` and the `RITHMIC_REQUEST_TIMEOUT_SECS` environment variable — control how long a request waits for a response. The default is 30 seconds; the environment variable takes plain digits only.
-- **`RithmicBracketLevelAdjustment`** — the command struct for `adjust_target`/`adjust_stop`: basket `id`, new `ticks` distance, and the `level` selecting a leg.
-- **`RithmicCancelAllOrders`, `RithmicExitPosition`, `RithmicLinkOrders` and `RithmicModifyOrderReferenceData`** — command structs for the four order calls that previously took loose arguments. Every order call now takes a command struct.
-- **`PartialEq` on `RithmicOrder`, `RithmicBracketOrder`, `RithmicOcoOrderLeg`, `RithmicModifyOrder`, `RithmicCancelOrder`, `RithmicIfTouchedTrigger` and `TrailingStop`** (and on the six new command structs above), so a built command can be compared in a test. `Eq` is not derived: most of these carry `f64` price fields, and the rest stay `PartialEq`-only so a future proto field with an `f64` cannot take an already-promised `Eq` away.
-- **`PartialEq` on `RithmicMessage`, `RithmicResponse`, `LoginConfig` and `ConfigError`** (with `Eq` on `ConfigError`), so a whole response can be `assert_eq!`'d in a downstream test instead of being matched field by field.
-- **`#[must_use]` on the command, trigger and request types and on `RithmicConfigBuilder`.** The setters consume and return the value, so `order.symbol("ESH6");` on its own line compiles while silently discarding the order; the attribute makes that a warning.
-- **RMS auto-liquidation streaming** — `subscribe_account_rms_updates` takes a `Vec` of selectors; pass the new `rithmic_rs::RmsUpdateBits::AutoLiqThresholdCurrentValue` to receive auto-liquidation threshold updates. An empty `Vec` omits `update_bits` rather than sending `0`.
-- **`serde` derives on every order command type** behind the `serde` feature — `RithmicOrder`, `RithmicBracketOrder`, `RithmicOcoOrder` and its legs, `RithmicModifyOrder`, the cancel/exit/link/retag/adjustment commands, `TrailingStop`, `RithmicIfTouchedTrigger` and `VolumeProfileMinuteBarsRequest` — so a strategy can persist and replay any command. The feature-flag table in the crate docs had claimed `RithmicOrder` and `TrailingStop` since 1.0.0 without the impls existing; the impls now exist, and the table lists the feature's actual coverage.
-- **`RithmicModifyOrder::trigger_price`** — a modify can now set a trigger distinct from the limit price. When `None`, the four triggering price types send `price` in its place.
-- **`window_name` on `RithmicBracketOrder`, `RithmicModifyOrder`, `RithmicCancelOrder`, `RithmicExitPosition` and `RithmicOcoOrderLeg`** — the originating window Rithmic records; `RithmicOrder` already had it. On the OCO leg it is per-leg, since `RequestOCOOrder` declares the field `repeated`: like `user_tag`, every leg gets a slot once any leg sets one, and the field is omitted when none does.
-- **`RithmicOcoOrder::cancel_at_ssboe`/`cancel_at_usecs`/`cancel_after_secs`** — group-level cancel timing, with `.cancel_at(ssboe, usecs)` setting both halves, matching `RithmicBracketOrder`.
-- **`RithmicExitPosition::trading_algorithm`** — the algorithm name credited with the exit.
-- **`RithmicModifyOrder::trail_by_ticks` and `if_touched`** — the last two `RequestModifyOrder` fields that had no way to be set. `RequestModifyOrder` declares no `trail_by_price_id`, so the distance is a plain tick count rather than a `TrailingStop`, and the message's `trailing_stop` flag is derived from it.
+- **`show_fill_history(range, max_record_count)`** on the order handle — the
+  account's fill history (templates 3512/3513, new in 5.42), one response per fill.
+  `FillHistoryRange` takes either format the request accepts: `ssboe(start, finish)`
+  or `trade_date(start, finish)`. A `max_record_count` above 10,000 is refused with
+  `RithmicError::InvalidArgument`, since Rithmic rejects it.
 
-  With these, every field of the eleven order request messages is reachable from a command type. The request builders set each field explicitly instead of filling the rest from `Default`, so a field added by a future proto refresh fails to compile instead of being silently dropped.
+- **`get_user_info(user)`** on the order handle — a user's profile, entitlement
+  status and session limits (templates 3510/3511); pass `None` for the logged-in
+  user. The unsolicited **`RithmicMessage::UserInfoUpdate`** (template 357) carries
+  user-level changes as they happen; it previously surfaced as `Unknown` with a
+  `ProtocolError`.
+
+- **`load_ticks_all`, `load_tick_bars_all` and `load_time_bars_all`** — replay
+  loaders that auto-paginate. Rithmic truncates a large replay and puts a
+  `request_key` on its closing response; these follow each key until a page closes
+  without one. Resumption uses the server's key, not a timestamp restart, which
+  would skip or duplicate ticks sharing a timestamp at a page boundary. Set
+  `max_pages` to bound a runaway replay — `None` follows every page. The last
+  response still exposes its key through **`RithmicResponse::resume_key()`**.
+
+- **Per-order trade routes.** The new `trade_route` field on `RithmicOrder`,
+  `RithmicBracketOrder` and `RithmicOcoOrderLeg` overrides the route the plant
+  would pick, including one the server never published. **`trade_route_for(exchange)`**
+  reports the route an order would take now, **`record_trade_route(update)`** applies
+  a `TradeRoute` update to the cache, and **`RithmicError::NoTradeRoute`** is
+  returned when no route exists and the order set none.
+
+- **`validate()` on every command type that has something to check**, public as
+  well as called by `build()`. `Limit`, `StopLimit` and `LimitIfTouched` need a
+  price; the stop and if-touched types need a trigger; `Market` needs neither. It
+  also requires a symbol, an exchange and a positive quantity — and the basket id on
+  `RithmicModifyOrder`. It returns `RithmicError::InvalidArgument`. Market rules
+  beyond this are deliberately not enforced: Rithmic is the authority on what it
+  accepts.
+
+- **`RithmicExitPosition` can flatten the whole account.** Its `symbol` and
+  `exchange` are `Option<String>` and come as a pair — both set exits one
+  instrument, neither set sends the fields absent, which template 3504 reads as
+  every position on the account. The crate previously always sent them.
+
+- **Multi-leg OCO orders.** A `RithmicOcoOrder` now carries two or more legs
+  instead of a fixed pair, and each leg can carry its own trailing stop. Fewer than
+  two legs is rejected, since Rithmic has nothing to cancel a lone leg against.
+
+- **`RithmicBracketOrder::operation_type` and the `BracketOperationType` enum** —
+  the `order_operation_type` field Rithmic added in 5.37, selecting which event on
+  one order of the bracket cancels the rest. Leave it unset and it stays off the
+  wire, as before — async_rithmic, the Python client for the same API, tried
+  defaulting it to `OCA` and reverted after it broke bracket orders.
+
+- **`RithmicMessage::UnknownTemplate(UnknownTemplateMessage)`** — a frame whose
+  `template_id` has no definition here, body kept as received, with
+  **`decode_as<M>()`, `payload_hex()` and `from_payload_hex()`** to decode it into
+  your own `prost` type or capture it for replay. `Ok` from `decode_as` is not
+  proof the type was guessed right. **`RithmicMessage::RequestHeartbeat`**
+  (template 18) is now mapped too; the library does not reply to it.
+
+- **Request timeouts.** `rithmic_rs::DEFAULT_REQUEST_TIMEOUT` (30 seconds),
+  `RithmicConfigBuilder::request_timeout` and the `RITHMIC_REQUEST_TIMEOUT_SECS`
+  environment variable control how long a request waits before failing with the new
+  `RithmicError::RequestTimeout`.
+
+- **Crate-owned `ManualOrAutoEntry`, `OrderCondition`, `OrderPriceField` and
+  `RmsUpdateBits`** at the crate root, joining `OrderSide`, `OrderType` and
+  `TimeInForce`. `ManualOrAutoEntry` is new outright — origination was never
+  exposed before — defaults to `Auto` on every command, and converts into all seven
+  per-request `OrderPlacement` enums, which have no `Default` of their own.
+  `OrderCondition` defaults to `GreaterThanEqualTo` and `OrderPriceField` to
+  `TradePrice`, the values an unconfigured `RithmicIfTouchedTrigger` sends.
+
+- **`RithmicCancelAllOrders`, `RithmicExitPosition`, `RithmicLinkOrders`,
+  `RithmicModifyOrderReferenceData` and `RithmicBracketLevelAdjustment`** — command
+  structs for the order calls that previously took loose arguments. Every order
+  call now takes one.
+
+- **New command fields.** `window_name` on `RithmicOrder` and the bracket, modify,
+  cancel, exit and OCO-leg types; `release_at_*`, `cancel_at_*`, `cancel_after_secs`
+  and `if_touched` on `RithmicOrder`; group-level cancel timing on `RithmicOcoOrder`;
+  `trigger_price`, `trail_by_ticks` and `if_touched` on `RithmicModifyOrder`; and
+  `trading_algorithm` on `RithmicExitPosition`. With these, every field of the
+  eleven order request messages is reachable from a command type. On the OCO leg,
+  `window_name` is all-or-none across legs like `user_tag`: set it on one leg and
+  every leg gets a slot.
+
+- **RMS auto-liquidation streaming** — pass `RmsUpdateBits::AutoLiqThresholdCurrentValue`
+  to `subscribe_account_rms_updates`. An empty `Vec` omits `update_bits` rather
+  than sending `0`.
+
+- **`serde` derives on every order command type** behind the `serde` feature, so a
+  strategy can persist and replay any command.
+
+- **Reconnect backoff is jittered** by a random factor in `[0.5, 1.5)`, applied
+  after the cap, so plants that lost the same connection no longer retry in
+  lockstep. The schedule is otherwise unchanged — 500 ms more per attempt, capped
+  at 60 seconds — giving 30–90 s delays at the cap.
+
+- **`RithmicConfigBuilder::from_env(env)`** — a construction path for a type that
+  lost struct-literal syntax, pre-filled from the same environment variables
+  `RithmicConfig::from_env` reads so a single field can be overridden.
+
+- **Trait impls and re-exports.** `Clone` on the order and PnL handles (the ticker
+  and history handles already had it) — a clone's `subscription_receiver` starts at
+  the moment of the clone and does not replay earlier updates. `PartialEq` on the
+  command types and on `RithmicMessage`, `RithmicResponse`, `LoginConfig` and
+  `ConfigError`; `#[must_use]` on the command, trigger and request types; and
+  `SubscriptionFilter`, `rithmic_rs::prost` and the new order enums re-exported at
+  the crate root.
+
+- **The generated types pick up the fields Rithmic added through 5.42,** including
+  contact,
+  address, `order_copy_status` and per-plant session counts on `ResponseLoginInfo`;
+  `loss_limit` and creation timestamps on `ResponseAccountList`; `source_*` on
+  `ExchangeOrderNotification`; `level_1_market_data`/`level_2_market_data` on
+  `ResponseListExchangePermissions` (with `entitlement_flag` now `#[deprecated]`);
+  and `data_bar_seq_num` on `TickBar` and `ResponseTickBarReplay`.
 
 ### Changed
 
-- **`generate_protos` names four protos the 0.89.0.0 pool stopped importing.** `request`/`response_accept_agreement` and `request`/`response_set_rithmic_mrkt_data_self_cert_status` still ship as files and templates 504/505 and 508/509 still answer, so the generator compiles them alongside the pool and the crate keeps its agreement and self-certification calls.
-- **An unrecognized `template_id` is no longer treated as a decode failure.** It used to produce `Err` with `ProtocolError("Unknown message type…")` and discard the payload; it now returns `Ok` with `RithmicMessage::UnknownTemplate` and logs a `warn`. Code matching `RithmicMessage::Unknown` still compiles but no longer sees these frames — `Unknown` now means only that a frame failed to decode.
-- **An unsolicited `Reject` (one that echoes no `user_msg`) is logged at `warn` and dropped,** instead of reaching the request handler, matching nothing, and being dumped at `error`.
-- **A `Reject` is always surfaced as a rejection,** with `rp_code` passed through element for element. The success rules for `Response*` messages no longer apply to it, so codes like `["0"]` no longer make a rejected request look like a success.
-- **`RithmicError::RequestRejected` renders as `request rejected`** when the rejection carried no code and no message, instead of leaving a dangling separator.
-- **The crate-level "Error Handling" docs now cover every way an error surfaces** and what to do about each. Bad data never stops a plant; only transport failure does. `examples/error_handling.rs` covers the same ground as runnable code.
-- **Documentation pass across the crate.** Comments and rustdoc now describe what the code does, without describing server behaviour or assuming familiarity with the wire protocol. No API changed.
-- **Rustdoc examples on the command types now compile,** instead of being fenced as `ignore` blocks. The old fences hid code that would not build.
-- **docs.rs now builds the crate with all features enabled,** so the `serde` impls show up in the rendered docs.
-- **The README samples now show correct API usage.** `cancel_order` takes a `RithmicCancelOrder` rather than a bare id, `place_bracket_order` had a literal `...` for its argument, and the history plant block passed `&str` where owned `String`s are required and used an unimported `BarType`.
+- **An unrecognized `template_id` is no longer a decode failure.** It used to
+  return `Err` with `ProtocolError` and discard the payload; it now returns `Ok`
+  with `RithmicMessage::UnknownTemplate` and logs a `warn`. Code matching
+  `RithmicMessage::Unknown` still compiles but no longer sees these frames —
+  `Unknown` now means only that a frame failed to decode.
+
+- **A `Reject` is always surfaced as a rejection,** with `rp_code` passed through
+  element for element, so codes like `["0"]` no longer make a rejected request look
+  like a success. An unsolicited `Reject` — one echoing no `user_msg` — is logged
+  at `warn` and dropped instead of reaching the request handler.
+
+- **Documentation pass across the crate.** The "Error Handling" docs now cover
+  every way an error surfaces, the rustdoc examples on the command types compile
+  instead of being fenced as `ignore`, docs.rs builds with all features, and the
+  README samples show correct API usage. No API changed.
 
 ### Fixed
 
-- **Market orders were sent with `price = 0.0`.** The `price` field was sent unconditionally and defaults to zero, so an order with no meaningful price was priced at zero on the wire. It is now omitted when the caller supplies none.
-- **Multi-leg OCO orders zero-filled `price` and `trigger_price`.** Both now follow the all-or-none rule the trailing-stop fields already used: absent when no leg carries one, index-aligned once any leg does.
-- **Empty `user_tag` and `localid` were sent as `""`** instead of being omitted. `request_modify_order_reference_data` still sends whatever it is given — an empty tag there is how a tag is cleared.
-- **Order origination was attributed inconsistently.** Orders, modifies, cancels and exits sent the bare literal `2` while cancel-all sent `Manual`, so one session reported two different originators. All commands now use the typed enum of their own request module and default to `Auto`.
-- **Every order went out on `"globex"` (live) or `"simulator"` regardless of exchange,** ignoring the routes the server publishes. The plant now uses the published route for the order's exchange, preferring one marked default. `login()` reads the routes once, and orders route off that snapshot for the life of the connection.
-- **Requests were sent with a hardcoded `Trader` user type,** and the account list request carried no `fcm_id`/`ib_id`, so FCM and IB logins saw no accounts. `login()` now retrieves the login info once and scopes requests with it. As a result, **`get_account_list` and `get_account_rms_info` may return fewer accounts than before**, including for `Trader` logins.
-- **Requests could wait forever.** A request whose response never arrives now fails after 30 seconds with the new `RithmicError::RequestTimeout` instead of blocking its caller indefinitely. Reconcile a timed-out order rather than re-sending it.
-- **A frame that fails to decode is no longer discarded.** The echoed `user_msg` is now read off the wire even when the body will not decode, so the failure resolves the matching request with `ProtocolError` instead of leaving its caller waiting. Where no id is recoverable, the per-request timeout covers it.
-- **A response that ended a request without being marked `multi_response` leaked the parts accumulated under its id.** They were kept for the life of the connection and prepended to a later request that reused the id.
-- **The order and PnL plants now reject queued commands once a disconnect is in flight.** Previously, an order submitted from a cloned handle at the same time as `disconnect()` could still be sent to Rithmic while its caller saw `ConnectionClosed` — a failure on record for an order that was live at the exchange.
-- **`disconnect()` now sends `Close` even when the logout fails.** It used to return early, leaving the actor with `close_requested` set: no heartbeats, every later command dropped, pending requests never drained.
-- **A server `ForcedLogout` (template 77) now stops the plant actor,** failing pending requests with `ConnectionClosed`. Previously the plant kept heartbeating a session the server had already ended, while callers waited on responses that would never come.
-- **The `heartbeat_interval` from the login response is now used as the heartbeat period.** Plants used `hb.max(60)`, so a server asking for a heartbeat every 30 seconds got one every 60 and dropped the connection as idle.
-- **A `MarketIfTouched` or `LimitIfTouched` modify omitted `trigger_price`.** The fallback to the order's own price covered only the two stop types, so an if-touched modify with no separate trigger level went out with the field unset. The fallback now covers the same four types `validate()` requires a trigger for.
-- **Single-order trailing stops now populate `trail_by_price_id`.** It was omitted before, and Rithmic rejected the trailing stop with rp_code 1112.
-- **Bracket target/stop adjustments omitted the `level` field,** so on a multi-leg bracket every adjustment landed on the server's default leg and the other legs were unreachable.
-- **`request_account_rms_updates` sent `update_bits: None`,** so `auto_liq_threshold_current_value` never streamed even when subscribed.
-- **`examples/bracket_order.rs` no longer exits its listener on a recoverable error.** It broke out of the loop on any populated `update.error` — which a per-message decode failure also sets — so a single undecodable frame silently stopped order updates on a live bracket.
-- **Samples handled a rejected `subscribe` in an `Err` arm that can never match,** so a rejected subscription was reported as a success. They now check `resp.error`.
+- **Market orders were sent with `price = 0.0`,** and multi-leg OCO orders
+  zero-filled `price` and `trigger_price`. Both now follow the all-or-none rule the
+  trailing-stop fields already used: absent when no leg carries one, index-aligned
+  once any leg does.
+
+- **Every order went out on `"globex"` or `"simulator"` regardless of exchange,**
+  ignoring the routes the server publishes. The plant now uses the published route
+  for the order's exchange, preferring one marked default, read once at `login()`.
+
+- **Requests carried a hardcoded `Trader` user type,** and the account list request
+  carried no `fcm_id`/`ib_id`, so FCM and IB logins saw no accounts. `login()` now
+  scopes requests with the real login info. As a result, **`get_account_list` and
+  `get_account_rms_info` may return fewer accounts than before,** including for
+  `Trader` logins.
+
+- **Requests could wait forever.** A request whose response never arrives now fails
+  after 30 seconds with `RithmicError::RequestTimeout`. Reconcile a timed-out order
+  rather than re-sending it.
+
+- **Order origination was attributed inconsistently** — orders, modifies, cancels
+  and exits sent the bare literal `2` while cancel-all sent `Manual`, so one session
+  reported two different originators. All commands now use the typed enum of their
+  own request module.
+
+- **Empty `user_tag` and `localid` were sent as `""`** instead of being omitted.
+  `request_modify_order_reference_data` still sends what it is given — an empty tag
+  there is how a tag is cleared.
+
+- **A frame that fails to decode is no longer discarded.** The echoed `user_msg` is
+  read off the wire even when the body will not decode, so the failure resolves the
+  matching request with `ProtocolError` instead of leaving its caller waiting.
+
+- **A response that ended a request without being marked `multi_response` leaked
+  the parts accumulated under its id.** They were kept for the life of the
+  connection and prepended to a later request that reused the id.
+
+- **The order and PnL plants now reject queued commands once a disconnect is in
+  flight.** An order submitted from a cloned handle alongside `disconnect()` could
+  still reach Rithmic while its caller saw `ConnectionClosed` — a failure on record
+  for an order that was live at the exchange.
+
+- **`disconnect()` sends `Close` even when the logout fails.** It used to return
+  early, leaving the actor with `close_requested` set: no heartbeats, every later
+  command dropped, pending requests never drained.
+
+- **A server `ForcedLogout` (template 77) now stops the plant actor,** failing
+  pending requests with `ConnectionClosed`. The plant used to keep heartbeating a
+  session the server had already ended.
+
+- **The `heartbeat_interval` from the login response is now used as the heartbeat
+  period.** Plants used `hb.max(60)`, so a server asking for a heartbeat every 30
+  seconds got one every 60 and dropped the connection as idle.
+
+- **A `MarketIfTouched` or `LimitIfTouched` modify omitted `trigger_price`.** The
+  fallback to the order's own price covered only the two stop types; it now covers
+  the same four types `validate()` requires a trigger for.
+
+- **Single-order trailing stops omitted `trail_by_price_id`,** which Rithmic
+  rejected with rp_code 1112.
+
+- **Bracket target/stop adjustments omitted the `level` field,** so on a multi-leg
+  bracket every adjustment landed on the server's default leg and the other legs
+  were unreachable.
+
+- **`request_account_rms_updates` sent `update_bits: None`,** so
+  `auto_liq_threshold_current_value` never streamed even when subscribed.
+
+- **Example fixes.** `examples/bracket_order.rs` no longer exits its listener on a
+  recoverable error, and the samples now check `resp.error` for a rejected
+  subscribe instead of an `Err` arm that can never match.
 
 ## [2.0.0]
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,0 +1,300 @@
+# Migrating to 3.0.0
+
+3.0.0 reshapes the order surface. Commands are built with `new()` and chained
+setters instead of struct literals, the generated protobuf enums are replaced by
+crate-owned ones, and every order call takes a command struct.
+
+Most of the work is mechanical and the compiler finds it. Work through the
+sections in order — section 1 resolves the majority of the errors.
+
+Section 9 lists what the compiler will *not* find: six changes that compile
+untouched and alter what reaches the exchange. Read that one even if everything
+else builds.
+
+## 1. Build commands with `new()` and setters
+
+The order command types are `#[non_exhaustive]`, so `..Default::default()` no
+longer compiles outside this crate. There is no separate builder type: `new()`
+takes no arguments and returns the command with its defaults filled in, every
+field has a setter of the same name, and `build()` runs `validate()` and returns
+`Result<Self, RithmicError>`.
+
+```rust
+// Before
+let order = RithmicOrder {
+    symbol: "ESM6".into(),
+    exchange: "CME".into(),
+    quantity: 1,
+    ..Default::default()
+};
+
+// After
+let order = RithmicOrder::new()
+    .symbol("ESM6")
+    .exchange("CME")
+    .quantity(1)
+    .transaction_type(OrderSide::Buy)
+    .price_type(OrderType::Limit)
+    .price(5000.0)
+    .build()?;
+```
+
+The fields are still public, so direct assignment works when you need it:
+
+```rust
+let mut order = RithmicOrder::new();
+order.symbol = "ESH6".into();
+```
+
+`build()` is the opt-in strict path. It requires a symbol, an exchange, a positive
+quantity, and the prices the command's price type needs. The handles send what
+they are given, so a command assembled by field access skips those checks — call
+`validate()` yourself if you want them.
+
+`TrailingStop` and `RithmicIfTouchedTrigger` follow the same pattern, and neither
+implements `Default`. `TrailingStop` now requires `trail_by_price_id`; Rithmic
+rejects a zero id with rp_code 1112, so `build()` refuses it first.
+
+```rust
+let stop = TrailingStop::new().trail_by_ticks(15).trail_by_price_id(7).build()?;
+```
+
+### Other types that lost struct-literal syntax
+
+`RithmicConfig`, `RithmicAccount`, `LoginConfig`, `InstrumentInfo`,
+`InstrumentInfoError`, `RithmicEnv` and all 246 generated protobuf types are
+`#[non_exhaustive]`. Rithmic added fields to existing messages in 24 of the 35
+template releases in its change log; without the attribute, every proto refresh
+would be a major version bump here.
+
+- Config: use `RithmicConfig::builder(env)` or `RithmicConfigBuilder::from_env(env)`.
+- Generated types: `Default::default()` followed by field assignment.
+- Matches on generated enums need a `_` arm.
+
+`ConfigError::InvalidValue`, `RithmicError::NoTradeRoute`, `FillHistoryRange::Ssboe`
+and `FillHistoryRange::TradeDate` carry the attribute too, so their fields cannot
+be matched exhaustively or built as literals downstream.
+
+## 2. Replace the generated enums
+
+Fourteen generated enum re-exports leave the curated surface. The generated
+per-request enums named the same concepts but were incompatible with each other,
+so the same order could not be expressed against two request types.
+
+Twelve are replaced outright:
+
+| removed | use instead |
+|---|---|
+| `BracketTransactionType`, `OcoTransactionType`, `NewOrderTransactionType` | `OrderSide` |
+| `BracketPriceType`, `OcoPriceType`, `NewOrderPriceType`, `ModifyPriceType` | `OrderType` |
+| `BracketDuration`, `OcoDuration`, `NewOrderDuration` | `TimeInForce` |
+| `BracketCondition` | `OrderCondition` |
+| `BracketPriceField` | `OrderPriceField` |
+
+Two keep their names but now resolve to crate-owned enums: `BracketType`
+(was `rti::request_bracket_order::BracketType`) and `EasyToBorrowRequest`
+(was `rti::request_easy_to_borrow_list::Request`).
+
+Variant names are unchanged throughout, so the arms port over as written. Two
+things do not:
+
+- **The crate-owned enums are `#[non_exhaustive]`.** The generated enums were not,
+  so an exhaustive `match` that compiled at 2.0.0 now needs a `_` arm.
+- **`OrderType` has six variants where `OcoPriceType` had four**, adding
+  `MarketIfTouched` and `LimitIfTouched`.
+
+The prost-specific surface does not carry over either — `as i32`, `try_from`,
+`from_str_name` and the derived `Ord`/`PartialOrd`. `as_str_name` is still
+available.
+
+## 3. Rename handle methods
+
+Seven names change, covering ten methods (`list_system_info` exists on all four
+plants). Each method is now named after the request it sends. Signatures are
+unchanged except `adjust_target`, which also swaps `(id, ticks)` for a command
+struct — see section 6.
+
+| old | new | handle |
+|---|---|---|
+| `list_system_info` | `get_system_info` | all four plants |
+| `list_exchanges` | `list_exchange_permissions` | ticker |
+| `request_depth_by_order_snapshot` | `get_depth_by_order_snapshot` | ticker |
+| `subscribe_order_book` | `subscribe_depth_by_order_update` | ticker |
+| `unsubscribe_order_book` | `unsubscribe_depth_by_order_update` | ticker |
+| `pnl_position_snapshots` | `get_pnl_position_snapshot` | pnl |
+| `adjust_profit` | `adjust_target` | order |
+
+`list_exchange_permissions` already existed on the order plant; the ticker method
+was renamed to match, and both remain — two plants' handles onto the same request.
+`subscribe_order_book_summary`/`unsubscribe_order_book_summary` is a different
+request pair and is unchanged. `RithmicSenderApi::request_depth_by_order_snapshot`
+keeps its name, since every sender-api method is `request_*`.
+
+## 4. Prices are `Option<f64>`
+
+`price` on `RithmicOrder`, `RithmicOcoOrderLeg` and `RithmicModifyOrder` is now
+`Option<f64>`. Wrap existing values in `Some(..)`, and pass `None` for market
+orders — those previously went out priced at `0.0`.
+
+An unset price is now left out of the request entirely. It can no longer reach the
+wire as `0.0` or stand in as a `0.0` trigger.
+
+A modify still restates the whole order, so set `price` to the order's current
+price when only the quantity is changing.
+
+## 5. `RithmicAdvancedBracketOrder` is gone
+
+`RithmicBracketOrder` now carries every venue-native field the advanced type did —
+trailing stops, break-even, timed release and cancel, if-touched entry. Call
+`place_bracket_order` instead of the removed `place_advanced_bracket_order`.
+
+Which fields you rename depends on which type you were using — 2.0.0 had both, and
+they did not agree.
+
+**Coming from the plain `RithmicBracketOrder`:** the tick fields change name *and*
+type. `profit_ticks: i32` becomes `target_ticks: Vec<i32>`, and `stop_ticks: i32`
+becomes `stop_ticks: Vec<i32>` — same name, new type. Reads need an index:
+`bracket.stop_ticks[0]` where you had `bracket.stop_ticks`.
+
+**Coming from `RithmicAdvancedBracketOrder`:** `target_quantity`, `target_ticks`,
+`stop_quantity` and `stop_ticks` keep both their names and their `Vec<i32>` types.
+Field access ports over unchanged.
+
+Either way:
+
+- The single-value **setters** are renamed: `.profit_ticks(n)` is now `.target(n)`,
+  `.stop_ticks(n)` is now `.stop(n)`.
+- `.target(n)`/`.stop(n)` size their leg from the entry quantity at the moment
+  they are called, so call `.quantity()` first — otherwise `build()` rejects the
+  zero-sized leg. The plural `.targets(..)`/`.stops(..)` take explicit
+  `(quantity, ticks)` pairs and can be called in any order.
+- `bracket_type` is now `Option<BracketType>`. Left unset, `build()` derives it
+  from the exit legs present and omits it when there are none.
+
+That last point changes the wire for a target-only bracket: it now sends
+`TARGET_ONLY_STATIC`. At 2.0.0 the plain `RithmicBracketOrder` always sent
+`TargetAndStopStatic`, whatever legs you gave it, because its conversion into the
+advanced type hardcoded that value. Set `.bracket_type(..)` to override;
+`validate()` rejects a value that does not match the legs supplied.
+
+## 6. Order calls take command structs
+
+`cancel_all_orders()` now takes a `RithmicCancelAllOrders`, and
+`exit_position(symbol, exchange)` now takes a `RithmicExitPosition`, matching every
+other order call.
+
+Origination is a field on the command rather than a handle argument, set with
+`.manual_or_auto(..)`. It defaults to `ManualOrAutoEntry::Auto` on every command
+type — set it explicitly on all of them or none, or one session will report two
+different originators.
+
+`adjust_target`/`adjust_stop` take a `RithmicBracketLevelAdjustment` instead of
+`(id, ticks)`. Its `level` field selects which bracket leg to adjust, and
+`level: None` keeps the old behavior.
+
+`load_volume_profile_minute_bars` takes a `VolumeProfileMinuteBarsRequest` instead
+of seven positional arguments, so fields Rithmic adds later land as setters rather
+than signature changes:
+
+```rust
+let request = VolumeProfileMinuteBarsRequest::new()
+    .symbol("ESM6")
+    .exchange("CME")
+    .bar_type_period(5)
+    .start_time_sec(start_ssboe)
+    .end_time_sec(end_ssboe)
+    .build()?;
+
+let bars = handle.load_volume_profile_minute_bars(request).await?;
+```
+
+`build()` requires a symbol, an exchange, a bar period of at least one minute, and
+a window whose end does not precede its start. The handle runs the same checks, so
+a request that skipped `build()` fails with `RithmicError::InvalidArgument` rather
+than reaching the server incomplete.
+
+`subscribe_account_rms_updates` gains a required `update_bits` parameter. Pass
+`vec![]` for the old behavior.
+
+## 7. Config gains a required `request_timeout`
+
+`RithmicConfig` has a required `request_timeout: Duration`. Build it with
+`RithmicConfig::builder(env)` or `RithmicConfigBuilder::from_env(env)`, which
+pre-fills from the same environment variables `RithmicConfig::from_env` reads so a
+single field can be overridden.
+
+The default is `DEFAULT_REQUEST_TIMEOUT`, 30 seconds, and
+`RITHMIC_REQUEST_TIMEOUT_SECS` sets it from the environment (plain digits only).
+
+A request whose response never arrives now fails with `RithmicError::RequestTimeout`
+instead of blocking its caller forever. Reconcile a timed-out order rather than
+re-sending it.
+
+## 8. Field and module changes
+
+| change | what to do |
+|---|---|
+| `RithmicModifyOrder::qty` renamed to `quantity` | rename field and setter |
+| `RithmicOrder::duration` is `TimeInForce`, not `Option<TimeInForce>` | unwrap; `None` already sent `Day`, so the wire is unchanged |
+| `ws` module is private | spell `rithmic_rs::ws::ConnectStrategy` as `rithmic_rs::ConnectStrategy` |
+| new `Option` fields on the command types | leave `None` to keep old behavior |
+
+The new fields are `trade_route` on `RithmicOrder`/`RithmicBracketOrder`/`RithmicOcoOrderLeg`;
+`trailing_stop` on `RithmicOcoOrderLeg`; `trigger_price`, `trail_by_ticks` and
+`if_touched` on `RithmicModifyOrder`; `window_name`, `release_at_*`, `cancel_at_*`,
+`cancel_after_secs` and `if_touched` on `RithmicOrder`; and `manual_or_auto` on
+every order command.
+
+## 9. Behavior changes that need no code change
+
+These compile as-is but change what goes on the wire or what the server records.
+
+- **Orders route off the exchange's published trade route** instead of a hardcoded
+  `"globex"`/`"simulator"`. `login()` reads the routes once and orders route off
+  that snapshot. With no route published and none set on the command, the order is
+  not sent and you get `RithmicError::NoTradeRoute`.
+- **`get_account_list` and `get_account_rms_info` may return fewer accounts.**
+  Requests used to carry a hardcoded `Trader` user type and no `fcm_id`/`ib_id`.
+  `login()` now scopes requests with the real login info, which also fixes FCM and
+  IB logins seeing no accounts at all.
+- **`cancel_all_orders` is attributed as `Auto`, not `Manual`.** Set
+  `.manual_or_auto(ManualOrAutoEntry::Manual)` on the command to keep the old
+  attribution.
+- **An order placed with an empty `user_tag` echoes back as `None`, not `Some("")`,**
+  because the field is no longer sent as `""`.
+- **An unrecognized `template_id` is no longer a decode failure.** It arrives as
+  `RithmicMessage::UnknownTemplate` with the body intact. Code matching
+  `RithmicMessage::Unknown` still compiles but no longer sees these frames —
+  `Unknown` now means only that a frame failed to decode.
+- **Reconnect delays are jittered** by a random factor in `[0.5, 1.5)`, applied
+  after the cap, so plants that lost the same connection no longer retry in
+  lockstep. The schedule is otherwise unchanged.
+
+## 10. Protos move to 0.89.0.0
+
+The bundled protos track R | Protocol API 0.89.0.0 (template version 5.42).
+
+`RithmicMessage::AccountListUpdates` is removed — Rithmic dropped
+`account_list_updates.proto` (template 354) from the pool and its release notes
+point to the account RMS updates stream instead. Subscribe with
+`subscribe_account_rms_updates` and match `RithmicMessage::AccountRmsUpdates`.
+
+Two `UserAccountUpdate` fields became strings: `update_type` and `access_type` are
+now `Option<String>` (values like `add_account`, `modify_account`), and the
+generated `UpdateType`/`AccessType` enums no longer exist.
+
+## Checklist
+
+- [ ] Replace struct literals and `..Default::default()` with `new()` + setters
+- [ ] Swap the generated enums for the crate-owned ones (section 2)
+- [ ] Rename the handle methods (section 3)
+- [ ] Wrap prices in `Some(..)`; pass `None` for market orders
+- [ ] Move off `RithmicAdvancedBracketOrder`
+- [ ] Convert loose-argument order calls to command structs
+- [ ] Build `RithmicConfig` through the builder; pick a `request_timeout`
+- [ ] Add a `_` arm to matches on generated enums
+- [ ] Handle `RithmicError::NoTradeRoute` and `RithmicError::RequestTimeout`
+- [ ] Re-check account lists if you rely on `get_account_list` returning everything
+- [ ] Decide whether `cancel_all_orders` should stay `Manual` — it is now `Auto`
+- [ ] Check target-only brackets: they now send `TARGET_ONLY_STATIC`
+- [ ] Confirm a trade route exists for every exchange you trade


### PR DESCRIPTION
Documentation only. No source changes, no version bump — `Cargo.toml` stays at
2.0.0 and the changelog section stays headed `[Unreleased]`.

## What changed

**`CHANGELOG.md`** — the `[Unreleased]` section went from 4311 words to 2728.
The cut is mostly maintainer rationale ("we chose X because Y") and long
before/after code blocks, which moved to the migration guide. Each major change
is now 2–3 lines with a pointer to the guide for the detail.

Two tables survived because they carry more per line than prose would: the 12
generated enums and their crate-owned replacements, and the 7 renamed handle
methods.

A new section sits above Breaking Changes: **Changes that compile but alter live
order flow.** Six changes need no code edit, so nothing points at them at build
time — trade-route selection, `cancel_all_orders` attribution, target-only
brackets, account-list scoping, unpriced market orders, and empty `user_tag`.

**`MIGRATING.md`** (new) — 10 sections organised by upgrade task rather than by
changelog category, plus a checklist. It ships with the crate; `cargo package
--list` confirms it.

## Accuracy fixes

Four claims in the existing text did not match the code:

- a `with_placement` builder setter that does not exist anywhere in the crate
- "reading `bracket.stop_ticks` still works" — true coming from
  `RithmicAdvancedBracketOrder`, false coming from the plain
  `RithmicBracketOrder`, where the field was `i32`. Both paths are now
  documented separately.
- "no signatures changed" on the handle renames — `adjust_target` also moved to
  a command struct
- "matches keep compiling" for the enum swap — the crate-owned enums are
  `#[non_exhaustive]` and one went from 4 to 6 variants

Also corrected: the removed-enum count (14, not 15, enumerated from
`git show v2.0.0:src/api.rs`) and `RmsUpdateBits`, which the text described as a
rename when it is new — `git grep RmsUpdateBits v2.0.0 -- src/` returns nothing.

Every code example in both files was checked against source.

## Known loose end

`MIGRATING.md` is titled "Migrating to 3.0.0", a version that does not exist
yet. It reads as forward-looking documentation; happy to make it neutral until
the bump.