### PR TITLE
feat(history): return whole replay windows instead of the first 10,000 records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,12 +163,16 @@ before the first run against a live account.
   `ProtocolError`.
 
 - **`load_ticks_all`, `load_tick_bars_all` and `load_time_bars_all`** — replay
-  loaders that auto-paginate. Rithmic truncates a large replay and puts a
-  `request_key` on its closing response; these follow each key until a page closes
-  without one. Resumption uses the server's key, not a timestamp restart, which
-  would skip or duplicate ticks sharing a timestamp at a page boundary. Set
-  `max_pages` to bound a runaway replay — `None` follows every page. The last
-  response still exposes its key through **`RithmicResponse::resume_key()`**.
+  loaders that return the whole window instead of the first 10,000 records.
+  A plain replay stops at 10,000 and says nothing about it: the closing response
+  of a truncated replay is byte-identical to a complete one's. These loaders set
+  `resume_bars` on the request, which lifts the cap, so one request covers the
+  window. The whole window is buffered before it returns, so a full 23-hour ES
+  session is roughly 800,000 records in memory.
+
+- **`resume_bars` on the replay requests.** `request_tick_bar_replay` and
+  `request_time_bar_replay` now take `user_max_count` and `resume_bars`, so a
+  caller building requests directly can cap or uncap a replay themselves.
 
 - **Per-order trade routes.** The new `trade_route` field on `RithmicOrder`,
   `RithmicBracketOrder` and `RithmicOcoOrderLeg` overrides the route the plant
@@ -285,6 +289,13 @@ before the first run against a live account.
   README samples show correct API usage. No API changed.
 
 ### Fixed
+
+- **Login declared template version `5.30`,** the version of the 0.84.0.0 protos
+  the crate used to bundle, while the bundled protos are now 0.89.0.0 / template
+  5.42. It declares `5.42`. The field is a client declaration rather than a
+  negotiation — Rithmic's own samples send `3.9`, and the server answers with its
+  own version whatever you send (`5.54` at the time of writing) — so this changes
+  no server behavior. It just stops the login misreporting what the crate speaks.
 
 - **Market orders were sent with `price = 0.0`,** and multi-leg OCO orders
   zero-filled `price` and `trigger_price`. Both now follow the all-or-none rule the

--- a/examples/bracket_order.rs
+++ b/examples/bracket_order.rs
@@ -107,7 +107,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Define the bracket order
     // Note: Update symbol to a valid front-month contract for your use case
     let bracket_order = RithmicBracketOrder::new()
-        .symbol("ESM6")
+        .symbol("ESU6")
         .exchange("CME")
         .quantity(1)
         .action(OrderSide::Buy)

--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Everywhere else, Ok doesn't mean it worked — check resp.error.
-    match handle.subscribe("ESM6", "CME").await {
+    match handle.subscribe("ESU6", "CME").await {
         Ok(resp) => match resp.error {
             Some(RithmicError::RequestRejected(err)) => warn!(
                 "subscribe rejected: {}",

--- a/examples/load_historical_bars.rs
+++ b/examples/load_historical_bars.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenvy::dotenv().ok();
     tracing_subscriber::fmt().init();
 
-    let symbol = env::var("SYMBOL").unwrap_or_else(|_| "ESM6".to_string());
+    let symbol = env::var("SYMBOL").unwrap_or_else(|_| "ESU6".to_string());
     let exchange = env::var("EXCHANGE").unwrap_or_else(|_| "CME".to_string());
     let start_time: i32 = env::var("START_TIME")
         .ok()
@@ -47,8 +47,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         symbol, start_time, end_time
     );
 
-    // `load_time_bars_all` follows Rithmic's resume keys, so a replay the
-    // server truncates comes back complete; `None` places no cap on the pages.
+    // `load_time_bars_all` sets `resume_bars`, which lifts the server's 10,000
+    // record cap, so the whole window arrives in one request. `load_time_bars`
+    // leaves the cap in place.
     let bars = handle
         .load_time_bars_all(
             symbol,
@@ -57,7 +58,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             5,
             start_time,
             end_time,
-            None,
         )
         .await?;
 

--- a/examples/load_historical_ticks.rs
+++ b/examples/load_historical_ticks.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenvy::dotenv().ok();
     tracing_subscriber::fmt().init();
 
-    let symbol = env::var("SYMBOL").unwrap_or_else(|_| "ESM6".to_string());
+    let symbol = env::var("SYMBOL").unwrap_or_else(|_| "ESU6".to_string());
     let exchange = env::var("EXCHANGE").unwrap_or_else(|_| "CME".to_string());
     let start_time: i32 = env::var("START_TIME")
         .ok()
@@ -46,10 +46,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         symbol, start_time, end_time
     );
 
-    // `load_ticks_all` follows Rithmic's resume keys, so a replay the server
-    // truncates comes back complete. `load_ticks` returns just the first page.
+    // `load_ticks_all` sets `resume_bars`, which lifts the server's 10,000
+    // record cap, so the whole window arrives in one request. `load_ticks`
+    // leaves the cap in place and returns at most 10,000 records.
     let ticks = handle
-        .load_ticks_all(symbol, exchange, start_time, end_time, None)
+        .load_ticks_all(symbol, exchange, start_time, end_time)
         .await?;
 
     info!("Received {} tick responses", ticks.len());

--- a/examples/reconnect.rs
+++ b/examples/reconnect.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let config = RithmicConfig::from_env(RithmicEnv::Demo)?;
     let mut subscriptions: HashSet<(String, String)> = HashSet::new();
-    let symbol = env::var("SYMBOL").unwrap_or_else(|_| "ESM6".to_string());
+    let symbol = env::var("SYMBOL").unwrap_or_else(|_| "ESU6".to_string());
     let exchange = env::var("EXCHANGE").unwrap_or_else(|_| "CME".to_string());
 
     subscriptions.insert((symbol, exchange));

--- a/examples/trade_routes.rs
+++ b/examples/trade_routes.rs
@@ -82,7 +82,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // `.trade_route(..)` to send on a route of your own, including one the
     // server never published.
     let order = RithmicOrder::new()
-        .symbol("ESM6")
+        .symbol("ESU6")
         .exchange("CME")
         .quantity(1)
         .transaction_type(OrderSide::Buy)

--- a/src/api/response.rs
+++ b/src/api/response.rs
@@ -65,13 +65,15 @@ impl RithmicResponse {
         self.rp_code().and_then(|c| c.get(1).map(String::as_str))
     }
 
-    /// The `request_key` a truncated bar replay carries on its closing response.
+    /// The `request_key` a bar replay carries, to pass to
+    /// [`resume_bars`](crate::RithmicHistoryPlantHandle::resume_bars).
     ///
-    /// Rithmic truncates large history replays; the closing response of a
-    /// truncated page carries a `request_key` to pass to
-    /// [`resume_bars`](crate::RithmicHistoryPlantHandle::resume_bars) for the
-    /// next page. Returns `None` when the replay is complete or the message is
-    /// not a bar replay response.
+    /// Returns `None` when the message is not a bar replay response, or when the
+    /// server sent no key — which, against Rithmic's live and demo systems, is
+    /// every replay tried so far, truncated or not. A truncated replay is
+    /// instead resumed by setting `resume_bars` on the original request, which
+    /// makes the server send the remaining records on that request; see
+    /// [`load_ticks_all`](crate::RithmicHistoryPlantHandle::load_ticks_all).
     pub fn resume_key(&self) -> Option<&str> {
         let key = match &self.message {
             RithmicMessage::ResponseTickBarReplay(m) => m.request_key.as_deref(),

--- a/src/api/sender_api.rs
+++ b/src/api/sender_api.rs
@@ -45,6 +45,13 @@ use crate::{
     types::{EasyToBorrowRequest, FillHistoryRange, OrderType, RmsUpdateBits},
 };
 
+/// The protocol template version sent on every login.
+///
+/// It names the `.proto` set in `src/raw-proto/`, which the R | Protocol API
+/// 0.89.0.0 change log labels template 5.42. Bump it whenever those protos are
+/// regenerated against a newer release.
+pub(crate) const TEMPLATE_VERSION: &str = "5.42";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum LoginUserType {
     Fcm,
@@ -193,7 +200,7 @@ impl RithmicSenderApi {
 
         let req = RequestLogin {
             template_id: 10,
-            template_version: Some("5.30".into()),
+            template_version: Some(TEMPLATE_VERSION.into()),
             user: Some(user.to_string()),
             password: Some(password.to_string()),
             app_name: Some(self.app_name.clone()),
@@ -1018,10 +1025,15 @@ impl RithmicSenderApi {
     ///   individual ticks, `"5"` for 5-tick bars)
     /// * `start_index_sec` - Start time as a Unix timestamp (seconds)
     /// * `finish_index_sec` - End time as a Unix timestamp (seconds)
+    /// * `user_max_count` - cap on records returned; `None` leaves the server's
+    ///   own cap to apply silently
+    /// * `resume_bars` - `Some(true)` lifts the server's 10,000 record cap so the
+    ///   whole window replays in one response stream
     ///
     /// # Returns
     ///
     /// A tuple containing the request buffer and the message id.
+    #[allow(clippy::too_many_arguments)]
     pub fn request_tick_bar_replay(
         &mut self,
         symbol: &str,
@@ -1029,6 +1041,8 @@ impl RithmicSenderApi {
         bar_type_specifier: &str,
         start_index_sec: i32,
         finish_index_sec: i32,
+        user_max_count: Option<i32>,
+        resume_bars: Option<bool>,
     ) -> (Vec<u8>, String) {
         let id = self.get_next_message_id();
 
@@ -1043,6 +1057,8 @@ impl RithmicSenderApi {
             finish_index: Some(finish_index_sec),
             direction: Some(Direction::First.into()),
             time_order: Some(TimeOrder::Forwards.into()),
+            user_max_count,
+            resume_bars,
             user_msg: vec![id.clone()],
             ..Default::default()
         };
@@ -1060,10 +1076,15 @@ impl RithmicSenderApi {
     /// * `bar_type_period` - The period for the bar type (e.g., 1 for 1-minute bars, 5 for 5-minute bars)
     /// * `start_index_sec` - unix seconds
     /// * `finish_index_sec` - unix seconds
+    /// * `user_max_count` - cap on records returned; `None` leaves the server's
+    ///   own cap to apply silently
+    /// * `resume_bars` - `Some(true)` lifts the server's 10,000 record cap so the
+    ///   whole window replays in one response stream
     ///
     /// # Returns
     ///
     /// A tuple containing the request buffer and the message id
+    #[allow(clippy::too_many_arguments)]
     pub fn request_time_bar_replay(
         &mut self,
         symbol: &str,
@@ -1072,6 +1093,8 @@ impl RithmicSenderApi {
         bar_type_period: i32,
         start_index_sec: i32,
         finish_index_sec: i32,
+        user_max_count: Option<i32>,
+        resume_bars: Option<bool>,
     ) -> (Vec<u8>, String) {
         let id = self.get_next_message_id();
 
@@ -1085,6 +1108,8 @@ impl RithmicSenderApi {
             finish_index: Some(finish_index_sec),
             direction: Some(request_time_bar_replay::Direction::First.into()),
             time_order: Some(request_time_bar_replay::TimeOrder::Forwards.into()),
+            user_max_count,
+            resume_bars,
             user_msg: vec![id.clone()],
             ..Default::default()
         };

--- a/src/plants/history_plant.rs
+++ b/src/plants/history_plant.rs
@@ -45,6 +45,8 @@ pub(crate) enum HistoryPlantCommand {
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
         start_time_sec: i32,
         symbol: String,
+        user_max_count: Option<i32>,
+        resume_bars: Option<bool>,
     },
     LoadTimeBars {
         bar_type: BarType,
@@ -54,6 +56,8 @@ pub(crate) enum HistoryPlantCommand {
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
         start_time_sec: i32,
         symbol: String,
+        user_max_count: Option<i32>,
+        resume_bars: Option<bool>,
     },
     LoadVolumeProfileMinuteBars {
         request: VolumeProfileMinuteBarsRequest,
@@ -82,57 +86,112 @@ pub(crate) enum HistoryPlantCommand {
     },
 }
 
-/// The RithmicHistoryPlant provides access to historical market data through the Rithmic API.
+/// Historical market data from Rithmic: past ticks and past bars.
 ///
-/// It allows applications to retrieve historical tick data and time bar data for specific instruments and time ranges
-/// from Rithmic's history database.
+/// Connect once, log in, then ask for whatever window of history you need. The
+/// plant runs on its own background task; you talk to it through a
+/// [`RithmicHistoryPlantHandle`], which is cheap to clone and safe to share
+/// between tasks.
+///
+/// # Getting data out
+///
+/// Every loader returns a `Vec<RithmicResponse>`. Each entry wraps a
+/// [`RithmicMessage`], so you match on it to get at the numbers:
+///
+/// ```no_run
+/// # use rithmic_rs::{RithmicResponse, rti::messages::RithmicMessage};
+/// # fn demo(ticks: Vec<RithmicResponse>) {
+/// for response in &ticks {
+///     if let RithmicMessage::ResponseTickBarReplay(tick) = &response.message {
+///         println!("{:?} @ {:?}", tick.close_price, tick.data_bar_ssboe);
+///     }
+/// }
+/// # }
+/// ```
+///
+/// Three things to know about the shape of that `Vec`:
+///
+/// - **The last entry is an end marker, not data.** Rithmic closes every replay
+///   with a response that carries no bar. Matching on the message type as above
+///   skips it; counting `responses.len()` does not, so subtract one if you want
+///   a record count.
+/// - **Times are Unix seconds as `i32`,** both going in and coming back. This is
+///   Rithmic's own type and it overflows in 2038.
+/// - **Tick bars carry two timestamps.** `data_bar_ssboe` and `data_bar_usecs`
+///   are two-element arrays holding the bar's open and close: index 0 is when
+///   the bar started, index 1 is when it ended. For one-tick bars both describe
+///   the same trade. See [`load_ticks`](RithmicHistoryPlantHandle::load_ticks)
+///   for a quirk in the first record's open.
+///
+/// # Which loader do I want?
+///
+/// | You want | Use | Records |
+/// |---|---|---|
+/// | Individual trades | [`load_ticks`] / [`load_ticks_all`] | one per trade |
+/// | Bars of N trades | [`load_tick_bars`] / [`load_tick_bars_all`] | one per N trades |
+/// | Bars of a fixed duration | [`load_time_bars`] / [`load_time_bars_all`] | one per interval |
+/// | Volume traded at each price | [`load_volume_profile_minute_bars`] | one per minute |
+///
+/// The plain methods return at most 10,000 records, because that is where
+/// Rithmic cuts a replay off. The `_all` methods lift that cap and return the
+/// whole window. Prefer an `_all` method unless you specifically want a bounded
+/// result — see [`load_ticks_all`] for why, and for the memory that costs.
+///
+/// [`load_ticks`]: RithmicHistoryPlantHandle::load_ticks
+/// [`load_ticks_all`]: RithmicHistoryPlantHandle::load_ticks_all
+/// [`load_tick_bars`]: RithmicHistoryPlantHandle::load_tick_bars
+/// [`load_tick_bars_all`]: RithmicHistoryPlantHandle::load_tick_bars_all
+/// [`load_time_bars`]: RithmicHistoryPlantHandle::load_time_bars
+/// [`load_time_bars_all`]: RithmicHistoryPlantHandle::load_time_bars_all
+/// [`load_volume_profile_minute_bars`]: RithmicHistoryPlantHandle::load_volume_profile_minute_bars
 ///
 /// # Example
 ///
 /// ```no_run
 /// use rithmic_rs::{
-///     RithmicConfig, RithmicEnv, ConnectStrategy, RithmicHistoryPlant,
+///     ConnectStrategy, RithmicConfig, RithmicEnv, RithmicHistoryPlant,
+///     rti::messages::RithmicMessage,
 /// };
-/// use tokio::time::{sleep, Duration};
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     // Step 1: Create connection configuration
+///     // Credentials come from the environment; see examples/.env.blank.
 ///     let config = RithmicConfig::from_env(RithmicEnv::Demo)?;
 ///
-///     // Step 2: Connect to the history plant
-///     let history_plant = RithmicHistoryPlant::connect(&config, ConnectStrategy::Retry).await?;
-///
-///     // Step 3: Get a handle to interact with the plant
-///     let mut handle = history_plant.get_handle();
-///
-///     // Step 4: Login to the history plant
+///     let plant = RithmicHistoryPlant::connect(&config, ConnectStrategy::Retry).await?;
+///     let handle = plant.get_handle();
 ///     handle.login().await?;
 ///
-///     // Step 5: Load historical tick data
 ///     let now = std::time::SystemTime::now()
-///         .duration_since(std::time::UNIX_EPOCH)
-///         .unwrap()
+///         .duration_since(std::time::UNIX_EPOCH)?
 ///         .as_secs() as i32;
 ///
-///     // Get the last hour of data
-///     let one_hour_ago = now - 3600;
+///     // Every trade in the last hour, however many that is.
+///     let ticks = handle
+///         .load_ticks_all("ESU6".to_string(), "CME".to_string(), now - 3600, now)
+///         .await?;
 ///
-///     let ticks = handle.load_ticks(
-///         "ESH6".to_string(),
-///         "CME".to_string(),
-///         one_hour_ago,
-///         now,
-///     ).await?;
+///     for response in &ticks {
+///         if let RithmicMessage::ResponseTickBarReplay(tick) = &response.message {
+///             println!("{:?}", tick.close_price);
+///         }
+///     }
 ///
-///     println!("Received {} tick responses", ticks.len());
-///
-///     // Step 6: Disconnect when done
 ///     handle.disconnect().await?;
-///
 ///     Ok(())
 /// }
 /// ```
+///
+/// # Runnable examples
+///
+/// - [`load_historical_ticks.rs`](https://github.com/pbeets/rithmic-rs/blob/main/examples/load_historical_ticks.rs)
+///   — load a window of trades
+/// - [`load_historical_bars.rs`](https://github.com/pbeets/rithmic-rs/blob/main/examples/load_historical_bars.rs)
+///   — load five-minute bars
+/// - [`reconnect.rs`](https://github.com/pbeets/rithmic-rs/blob/main/examples/reconnect.rs)
+///   — surviving a dropped connection
+/// - [`.env.blank`](https://github.com/pbeets/rithmic-rs/blob/main/examples/.env.blank)
+///   — the credentials the examples expect
 #[derive(Debug)]
 pub struct RithmicHistoryPlant {
     pub(crate) connection_handle: JoinHandle<()>,
@@ -290,6 +349,8 @@ impl PlantActor for HistoryPlant {
                 start_time_sec,
                 end_time_sec,
                 response_sender,
+                user_max_count,
+                resume_bars,
             } => {
                 let (tick_bar_replay_buf, id) =
                     self.core.rithmic_sender_api.request_tick_bar_replay(
@@ -298,6 +359,8 @@ impl PlantActor for HistoryPlant {
                         &bar_type_specifier,
                         start_time_sec,
                         end_time_sec,
+                        user_max_count,
+                        resume_bars,
                     );
 
                 self.core
@@ -312,6 +375,8 @@ impl PlantActor for HistoryPlant {
                 response_sender,
                 start_time_sec,
                 symbol,
+                user_max_count,
+                resume_bars,
             } => {
                 let (time_bar_replay_buf, id) =
                     self.core.rithmic_sender_api.request_time_bar_replay(
@@ -321,6 +386,8 @@ impl PlantActor for HistoryPlant {
                         bar_type_period,
                         start_time_sec,
                         end_time_sec,
+                        user_max_count,
+                        resume_bars,
                     );
 
                 self.core
@@ -402,11 +469,19 @@ impl PlantActor for HistoryPlant {
     }
 }
 
-/// Handle for sending commands to a [`RithmicHistoryPlant`] and receiving historical data.
+/// The way you talk to a [`RithmicHistoryPlant`].
 ///
-/// Obtained from [`RithmicHistoryPlant::connect()`]. Use the methods on this handle to
-/// log in and request historical tick, time-bar, or volume data. Streamed responses
-/// arrive on [`subscription_receiver`](Self::subscription_receiver).
+/// Get one from [`RithmicHistoryPlant::get_handle`], call
+/// [`login`](Self::login), then use the `load_*` methods to pull history. The
+/// handle is cheap to clone and can be shared across tasks; every clone talks to
+/// the same connection.
+///
+/// Live bar subscriptions are different from the loaders: `subscribe_*` returns
+/// only an acknowledgement, and the bars arrive on
+/// [`subscription_receiver`](Self::subscription_receiver).
+///
+/// See [`RithmicHistoryPlant`] for what the responses look like and which loader
+/// to reach for.
 pub struct RithmicHistoryPlantHandle {
     sender: mpsc::Sender<HistoryPlantCommand>,
     subscription_sender: broadcast::Sender<RithmicResponse>,
@@ -544,19 +619,34 @@ impl RithmicHistoryPlantHandle {
         let _ = self.sender.try_send(HistoryPlantCommand::Abort);
     }
 
-    /// Load historical tick data for a specific symbol and time range.
+    /// Load individual trades for a symbol over a time window.
     ///
-    /// This is a convenience wrapper around [`load_tick_bars`](Self::load_tick_bars) with
-    /// `bar_length = 1`, so each response contains a single tick.
+    /// Each response is one trade. This returns **at most 10,000 trades** — the
+    /// limit Rithmic puts on a single replay — and gives no sign when it has cut
+    /// the result short. For a window that may hold more, use
+    /// [`load_ticks_all`](Self::load_ticks_all).
+    ///
+    /// # A quirk worth knowing
+    ///
+    /// Rithmic stamps the **first** record's open time with the second you asked
+    /// for, at microsecond 0, rather than the trade's own time. Since the request
+    /// is second-granular, that open can read up to a second early. The close
+    /// time (index 1 of `data_bar_ssboe` / `data_bar_usecs`) is always the real
+    /// trade time, so prefer it if you are ordering or bucketing trades. The
+    /// crate passes the values through untouched; what to do about the open is
+    /// yours to decide.
     ///
     /// # Arguments
-    /// * `symbol` - The trading symbol (e.g., `"ESH6"`)
-    /// * `exchange` - The exchange code (e.g., `"CME"`)
-    /// * `start_time_sec` - Start time as a Unix timestamp (seconds)
-    /// * `end_time_sec` - End time as a Unix timestamp (seconds)
+    /// * `symbol` - The trading symbol, e.g. `"ESU6"`
+    /// * `exchange` - The exchange code, e.g. `"CME"`
+    /// * `start_time_sec` - Window start, Unix seconds
+    /// * `end_time_sec` - Window end, Unix seconds
     ///
     /// # Returns
-    /// The historical tick data responses, or a [`RithmicError`] on failure.
+    /// One response per trade, followed by an end marker carrying no data.
+    ///
+    /// # Example
+    /// See [`load_historical_ticks.rs`](https://github.com/pbeets/rithmic-rs/blob/main/examples/load_historical_ticks.rs).
     pub async fn load_ticks(
         &self,
         symbol: String,
@@ -568,20 +658,24 @@ impl RithmicHistoryPlantHandle {
             .await
     }
 
-    /// Load historical tick bar data for a specific symbol and time range.
+    /// Load bars that each aggregate a fixed number of trades.
     ///
-    /// Each response contains a bar that aggregates `bar_length` ticks. For
-    /// example, `bar_length = 5` returns 5-tick bars.
+    /// `bar_length = 5` gives one bar per five trades. `bar_length = 1` gives one
+    /// bar per trade, which is what [`load_ticks`](Self::load_ticks) is.
+    ///
+    /// Returns **at most 10,000 bars**, with no sign when the result was cut
+    /// short. Use [`load_tick_bars_all`](Self::load_tick_bars_all) for the whole
+    /// window.
     ///
     /// # Arguments
-    /// * `symbol` - The trading symbol (e.g., `"ESH6"`)
-    /// * `exchange` - The exchange code (e.g., `"CME"`)
-    /// * `bar_length` - Number of ticks per bar (must be &ge; 1)
-    /// * `start_time_sec` - Start time as a Unix timestamp (seconds)
-    /// * `end_time_sec` - End time as a Unix timestamp (seconds)
+    /// * `symbol` - The trading symbol, e.g. `"ESU6"`
+    /// * `exchange` - The exchange code, e.g. `"CME"`
+    /// * `bar_length` - Trades per bar, at least 1
+    /// * `start_time_sec` - Window start, Unix seconds
+    /// * `end_time_sec` - Window end, Unix seconds
     ///
     /// # Returns
-    /// The historical tick bar data responses, or a [`RithmicError`] on failure.
+    /// One response per bar, followed by an end marker carrying no data.
     ///
     /// # Errors
     /// * [`RithmicError::InvalidArgument`] if `bar_length` is 0.
@@ -600,6 +694,30 @@ impl RithmicHistoryPlantHandle {
             ));
         }
 
+        self.tick_bar_page(
+            symbol,
+            exchange,
+            bar_length,
+            start_time_sec,
+            end_time_sec,
+            None,
+            None,
+        )
+        .await
+    }
+
+    /// One tick bar replay request.
+    #[allow(clippy::too_many_arguments)]
+    async fn tick_bar_page(
+        &self,
+        symbol: String,
+        exchange: String,
+        bar_length: u32,
+        start_time_sec: i32,
+        end_time_sec: i32,
+        user_max_count: Option<i32>,
+        resume_bars: Option<bool>,
+    ) -> Result<Vec<RithmicResponse>, RithmicError> {
         let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, RithmicError>>();
 
         let command = HistoryPlantCommand::LoadTicks {
@@ -609,6 +727,8 @@ impl RithmicHistoryPlantHandle {
             start_time_sec,
             end_time_sec,
             response_sender: tx,
+            user_max_count,
+            resume_bars,
         };
 
         let _ = self.sender.send(command).await;
@@ -616,40 +736,50 @@ impl RithmicHistoryPlantHandle {
         await_all_responses(rx).await
     }
 
-    /// Load historical tick data, following resume keys until the replay completes.
+    /// Load every trade in the window, however many there are.
     ///
-    /// This is a convenience wrapper around [`load_tick_bars_all`](Self::load_tick_bars_all)
-    /// with `bar_length = 1`, so each response contains a single tick.
-    /// See there for how truncation and `max_pages` behave.
+    /// Same as [`load_ticks`](Self::load_ticks) but without the 10,000 record
+    /// limit, so you get the whole window in one call. This is usually what you
+    /// want: an hour of a liquid contract runs well past 10,000 trades, and the
+    /// capped version would silently hand you only the beginning of it.
+    ///
+    /// # How it works
+    ///
+    /// A normal replay stops at 10,000 records and does not say so — the closing
+    /// response looks the same whether it was cut short or not. Setting Rithmic's
+    /// `resume_bars` flag on the request lifts that limit, and the server sends
+    /// the rest on the same request. There is no paging and no second call.
+    ///
+    /// # Cost
+    ///
+    /// The whole window is collected in memory before it returns. A full 23-hour
+    /// ES session is roughly 800,000 records, so ask for the window you actually
+    /// need rather than a day at a time.
+    ///
+    /// The first record's open time carries the same quirk described on
+    /// [`load_ticks`](Self::load_ticks).
+    ///
+    /// # Example
+    /// See [`load_historical_ticks.rs`](https://github.com/pbeets/rithmic-rs/blob/main/examples/load_historical_ticks.rs).
     pub async fn load_ticks_all(
         &self,
         symbol: String,
         exchange: String,
         start_time_sec: i32,
         end_time_sec: i32,
-        max_pages: Option<usize>,
     ) -> Result<Vec<RithmicResponse>, RithmicError> {
-        self.load_tick_bars_all(symbol, exchange, 1, start_time_sec, end_time_sec, max_pages)
+        self.load_tick_bars_all(symbol, exchange, 1, start_time_sec, end_time_sec)
             .await
     }
 
-    /// Load historical tick bar data, following resume keys until the replay completes.
+    /// Load every fixed-trade-count bar in the window, however many there are.
     ///
-    /// Rithmic truncates a large replay and puts a `request_key` on its closing
-    /// response. Where [`load_tick_bars`](Self::load_tick_bars) returns such a
-    /// page as-is, this method keeps issuing [`resume_bars`](Self::resume_bars)
-    /// until a page closes without a key, and returns every page's responses in
-    /// order.
-    ///
-    /// `max_pages` caps how many pages are fetched; `None` means unbounded,
-    /// and the initial page always loads, so `Some(0)` behaves like `Some(1)`.
-    /// When the cap cuts the replay short, the last returned response still
-    /// carries its resume key — check [`RithmicResponse::resume_key`] and
-    /// continue manually with [`resume_bars`](Self::resume_bars).
+    /// The uncapped form of [`load_tick_bars`](Self::load_tick_bars). See
+    /// [`load_ticks_all`](Self::load_ticks_all) for how the cap is lifted and
+    /// what it costs in memory.
     ///
     /// # Errors
-    /// An error on any page — including a [`RithmicError::RequestTimeout`] on a
-    /// stalled resume — discards the pages already gathered.
+    /// * [`RithmicError::InvalidArgument`] if `bar_length` is 0.
     pub async fn load_tick_bars_all(
         &self,
         symbol: String,
@@ -657,23 +787,34 @@ impl RithmicHistoryPlantHandle {
         bar_length: u32,
         start_time_sec: i32,
         end_time_sec: i32,
-        max_pages: Option<usize>,
     ) -> Result<Vec<RithmicResponse>, RithmicError> {
-        let mut responses = self
-            .load_tick_bars(symbol, exchange, bar_length, start_time_sec, end_time_sec)
-            .await?;
+        if bar_length == 0 {
+            return Err(RithmicError::InvalidArgument(
+                "bar_length must be at least 1".to_string(),
+            ));
+        }
 
-        self.follow_resume_keys(&mut responses, max_pages).await?;
-
-        Ok(responses)
+        self.tick_bar_page(
+            symbol,
+            exchange,
+            bar_length,
+            start_time_sec,
+            end_time_sec,
+            None,
+            Some(true),
+        )
+        .await
     }
 
-    /// Load historical time bar data, following resume keys until the replay completes.
+    /// Load every time bar in the window, however many there are.
     ///
-    /// The paginating counterpart of [`load_time_bars`](Self::load_time_bars);
-    /// truncation, `max_pages` and errors behave as on
-    /// [`load_tick_bars_all`](Self::load_tick_bars_all).
-    #[allow(clippy::too_many_arguments)]
+    /// The uncapped form of [`load_time_bars`](Self::load_time_bars). One-second
+    /// bars pass 10,000 in under three hours, so this is the one you usually
+    /// want. See [`load_ticks_all`](Self::load_ticks_all) for how the cap is
+    /// lifted and what it costs in memory.
+    ///
+    /// # Example
+    /// See [`load_historical_bars.rs`](https://github.com/pbeets/rithmic-rs/blob/main/examples/load_historical_bars.rs).
     pub async fn load_time_bars_all(
         &self,
         symbol: String,
@@ -682,75 +823,46 @@ impl RithmicHistoryPlantHandle {
         bar_type_period: i32,
         start_time_sec: i32,
         end_time_sec: i32,
-        max_pages: Option<usize>,
     ) -> Result<Vec<RithmicResponse>, RithmicError> {
-        let mut responses = self
-            .load_time_bars(
-                symbol,
-                exchange,
-                bar_type,
-                bar_type_period,
-                start_time_sec,
-                end_time_sec,
-            )
-            .await?;
-
-        self.follow_resume_keys(&mut responses, max_pages).await?;
-
-        Ok(responses)
+        self.time_bar_page(
+            symbol,
+            exchange,
+            bar_type,
+            bar_type_period,
+            start_time_sec,
+            end_time_sec,
+            None,
+            Some(true),
+        )
+        .await
     }
 
-    /// Append resumed pages to `responses` until one closes without a resume key
-    /// or `max_pages` pages have been fetched.
-    //
-    // Pages resume with the server's `request_key`, never by re-requesting from
-    // the last item's timestamp. A tick replay routinely carries several ticks
-    // on one timestamp — one aggressor filling several resting orders stamps
-    // every fill identically — so a page boundary can fall mid-timestamp, and a
-    // timestamp restart would either skip the rest of that instant or duplicate
-    // what already arrived. Only the server's own cursor resumes exactly.
-    async fn follow_resume_keys(
-        &self,
-        responses: &mut Vec<RithmicResponse>,
-        max_pages: Option<usize>,
-    ) -> Result<(), RithmicError> {
-        let mut pages: usize = 1;
-
-        while max_pages.is_none_or(|cap| pages < cap) {
-            let Some(key) = responses
-                .last()
-                .and_then(|r| r.resume_key().map(String::from))
-            else {
-                break;
-            };
-
-            let page = self.resume_bars(key).await?;
-
-            // An empty page would leave the old closing response — and its
-            // key — as `last()`, so break rather than resume it forever.
-            if page.is_empty() {
-                break;
-            }
-
-            pages += 1;
-            responses.extend(page);
-        }
-
-        Ok(())
-    }
-
-    /// Load historical time bar data for a specific symbol and time range
+    /// Load bars covering a fixed span of time each.
+    ///
+    /// `bar_type` picks the unit — second, minute, day or week — and
+    /// `bar_type_period` how many of them per bar. `MinuteBar` with a period of
+    /// 5 gives five-minute bars.
+    ///
+    /// Each bar carries a `marker`, which is the time the bar **closed**, plus
+    /// its open, high, low, close, volume and trade count.
+    ///
+    /// Returns **at most 10,000 bars**, with no sign when the result was cut
+    /// short. Use [`load_time_bars_all`](Self::load_time_bars_all) for the whole
+    /// window.
     ///
     /// # Arguments
-    /// * `symbol` - The trading symbol (e.g., "ESH6")
-    /// * `exchange` - The exchange code (e.g., "CME")
-    /// * `bar_type` - The type of time bar (SecondBar, MinuteBar, DailyBar, WeeklyBar)
-    /// * `bar_type_period` - The period for the bar type (e.g., 1 for 1-minute bars, 5 for 5-minute bars)
-    /// * `start_time_sec` - Start time in Unix timestamp (seconds)
-    /// * `end_time_sec` - End time in Unix timestamp (seconds)
+    /// * `symbol` - The trading symbol, e.g. `"ESU6"`
+    /// * `exchange` - The exchange code, e.g. `"CME"`
+    /// * `bar_type` - `SecondBar`, `MinuteBar`, `DailyBar` or `WeeklyBar`
+    /// * `bar_type_period` - How many of those units per bar
+    /// * `start_time_sec` - Window start, Unix seconds
+    /// * `end_time_sec` - Window end, Unix seconds
     ///
     /// # Returns
-    /// The historical time bar data responses or an error message
+    /// One response per bar, followed by an end marker carrying no data.
+    ///
+    /// # Example
+    /// See [`load_historical_bars.rs`](https://github.com/pbeets/rithmic-rs/blob/main/examples/load_historical_bars.rs).
     pub async fn load_time_bars(
         &self,
         symbol: String,
@@ -759,6 +871,32 @@ impl RithmicHistoryPlantHandle {
         bar_type_period: i32,
         start_time_sec: i32,
         end_time_sec: i32,
+    ) -> Result<Vec<RithmicResponse>, RithmicError> {
+        self.time_bar_page(
+            symbol,
+            exchange,
+            bar_type,
+            bar_type_period,
+            start_time_sec,
+            end_time_sec,
+            None,
+            None,
+        )
+        .await
+    }
+
+    /// One time bar replay request.
+    #[allow(clippy::too_many_arguments)]
+    async fn time_bar_page(
+        &self,
+        symbol: String,
+        exchange: String,
+        bar_type: BarType,
+        bar_type_period: i32,
+        start_time_sec: i32,
+        end_time_sec: i32,
+        user_max_count: Option<i32>,
+        resume_bars: Option<bool>,
     ) -> Result<Vec<RithmicResponse>, RithmicError> {
         let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, RithmicError>>();
 
@@ -770,6 +908,8 @@ impl RithmicHistoryPlantHandle {
             response_sender: tx,
             start_time_sec,
             symbol,
+            user_max_count,
+            resume_bars,
         };
 
         let _ = self.sender.send(command).await;
@@ -777,10 +917,14 @@ impl RithmicHistoryPlantHandle {
         await_all_responses(rx).await
     }
 
-    /// Load volume profile minute bars for the window `request` describes.
+    /// Load minute bars that break volume down by price.
+    ///
+    /// Each bar reports how much traded at each price during that minute, rather
+    /// than a single volume figure — useful for building a volume profile. Build
+    /// the `request` with [`VolumeProfileMinuteBarsRequest`].
     ///
     /// # Returns
-    /// The volume profile minute bar responses or an error message
+    /// One response per minute, followed by an end marker carrying no data.
     pub async fn load_volume_profile_minute_bars(
         &self,
         request: VolumeProfileMinuteBarsRequest,
@@ -798,6 +942,14 @@ impl RithmicHistoryPlantHandle {
     }
 
     /// Resume a bars request from a previous response's `request_key`.
+    ///
+    /// Rithmic's release notes introduce `RequestResumeBars` as the way to pull
+    /// the chunks a truncated replay left out, but the server has not been seen
+    /// to hand out a `request_key` to call it with — see
+    /// [`RithmicResponse::resume_key`]. Setting `resume_bars` on the replay
+    /// request is what actually lifts the cap, which is what
+    /// [`load_ticks_all`](Self::load_ticks_all) does. This stays for a server
+    /// that does send a key.
     ///
     /// # Arguments
     /// * `request_key` - The `request_key` carried on the previous response
@@ -820,17 +972,19 @@ impl RithmicHistoryPlantHandle {
         await_all_responses(rx).await
     }
 
-    /// Subscribe to live time bar updates
+    /// Start or stop a live feed of time bars as they complete.
+    ///
+    /// Unlike the loaders, this does not return the bars. It returns the
+    /// server's acknowledgement, and the bars themselves then arrive on
+    /// [`subscription_receiver`](Self::subscription_receiver) as they close.
+    /// Pass `Request::Unsubscribe` to stop.
     ///
     /// # Arguments
-    /// * `symbol` - The trading symbol (e.g., "ESH6")
-    /// * `exchange` - The exchange code (e.g., "CME")
-    /// * `bar_type` - The type of time bar (SecondBar, MinuteBar, DailyBar, WeeklyBar)
-    /// * `bar_type_period` - The period for the bar type (e.g., 1 for 1-minute bars)
-    /// * `request` - Subscribe or Unsubscribe
-    ///
-    /// # Returns
-    /// The subscription response or an error message
+    /// * `symbol` - The trading symbol, e.g. `"ESU6"`
+    /// * `exchange` - The exchange code, e.g. `"CME"`
+    /// * `bar_type` - `SecondBar`, `MinuteBar`, `DailyBar` or `WeeklyBar`
+    /// * `bar_type_period` - How many of those units per bar
+    /// * `request` - `Subscribe` or `Unsubscribe`
     pub async fn subscribe_time_bar_updates(
         &self,
         symbol: &str,
@@ -855,18 +1009,19 @@ impl RithmicHistoryPlantHandle {
         await_first_response(rx).await
     }
 
-    /// Subscribe to live tick bar updates
+    /// Start or stop a live feed of tick bars as they complete.
+    ///
+    /// Works like [`subscribe_time_bar_updates`](Self::subscribe_time_bar_updates):
+    /// the acknowledgement comes back from this call, the bars arrive on
+    /// [`subscription_receiver`](Self::subscription_receiver).
     ///
     /// # Arguments
-    /// * `symbol` - The trading symbol (e.g., "ESH6")
-    /// * `exchange` - The exchange code (e.g., "CME")
-    /// * `bar_type` - The type of tick bar
-    /// * `bar_sub_type` - Sub-type of the bar
-    /// * `bar_type_specifier` - Specifier for the bar (e.g., "1" for 1-tick bars)
-    /// * `request` - Subscribe or Unsubscribe
-    ///
-    /// # Returns
-    /// The subscription response or an error message
+    /// * `symbol` - The trading symbol, e.g. `"ESU6"`
+    /// * `exchange` - The exchange code, e.g. `"CME"`
+    /// * `bar_type` - The kind of tick bar
+    /// * `bar_sub_type` - Regular or custom aggregation
+    /// * `bar_type_specifier` - Trades per bar, as a string, e.g. `"1"`
+    /// * `request` - `Subscribe` or `Unsubscribe`
     pub async fn subscribe_tick_bar_updates(
         &self,
         symbol: &str,

--- a/src/plants/history_plant/tests.rs
+++ b/src/plants/history_plant/tests.rs
@@ -8,8 +8,7 @@ use crate::{
         assert_sent_while_open, assert_wire_silent, read_wire_request, write_wire_response,
     },
     rti::{
-        RequestResumeBars, RequestTickBarReplay, RequestTimeBarReplay, ResponseTickBarReplay,
-        ResponseTimeBarReplay,
+        RequestTickBarReplay, RequestTimeBarReplay, ResponseTickBarReplay, ResponseTimeBarReplay,
     },
 };
 
@@ -29,6 +28,8 @@ fn load_ticks(response_sender: Responder) -> HistoryPlantCommand {
         response_sender,
         start_time_sec: 0,
         symbol: "ESH6".to_string(),
+        user_max_count: None,
+        resume_bars: None,
     }
 }
 
@@ -105,180 +106,190 @@ async fn running_plant_with_handle() -> (
     (handle, actor, client)
 }
 
-/// An intermediate replay frame: the presence of `rq_handler_rp_code` marks it.
-fn tick_page_bar(id: &str) -> ResponseTickBarReplay {
+/// An intermediate replay frame carrying one tick at `sec`.`usec`.
+fn tick_at(id: &str, sec: i32, usec: i32) -> ResponseTickBarReplay {
     ResponseTickBarReplay {
         template_id: 207,
         user_msg: vec![id.to_string()],
         rq_handler_rp_code: vec!["0".to_string()],
+        data_bar_ssboe: vec![sec, sec],
+        data_bar_usecs: vec![usec, usec],
         ..Default::default()
     }
 }
 
-/// A closing replay frame, truncated when it carries a `request_key`.
-fn tick_page_end(id: &str, resume_key: Option<&str>) -> ResponseTickBarReplay {
+/// The data-less frame every replay closes with, truncated or not.
+fn tick_page_end(id: &str) -> ResponseTickBarReplay {
     ResponseTickBarReplay {
         template_id: 207,
         user_msg: vec![id.to_string()],
         rp_code: vec!["0".to_string()],
-        request_key: resume_key.map(String::from),
         ..Default::default()
     }
 }
 
-#[tokio::test]
-async fn load_ticks_all_follows_the_resume_key_across_pages() {
-    let (handle, actor, mut client) = running_plant_with_handle().await;
+fn time_bar_at(id: &str, marker: i32) -> ResponseTimeBarReplay {
+    ResponseTimeBarReplay {
+        template_id: 203,
+        user_msg: vec![id.to_string()],
+        rq_handler_rp_code: vec!["0".to_string()],
+        marker: Some(marker),
+        ..Default::default()
+    }
+}
 
-    let call = tokio::spawn({
-        let handle = handle.clone();
-        async move {
-            handle
-                .load_ticks_all("ESH6".to_string(), "CME".to_string(), 0, 1000, None)
-                .await
-        }
-    });
+fn time_bar_page_end(id: &str) -> ResponseTimeBarReplay {
+    ResponseTimeBarReplay {
+        template_id: 203,
+        user_msg: vec![id.to_string()],
+        rp_code: vec!["0".to_string()],
+        ..Default::default()
+    }
+}
 
-    // Page 1: the replay request goes out, and its closing frame is truncated.
-    let request = RequestTickBarReplay::decode(read_wire_request(&mut client).await.as_slice())
-        .expect("the first request must be a tick bar replay");
+/// Read one tick bar replay request and return its `resume_bars` and message id.
+async fn read_tick_replay(client: &mut TcpStream) -> (Option<bool>, String) {
+    let request = RequestTickBarReplay::decode(read_wire_request(client).await.as_slice())
+        .expect("the request must be a tick bar replay");
+
     assert_eq!(request.template_id, 206);
-    let id = request.user_msg[0].clone();
 
-    write_wire_response(&mut client, &tick_page_bar(&id)).await;
-    write_wire_response(&mut client, &tick_page_end(&id, Some("key-1"))).await;
-
-    // Page 2: the truncation must be resumed with the key the server handed out.
-    let resume = RequestResumeBars::decode(read_wire_request(&mut client).await.as_slice())
-        .expect("the second request must be a resume");
-    assert_eq!(resume.template_id, 210);
-    assert_eq!(resume.request_key.as_deref(), Some("key-1"));
-    let id = resume.user_msg[0].clone();
-
-    write_wire_response(&mut client, &tick_page_bar(&id)).await;
-    write_wire_response(&mut client, &tick_page_end(&id, None)).await;
-
-    let responses = call
-        .await
-        .expect("call task panicked")
-        .expect("the paginated load must succeed");
-
-    assert_eq!(responses.len(), 4, "both pages must be returned");
-    assert_eq!(
-        responses[1].resume_key(),
-        Some("key-1"),
-        "page order must be preserved"
-    );
-    assert!(
-        responses.last().unwrap().resume_key().is_none(),
-        "a completed replay leaves no resume key"
-    );
-
-    handle.abort();
-    let _ = actor.await;
+    (request.resume_bars, request.user_msg[0].clone())
 }
 
 #[tokio::test]
-async fn load_ticks_all_with_max_pages_stops_and_keeps_the_resume_key() {
+async fn load_ticks_all_asks_the_server_to_lift_the_record_cap() {
     let (handle, actor, mut client) = running_plant_with_handle().await;
 
-    let call = tokio::spawn({
-        let handle = handle.clone();
-        async move {
-            handle
-                .load_ticks_all("ESH6".to_string(), "CME".to_string(), 0, 1000, Some(1))
-                .await
-        }
+    let loader = tokio::spawn(async move {
+        handle
+            .load_ticks_all("ESH6".to_string(), "CME".to_string(), 0, 1000)
+            .await
     });
 
-    let request = RequestTickBarReplay::decode(read_wire_request(&mut client).await.as_slice())
-        .expect("the first request must be a tick bar replay");
-    let id = request.user_msg[0].clone();
-
-    write_wire_response(&mut client, &tick_page_bar(&id)).await;
-    write_wire_response(&mut client, &tick_page_end(&id, Some("key-1"))).await;
-
-    let responses = call
-        .await
-        .expect("call task panicked")
-        .expect("a capped load still returns the gathered page");
-
-    assert_eq!(responses.len(), 2, "only the first page must be returned");
+    // One request only: resume_bars replaces paging, so there is nothing to
+    // follow up.
+    let (resume_bars, id) = read_tick_replay(&mut client).await;
     assert_eq!(
-        responses.last().unwrap().resume_key(),
-        Some("key-1"),
-        "the cut-short replay must keep its resume key"
+        resume_bars,
+        Some(true),
+        "load_ticks_all must set resume_bars, which is what lifts the 10,000 record cap"
     );
-    assert_wire_silent(&mut client).await;
 
-    handle.abort();
-    let _ = actor.await;
+    write_wire_response(&mut client, &tick_at(&id, 100, 1)).await;
+    write_wire_response(&mut client, &tick_at(&id, 100, 2)).await;
+    write_wire_response(&mut client, &tick_at(&id, 200, 5)).await;
+    write_wire_response(&mut client, &tick_page_end(&id)).await;
+
+    let responses = loader
+        .await
+        .expect("the loader must not panic")
+        .expect("the load must succeed");
+
+    let ticks: Vec<(i32, i32)> = responses
+        .iter()
+        .filter_map(|response| match &response.message {
+            RithmicMessage::ResponseTickBarReplay(bar) if bar.data_bar_ssboe.len() == 2 => {
+                Some((bar.data_bar_ssboe[1], bar.data_bar_usecs[1]))
+            }
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(ticks, vec![(100, 1), (100, 2), (200, 5)]);
+    assert_eq!(
+        responses.len(),
+        4,
+        "every record plus the replay's closing frame"
+    );
+
+    actor.abort();
 }
 
 #[tokio::test]
-async fn load_time_bars_all_follows_the_resume_key_across_pages() {
+async fn load_ticks_leaves_the_cap_in_place() {
     let (handle, actor, mut client) = running_plant_with_handle().await;
 
-    let call = tokio::spawn({
-        let handle = handle.clone();
-        async move {
-            handle
-                .load_time_bars_all(
-                    "ESH6".to_string(),
-                    "CME".to_string(),
-                    BarType::MinuteBar,
-                    1,
-                    0,
-                    1000,
-                    None,
-                )
-                .await
-        }
+    let loader = tokio::spawn(async move {
+        handle
+            .load_ticks("ESH6".to_string(), "CME".to_string(), 0, 1000)
+            .await
+    });
+
+    let (resume_bars, id) = read_tick_replay(&mut client).await;
+    assert_eq!(
+        resume_bars, None,
+        "the capped loader must not ask for the cap to be lifted"
+    );
+
+    write_wire_response(&mut client, &tick_page_end(&id)).await;
+    loader
+        .await
+        .expect("the loader must not panic")
+        .expect("the load must succeed");
+
+    actor.abort();
+}
+
+#[tokio::test]
+async fn load_time_bars_all_asks_the_server_to_lift_the_record_cap() {
+    let (handle, actor, mut client) = running_plant_with_handle().await;
+
+    let loader = tokio::spawn(async move {
+        handle
+            .load_time_bars_all(
+                "ESH6".to_string(),
+                "CME".to_string(),
+                BarType::MinuteBar,
+                1,
+                0,
+                1000,
+            )
+            .await
     });
 
     let request = RequestTimeBarReplay::decode(read_wire_request(&mut client).await.as_slice())
-        .expect("the first request must be a time bar replay");
+        .expect("the request must be a time bar replay");
     assert_eq!(request.template_id, 202);
+    assert_eq!(
+        request.resume_bars,
+        Some(true),
+        "load_time_bars_all must set resume_bars too"
+    );
+
     let id = request.user_msg[0].clone();
+    write_wire_response(&mut client, &time_bar_at(&id, 60)).await;
+    write_wire_response(&mut client, &time_bar_at(&id, 120)).await;
+    write_wire_response(&mut client, &time_bar_page_end(&id)).await;
 
-    write_wire_response(
-        &mut client,
-        &ResponseTimeBarReplay {
-            template_id: 203,
-            user_msg: vec![id.clone()],
-            rp_code: vec!["0".to_string()],
-            request_key: Some("key-2".to_string()),
-            ..Default::default()
-        },
-    )
-    .await;
-
-    let resume = RequestResumeBars::decode(read_wire_request(&mut client).await.as_slice())
-        .expect("the second request must be a resume");
-    assert_eq!(resume.request_key.as_deref(), Some("key-2"));
-    let id = resume.user_msg[0].clone();
-
-    write_wire_response(
-        &mut client,
-        &ResponseTimeBarReplay {
-            template_id: 203,
-            user_msg: vec![id],
-            rp_code: vec!["0".to_string()],
-            ..Default::default()
-        },
-    )
-    .await;
-
-    let responses = call
+    let responses = loader
         .await
-        .expect("call task panicked")
-        .expect("the paginated load must succeed");
+        .expect("the loader must not panic")
+        .expect("the load must succeed");
 
-    assert_eq!(responses.len(), 2, "both pages must be returned");
-    assert!(responses.last().unwrap().resume_key().is_none());
+    let markers: Vec<i32> = responses
+        .iter()
+        .filter_map(|response| match &response.message {
+            RithmicMessage::ResponseTimeBarReplay(bar) => bar.marker,
+            _ => None,
+        })
+        .collect();
 
-    handle.abort();
-    let _ = actor.await;
+    assert_eq!(markers, vec![60, 120]);
+
+    actor.abort();
+}
+
+#[tokio::test]
+async fn load_tick_bars_all_rejects_a_zero_bar_length() {
+    let (handle, _command_receiver) = test_handle();
+
+    let err = handle
+        .load_tick_bars_all("ESH6".to_string(), "CME".to_string(), 0, 0, 1000)
+        .await
+        .expect_err("a zero bar length must be refused");
+
+    assert!(matches!(err, RithmicError::InvalidArgument(_)));
 }
 
 fn test_handle() -> (


### PR DESCRIPTION
## What

Rithmic caps a bar replay at 10,000 records and gives no sign it did — the closing response of a truncated replay is byte-identical to a complete one's. The crate never asked for the cap to be lifted: both replay senders built their requests with `..Default::default()`, so `resume_bars` was never set.

This sets it.

## Changes

- **`load_ticks_all`, `load_tick_bars_all`, `load_time_bars_all`** now send `resume_bars`. The server streams the remainder on the original request, so one request covers the whole window. No follow-up call and no `request_key` involved.
- **The page-walking helper is gone**, and with it `max_pages` from those three signatures.
- **`request_tick_bar_replay` and `request_time_bar_replay`** take `user_max_count` and `resume_bars`, so callers building requests directly can cap or uncap a replay themselves.
- **History plant docs rewritten** for third-party users: a table for picking a loader, response shapes and timestamp units spelled out, and links to the runnable examples so they resolve on docs.rs.
- **The first-record open-time clamp is documented, not patched.** Rithmic stamps the first record's open with the second you asked for at microsecond 0, rather than the trade's own time. The crate passes it through untouched and says so under `load_ticks`; what to do about it is the caller's call.
- Examples move off the expired ESM6 contract to ESU6.

## Note for callers

The whole window is buffered before it returns. A full 23-hour ES session is roughly 800,000 records in memory. Use the non-`_all` loaders, or narrower windows, if that matters.

## Checks

`cargo fmt`, `cargo test --all` (351 lib tests, 42 doctests) and `cargo clippy --all-targets` are clean.
