### PR TITLE
refactor(history): take a request struct on the replay calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,19 @@ before the first run against a live account.
 
 ### Breaking Changes
 
+- **The three replay senders take a request struct.**
+  `SenderApi::request_tick_bar_replay`, `request_time_bar_replay` and
+  `request_volume_profile_minute_bars` each took seven or eight positional
+  arguments; they now take a single `&TickBarReplayRequest`,
+  `&TimeBarReplayRequest` or `&VolumeProfileMinuteBarsRequest`. The history
+  plant's `load_*` methods are unchanged — they build the request for you.
+
+- **The `load_*` replay methods validate before sending.** A missing symbol or
+  exchange, a `bar_length` or `bar_type_period` below 1, a non-positive
+  timestamp, or an `end_time_sec` before `start_time_sec` now returns
+  `RithmicError::InvalidArgument` without a round trip. Previously only a zero
+  `bar_length` was caught.
+
 - **Order command types are their own builders and are `#[non_exhaustive]`.**
   `..Default::default()` no longer compiles on them outside this crate. `new()`
   takes no arguments, every field has a setter of the same name, and `build()`
@@ -170,9 +183,14 @@ before the first run against a live account.
   window. The whole window is buffered before it returns, so a full 23-hour ES
   session is roughly 800,000 records in memory.
 
-- **`resume_bars` on the replay requests.** `request_tick_bar_replay` and
-  `request_time_bar_replay` now take `user_max_count` and `resume_bars`, so a
-  caller building requests directly can cap or uncap a replay themselves.
+- **`TickBarReplayRequest` and `TimeBarReplayRequest`**, the replay counterparts
+  of `VolumeProfileMinuteBarsRequest`. Same shape as the order commands: `new()`,
+  chained setters, `validate()` and `build()`. They carry `user_max_count` and
+  `resume_bars`, so a caller building requests directly can cap or uncap a replay
+  themselves.
+
+- **`TimeBarType`**, an alias for the generated `request_time_bar_replay::BarType`
+  under a name that reads better on a request.
 
 - **Per-order trade routes.** The new `trade_route` field on `RithmicOrder`,
   `RithmicBracketOrder` and `RithmicOcoOrderLeg` overrides the route the plant

--- a/src/api/sender_api.rs
+++ b/src/api/sender_api.rs
@@ -42,7 +42,10 @@ use crate::{
         request_tick_bar_update, request_time_bar_replay, request_time_bar_update,
         response_login_info,
     },
-    types::{EasyToBorrowRequest, FillHistoryRange, OrderType, RmsUpdateBits},
+    types::{
+        EasyToBorrowRequest, FillHistoryRange, OrderType, RmsUpdateBits, TickBarReplayRequest,
+        TimeBarReplayRequest, VolumeProfileMinuteBarsRequest,
+    },
 };
 
 /// The protocol template version sent on every login.
@@ -1015,50 +1018,32 @@ impl RithmicSenderApi {
         self.request_to_buf(req, id)
     }
 
-    /// Request a replay of tick bar data.
+    /// Build a tick bar replay request.
     ///
     /// # Arguments
     ///
-    /// * `symbol` - The symbol to request data for
-    /// * `exchange` - The exchange of the symbol
-    /// * `bar_type_specifier` - Number of ticks per bar as a string (e.g., `"1"` for
-    ///   individual ticks, `"5"` for 5-tick bars)
-    /// * `start_index_sec` - Start time as a Unix timestamp (seconds)
-    /// * `finish_index_sec` - End time as a Unix timestamp (seconds)
-    /// * `user_max_count` - cap on records returned; `None` leaves the server's
-    ///   own cap to apply silently
-    /// * `resume_bars` - `Some(true)` lifts the server's 10,000 record cap so the
-    ///   whole window replays in one response stream
+    /// * `request` - The window and bar length to replay. Build it with
+    ///   [`TickBarReplayRequest::new`](crate::TickBarReplayRequest::new).
     ///
     /// # Returns
     ///
     /// A tuple containing the request buffer and the message id.
-    #[allow(clippy::too_many_arguments)]
-    pub fn request_tick_bar_replay(
-        &mut self,
-        symbol: &str,
-        exchange: &str,
-        bar_type_specifier: &str,
-        start_index_sec: i32,
-        finish_index_sec: i32,
-        user_max_count: Option<i32>,
-        resume_bars: Option<bool>,
-    ) -> (Vec<u8>, String) {
+    pub fn request_tick_bar_replay(&mut self, request: &TickBarReplayRequest) -> (Vec<u8>, String) {
         let id = self.get_next_message_id();
 
         let req = RequestTickBarReplay {
             template_id: 206,
-            exchange: Some(exchange.to_string()),
-            symbol: Some(symbol.to_string()),
+            exchange: Some(request.exchange.clone()),
+            symbol: Some(request.symbol.clone()),
             bar_type: Some(BarType::TickBar.into()),
             bar_sub_type: Some(BarSubType::Regular.into()),
-            bar_type_specifier: Some(bar_type_specifier.to_string()),
-            start_index: Some(start_index_sec),
-            finish_index: Some(finish_index_sec),
+            bar_type_specifier: Some(request.bar_type_specifier.clone()),
+            start_index: Some(request.start_time_sec),
+            finish_index: Some(request.end_time_sec),
             direction: Some(Direction::First.into()),
             time_order: Some(TimeOrder::Forwards.into()),
-            user_max_count,
-            resume_bars,
+            user_max_count: request.user_max_count,
+            resume_bars: request.resume_bars,
             user_msg: vec![id.clone()],
             ..Default::default()
         };
@@ -1066,50 +1051,31 @@ impl RithmicSenderApi {
         self.request_to_buf(req, id)
     }
 
-    /// Request a replay of time bar data
+    /// Build a time bar replay request.
     ///
     /// # Arguments
     ///
-    /// * `symbol` - The symbol to request data for
-    /// * `exchange` - The exchange of the symbol
-    /// * `bar_type` - The type of time bar (SecondBar, MinuteBar, DailyBar, WeeklyBar)
-    /// * `bar_type_period` - The period for the bar type (e.g., 1 for 1-minute bars, 5 for 5-minute bars)
-    /// * `start_index_sec` - unix seconds
-    /// * `finish_index_sec` - unix seconds
-    /// * `user_max_count` - cap on records returned; `None` leaves the server's
-    ///   own cap to apply silently
-    /// * `resume_bars` - `Some(true)` lifts the server's 10,000 record cap so the
-    ///   whole window replays in one response stream
+    /// * `request` - The window and bar size to replay. Build it with
+    ///   [`TimeBarReplayRequest::new`](crate::TimeBarReplayRequest::new).
     ///
     /// # Returns
     ///
-    /// A tuple containing the request buffer and the message id
-    #[allow(clippy::too_many_arguments)]
-    pub fn request_time_bar_replay(
-        &mut self,
-        symbol: &str,
-        exchange: &str,
-        bar_type: request_time_bar_replay::BarType,
-        bar_type_period: i32,
-        start_index_sec: i32,
-        finish_index_sec: i32,
-        user_max_count: Option<i32>,
-        resume_bars: Option<bool>,
-    ) -> (Vec<u8>, String) {
+    /// A tuple containing the request buffer and the message id.
+    pub fn request_time_bar_replay(&mut self, request: &TimeBarReplayRequest) -> (Vec<u8>, String) {
         let id = self.get_next_message_id();
 
         let req = RequestTimeBarReplay {
             template_id: 202,
-            exchange: Some(exchange.to_string()),
-            symbol: Some(symbol.to_string()),
-            bar_type: Some(bar_type.into()),
-            bar_type_period: Some(bar_type_period),
-            start_index: Some(start_index_sec),
-            finish_index: Some(finish_index_sec),
+            exchange: Some(request.exchange.clone()),
+            symbol: Some(request.symbol.clone()),
+            bar_type: request.bar_type.map(Into::into),
+            bar_type_period: Some(request.bar_type_period),
+            start_index: Some(request.start_time_sec),
+            finish_index: Some(request.end_time_sec),
             direction: Some(request_time_bar_replay::Direction::First.into()),
             time_order: Some(request_time_bar_replay::TimeOrder::Forwards.into()),
-            user_max_count,
-            resume_bars,
+            user_max_count: request.user_max_count,
+            resume_bars: request.resume_bars,
             user_msg: vec![id.clone()],
             ..Default::default()
         };
@@ -1117,44 +1083,34 @@ impl RithmicSenderApi {
         self.request_to_buf(req, id)
     }
 
-    /// Request volume profile minute bars
+    /// Build a volume profile minute bars request.
     ///
     /// Returns minute bar data with volume profile information.
     ///
     /// # Arguments
-    /// * `symbol` - The trading symbol (e.g., "ESH6")
-    /// * `exchange` - The exchange code (e.g., "CME")
-    /// * `bar_type_period` - The period for the bars
-    /// * `start_index_sec` - Start time in unix seconds
-    /// * `finish_index_sec` - End time in unix seconds
-    /// * `user_max_count` - Optional maximum number of bars to return
-    /// * `resume_bars` - Whether to resume from a previous request
+    ///
+    /// * `request` - The window and bar period to replay. Build it with
+    ///   [`VolumeProfileMinuteBarsRequest::new`](crate::VolumeProfileMinuteBarsRequest::new).
     ///
     /// # Returns
+    ///
     /// A tuple of (serialized request buffer, request ID)
-    #[allow(clippy::too_many_arguments)]
     pub fn request_volume_profile_minute_bars(
         &mut self,
-        symbol: &str,
-        exchange: &str,
-        bar_type_period: i32,
-        start_index_sec: i32,
-        finish_index_sec: i32,
-        user_max_count: Option<i32>,
-        resume_bars: Option<bool>,
+        request: &VolumeProfileMinuteBarsRequest,
     ) -> (Vec<u8>, String) {
         let id = self.get_next_message_id();
 
         let req = RequestVolumeProfileMinuteBars {
             template_id: 208,
             user_msg: vec![id.clone()],
-            symbol: Some(symbol.to_string()),
-            exchange: Some(exchange.to_string()),
-            bar_type_period: Some(bar_type_period),
-            start_index: Some(start_index_sec),
-            finish_index: Some(finish_index_sec),
-            user_max_count,
-            resume_bars,
+            symbol: Some(request.symbol.clone()),
+            exchange: Some(request.exchange.clone()),
+            bar_type_period: Some(request.bar_type_period),
+            start_index: Some(request.start_time_sec),
+            finish_index: Some(request.end_time_sec),
+            user_max_count: request.user_max_count,
+            resume_bars: request.resume_bars,
         };
 
         self.request_to_buf(req, id)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@
 //!
 //! | Flag | Default | Description |
 //! |------|---------|-------------|
-//! | `serde` | off | Adds `Serialize`/`Deserialize` derives on the config types (`RithmicEnv`, `RithmicAccount`), the trading enums (`OrderSide`, `OrderType`, `TimeInForce`, `ManualOrAutoEntry`, `OrderCondition`, `OrderPriceField`, `BracketType`, `BracketOperationType`, `FillHistoryRange`, `EasyToBorrowRequest`, `RmsUpdateBits`, `OrderStatus`), every order command type (`RithmicOrder`, `RithmicBracketOrder`, `RithmicOcoOrder` and its legs, `RithmicModifyOrder`, the cancel/exit/link/retag/adjustment commands), the triggers (`TrailingStop`, `RithmicIfTouchedTrigger`) and `VolumeProfileMinuteBarsRequest` |
+//! | `serde` | off | Adds `Serialize`/`Deserialize` derives on the config types (`RithmicEnv`, `RithmicAccount`), the trading enums (`OrderSide`, `OrderType`, `TimeInForce`, `ManualOrAutoEntry`, `OrderCondition`, `OrderPriceField`, `BracketType`, `BracketOperationType`, `FillHistoryRange`, `EasyToBorrowRequest`, `RmsUpdateBits`, `OrderStatus`), every order command type (`RithmicOrder`, `RithmicBracketOrder`, `RithmicOcoOrder` and its legs, `RithmicModifyOrder`, the cancel/exit/link/retag/adjustment commands), the triggers (`TrailingStop`, `RithmicIfTouchedTrigger`) and the history request types (`VolumeProfileMinuteBarsRequest`, `TickBarReplayRequest`) |
 //!
 //! **TLS backend:** The crate uses `native-tls` (via `tokio-tungstenite`) for all
 //! WebSocket connections. There is currently no `rustls` option.
@@ -322,6 +322,6 @@ pub use util::{
 pub use types::{
     BracketOperationType, BracketType, EasyToBorrowRequest, FillHistoryRange, ManualOrAutoEntry,
     OrderCondition, OrderPriceField, OrderSide, OrderType, ParseOrderSideError,
-    ParseOrderTypeError, ParseTimeInForceError, RmsUpdateBits, TimeInForce,
-    VolumeProfileMinuteBarsRequest,
+    ParseOrderTypeError, ParseTimeInForceError, RmsUpdateBits, TickBarReplayRequest,
+    TimeBarReplayRequest, TimeBarType, TimeInForce, VolumeProfileMinuteBarsRequest,
 };

--- a/src/plants/history_plant.rs
+++ b/src/plants/history_plant.rs
@@ -18,7 +18,7 @@ use crate::{
         messages::RithmicMessage, request_login::SysInfraType, request_tick_bar_update,
         request_time_bar_replay::BarType, request_time_bar_update,
     },
-    types::VolumeProfileMinuteBarsRequest,
+    types::{TickBarReplayRequest, TimeBarReplayRequest, VolumeProfileMinuteBarsRequest},
 };
 
 pub(crate) enum HistoryPlantCommand {
@@ -39,25 +39,12 @@ pub(crate) enum HistoryPlantCommand {
         seconds: u64,
     },
     LoadTicks {
-        bar_type_specifier: String,
-        end_time_sec: i32,
-        exchange: String,
+        request: TickBarReplayRequest,
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
-        start_time_sec: i32,
-        symbol: String,
-        user_max_count: Option<i32>,
-        resume_bars: Option<bool>,
     },
     LoadTimeBars {
-        bar_type: BarType,
-        bar_type_period: i32,
-        end_time_sec: i32,
-        exchange: String,
+        request: TimeBarReplayRequest,
         response_sender: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
-        start_time_sec: i32,
-        symbol: String,
-        user_max_count: Option<i32>,
-        resume_bars: Option<bool>,
     },
     LoadVolumeProfileMinuteBars {
         request: VolumeProfileMinuteBarsRequest,
@@ -343,52 +330,26 @@ impl PlantActor for HistoryPlant {
                 self.core.handle_update_heartbeat(seconds);
             }
             HistoryPlantCommand::LoadTicks {
-                bar_type_specifier,
-                exchange,
-                symbol,
-                start_time_sec,
-                end_time_sec,
+                request,
                 response_sender,
-                user_max_count,
-                resume_bars,
             } => {
-                let (tick_bar_replay_buf, id) =
-                    self.core.rithmic_sender_api.request_tick_bar_replay(
-                        &symbol,
-                        &exchange,
-                        &bar_type_specifier,
-                        start_time_sec,
-                        end_time_sec,
-                        user_max_count,
-                        resume_bars,
-                    );
+                let (tick_bar_replay_buf, id) = self
+                    .core
+                    .rithmic_sender_api
+                    .request_tick_bar_replay(&request);
 
                 self.core
                     .register_and_send(tick_bar_replay_buf, id, response_sender)
                     .await;
             }
             HistoryPlantCommand::LoadTimeBars {
-                bar_type,
-                bar_type_period,
-                end_time_sec,
-                exchange,
+                request,
                 response_sender,
-                start_time_sec,
-                symbol,
-                user_max_count,
-                resume_bars,
             } => {
-                let (time_bar_replay_buf, id) =
-                    self.core.rithmic_sender_api.request_time_bar_replay(
-                        &symbol,
-                        &exchange,
-                        bar_type,
-                        bar_type_period,
-                        start_time_sec,
-                        end_time_sec,
-                        user_max_count,
-                        resume_bars,
-                    );
+                let (time_bar_replay_buf, id) = self
+                    .core
+                    .rithmic_sender_api
+                    .request_time_bar_replay(&request);
 
                 self.core
                     .register_and_send(time_bar_replay_buf, id, response_sender)
@@ -401,15 +362,7 @@ impl PlantActor for HistoryPlant {
                 let (buf, id) = self
                     .core
                     .rithmic_sender_api
-                    .request_volume_profile_minute_bars(
-                        &request.symbol,
-                        &request.exchange,
-                        request.bar_type_period,
-                        request.start_time_sec,
-                        request.end_time_sec,
-                        request.user_max_count,
-                        request.resume_bars,
-                    );
+                    .request_volume_profile_minute_bars(&request);
 
                 self.core.register_and_send(buf, id, response_sender).await;
             }
@@ -678,7 +631,9 @@ impl RithmicHistoryPlantHandle {
     /// One response per bar, followed by an end marker carrying no data.
     ///
     /// # Errors
-    /// * [`RithmicError::InvalidArgument`] if `bar_length` is 0.
+    /// * [`RithmicError::InvalidArgument`] if the symbol or exchange is empty,
+    ///   `bar_length` is 0, either timestamp is not positive, or the window ends
+    ///   before it starts. Nothing is sent.
     /// * [`RithmicError::ConnectionClosed`] if the history plant has shut down.
     pub async fn load_tick_bars(
         &self,
@@ -688,47 +643,29 @@ impl RithmicHistoryPlantHandle {
         start_time_sec: i32,
         end_time_sec: i32,
     ) -> Result<Vec<RithmicResponse>, RithmicError> {
-        if bar_length == 0 {
-            return Err(RithmicError::InvalidArgument(
-                "bar_length must be at least 1".to_string(),
-            ));
-        }
-
-        self.tick_bar_page(
-            symbol,
-            exchange,
-            bar_length,
-            start_time_sec,
-            end_time_sec,
-            None,
-            None,
+        self.tick_bar_replay(
+            TickBarReplayRequest::new()
+                .symbol(symbol)
+                .exchange(exchange)
+                .bar_length(bar_length)
+                .start_time_sec(start_time_sec)
+                .end_time_sec(end_time_sec),
         )
         .await
     }
 
     /// One tick bar replay request.
-    #[allow(clippy::too_many_arguments)]
-    async fn tick_bar_page(
+    async fn tick_bar_replay(
         &self,
-        symbol: String,
-        exchange: String,
-        bar_length: u32,
-        start_time_sec: i32,
-        end_time_sec: i32,
-        user_max_count: Option<i32>,
-        resume_bars: Option<bool>,
+        request: TickBarReplayRequest,
     ) -> Result<Vec<RithmicResponse>, RithmicError> {
+        request.validate()?;
+
         let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, RithmicError>>();
 
         let command = HistoryPlantCommand::LoadTicks {
-            bar_type_specifier: bar_length.to_string(),
-            exchange,
-            symbol,
-            start_time_sec,
-            end_time_sec,
+            request,
             response_sender: tx,
-            user_max_count,
-            resume_bars,
         };
 
         let _ = self.sender.send(command).await;
@@ -779,7 +716,9 @@ impl RithmicHistoryPlantHandle {
     /// what it costs in memory.
     ///
     /// # Errors
-    /// * [`RithmicError::InvalidArgument`] if `bar_length` is 0.
+    /// * [`RithmicError::InvalidArgument`] if the symbol or exchange is empty,
+    ///   `bar_length` is 0, either timestamp is not positive, or the window ends
+    ///   before it starts. Nothing is sent.
     pub async fn load_tick_bars_all(
         &self,
         symbol: String,
@@ -788,20 +727,14 @@ impl RithmicHistoryPlantHandle {
         start_time_sec: i32,
         end_time_sec: i32,
     ) -> Result<Vec<RithmicResponse>, RithmicError> {
-        if bar_length == 0 {
-            return Err(RithmicError::InvalidArgument(
-                "bar_length must be at least 1".to_string(),
-            ));
-        }
-
-        self.tick_bar_page(
-            symbol,
-            exchange,
-            bar_length,
-            start_time_sec,
-            end_time_sec,
-            None,
-            Some(true),
+        self.tick_bar_replay(
+            TickBarReplayRequest::new()
+                .symbol(symbol)
+                .exchange(exchange)
+                .bar_length(bar_length)
+                .start_time_sec(start_time_sec)
+                .end_time_sec(end_time_sec)
+                .resume_bars(true),
         )
         .await
     }
@@ -824,15 +757,15 @@ impl RithmicHistoryPlantHandle {
         start_time_sec: i32,
         end_time_sec: i32,
     ) -> Result<Vec<RithmicResponse>, RithmicError> {
-        self.time_bar_page(
-            symbol,
-            exchange,
-            bar_type,
-            bar_type_period,
-            start_time_sec,
-            end_time_sec,
-            None,
-            Some(true),
+        self.time_bar_replay(
+            TimeBarReplayRequest::new()
+                .symbol(symbol)
+                .exchange(exchange)
+                .bar_type(bar_type)
+                .bar_type_period(bar_type_period)
+                .start_time_sec(start_time_sec)
+                .end_time_sec(end_time_sec)
+                .resume_bars(true),
         )
         .await
     }
@@ -872,44 +805,30 @@ impl RithmicHistoryPlantHandle {
         start_time_sec: i32,
         end_time_sec: i32,
     ) -> Result<Vec<RithmicResponse>, RithmicError> {
-        self.time_bar_page(
-            symbol,
-            exchange,
-            bar_type,
-            bar_type_period,
-            start_time_sec,
-            end_time_sec,
-            None,
-            None,
+        self.time_bar_replay(
+            TimeBarReplayRequest::new()
+                .symbol(symbol)
+                .exchange(exchange)
+                .bar_type(bar_type)
+                .bar_type_period(bar_type_period)
+                .start_time_sec(start_time_sec)
+                .end_time_sec(end_time_sec),
         )
         .await
     }
 
     /// One time bar replay request.
-    #[allow(clippy::too_many_arguments)]
-    async fn time_bar_page(
+    async fn time_bar_replay(
         &self,
-        symbol: String,
-        exchange: String,
-        bar_type: BarType,
-        bar_type_period: i32,
-        start_time_sec: i32,
-        end_time_sec: i32,
-        user_max_count: Option<i32>,
-        resume_bars: Option<bool>,
+        request: TimeBarReplayRequest,
     ) -> Result<Vec<RithmicResponse>, RithmicError> {
+        request.validate()?;
+
         let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, RithmicError>>();
 
         let command = HistoryPlantCommand::LoadTimeBars {
-            bar_type,
-            bar_type_period,
-            end_time_sec,
-            exchange,
+            request,
             response_sender: tx,
-            start_time_sec,
-            symbol,
-            user_max_count,
-            resume_bars,
         };
 
         let _ = self.sender.send(command).await;

--- a/src/plants/history_plant/tests.rs
+++ b/src/plants/history_plant/tests.rs
@@ -22,14 +22,13 @@ async fn plant_with_wire() -> (HistoryPlant, mpsc::Sender<HistoryPlantCommand>, 
 
 fn load_ticks(response_sender: Responder) -> HistoryPlantCommand {
     HistoryPlantCommand::LoadTicks {
-        bar_type_specifier: "1".to_string(),
-        end_time_sec: 1000,
-        exchange: "CME".to_string(),
+        request: TickBarReplayRequest::new()
+            .symbol("ESH6")
+            .exchange("CME")
+            .bar_length(1)
+            .start_time_sec(1)
+            .end_time_sec(1000),
         response_sender,
-        start_time_sec: 0,
-        symbol: "ESH6".to_string(),
-        user_max_count: None,
-        resume_bars: None,
     }
 }
 
@@ -66,7 +65,7 @@ async fn load_ticks_through_the_handle_after_close_requested_reports_connection_
 
     let err = tokio::time::timeout(
         std::time::Duration::from_secs(5),
-        handle.load_ticks("ESH6".to_string(), "CME".to_string(), 0, 1000),
+        handle.load_ticks("ESH6".to_string(), "CME".to_string(), 1, 1000),
     )
     .await
     .expect("load_ticks must be answered, not left waiting")
@@ -138,7 +137,7 @@ fn time_bar_at(id: &str, marker: i32) -> ResponseTimeBarReplay {
     }
 }
 
-fn time_bar_page_end(id: &str) -> ResponseTimeBarReplay {
+fn time_bar_replay_end(id: &str) -> ResponseTimeBarReplay {
     ResponseTimeBarReplay {
         template_id: 203,
         user_msg: vec![id.to_string()],
@@ -163,7 +162,7 @@ async fn load_ticks_all_asks_the_server_to_lift_the_record_cap() {
 
     let loader = tokio::spawn(async move {
         handle
-            .load_ticks_all("ESH6".to_string(), "CME".to_string(), 0, 1000)
+            .load_ticks_all("ESH6".to_string(), "CME".to_string(), 1, 1000)
             .await
     });
 
@@ -212,7 +211,7 @@ async fn load_ticks_leaves_the_cap_in_place() {
 
     let loader = tokio::spawn(async move {
         handle
-            .load_ticks("ESH6".to_string(), "CME".to_string(), 0, 1000)
+            .load_ticks("ESH6".to_string(), "CME".to_string(), 1, 1000)
             .await
     });
 
@@ -242,7 +241,7 @@ async fn load_time_bars_all_asks_the_server_to_lift_the_record_cap() {
                 "CME".to_string(),
                 BarType::MinuteBar,
                 1,
-                0,
+                1,
                 1000,
             )
             .await
@@ -260,7 +259,7 @@ async fn load_time_bars_all_asks_the_server_to_lift_the_record_cap() {
     let id = request.user_msg[0].clone();
     write_wire_response(&mut client, &time_bar_at(&id, 60)).await;
     write_wire_response(&mut client, &time_bar_at(&id, 120)).await;
-    write_wire_response(&mut client, &time_bar_page_end(&id)).await;
+    write_wire_response(&mut client, &time_bar_replay_end(&id)).await;
 
     let responses = loader
         .await
@@ -285,7 +284,7 @@ async fn load_tick_bars_all_rejects_a_zero_bar_length() {
     let (handle, _command_receiver) = test_handle();
 
     let err = handle
-        .load_tick_bars_all("ESH6".to_string(), "CME".to_string(), 0, 0, 1000)
+        .load_tick_bars_all("ESH6".to_string(), "CME".to_string(), 0, 1, 1000)
         .await
         .expect_err("a zero bar length must be refused");
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,6 +15,12 @@ use crate::{
     },
 };
 
+/// The unit a time bar covers: second, minute, day or week.
+///
+/// An alias for the generated `request_time_bar_replay::BarType`, under a name
+/// that reads better on [`TimeBarReplayRequest`].
+pub use crate::rti::request_time_bar_replay::BarType as TimeBarType;
+
 /// Buy or sell.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -744,15 +750,313 @@ impl VolumeProfileMinuteBarsRequest {
     /// Requires a symbol, an exchange, a bar period, and an ordered time
     /// window.
     pub fn validate(&self) -> Result<(), RithmicError> {
-        if self.symbol.is_empty() {
+        validate_replay_window(
+            "volume-profile",
+            &self.symbol,
+            &self.exchange,
+            self.start_time_sec,
+            self.end_time_sec,
+        )?;
+
+        if self.bar_type_period < 1 {
             return Err(RithmicError::InvalidArgument(
-                "a volume-profile request requires a symbol".to_string(),
+                "bar_type_period must be at least 1".to_string(),
             ));
         }
+        Ok(())
+    }
 
-        if self.exchange.is_empty() {
+    /// Requires a symbol, an exchange, a bar period, and an ordered time
+    /// window.
+    pub fn build(self) -> Result<Self, RithmicError> {
+        self.validate()?;
+        Ok(self)
+    }
+}
+
+/// The instrument and time window every replay request needs. `kind` names the
+/// request in the error message.
+fn validate_replay_window(
+    kind: &str,
+    symbol: &str,
+    exchange: &str,
+    start_time_sec: i32,
+    end_time_sec: i32,
+) -> Result<(), RithmicError> {
+    if symbol.is_empty() {
+        return Err(RithmicError::InvalidArgument(format!(
+            "a {kind} request requires a symbol"
+        )));
+    }
+
+    if exchange.is_empty() {
+        return Err(RithmicError::InvalidArgument(format!(
+            "a {kind} request requires an exchange"
+        )));
+    }
+
+    if start_time_sec < 1 || end_time_sec < 1 {
+        return Err(RithmicError::InvalidArgument(
+            "start_time_sec and end_time_sec are both required, as positive Unix timestamps"
+                .to_string(),
+        ));
+    }
+
+    if end_time_sec < start_time_sec {
+        return Err(RithmicError::InvalidArgument(
+            "end_time_sec must not precede start_time_sec".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// A tick bar replay request, passed to [`load_tick_bars`] and its siblings.
+///
+/// A tick bar groups a fixed number of trades. [`bar_length`](Self::bar_length)
+/// of 1 gives one bar per trade — the raw tape.
+///
+/// # Example
+///
+/// ```
+/// use rithmic_rs::TickBarReplayRequest;
+/// # fn main() -> Result<(), rithmic_rs::RithmicError> {
+/// let request = TickBarReplayRequest::new()
+///     .symbol("ESU6")
+///     .exchange("CME")
+///     .bar_length(1)
+///     .start_time_sec(1_750_000_000)
+///     .end_time_sec(1_750_003_600)
+///     .resume_bars(true)
+///     .build()?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// [`load_tick_bars`]: crate::RithmicHistoryPlantHandle::load_tick_bars
+#[derive(Debug, Clone, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+#[must_use = "a request does nothing until passed to the history handle"]
+pub struct TickBarReplayRequest {
+    /// The trading symbol, e.g. `"ESU6"`.
+    pub symbol: String,
+    /// The exchange code, e.g. `"CME"`.
+    pub exchange: String,
+    /// Trades per bar, as the string Rithmic expects. Set it with
+    /// [`bar_length`](Self::bar_length) unless you need the raw form.
+    pub bar_type_specifier: String,
+    /// Start of the window as a Unix timestamp in seconds.
+    pub start_time_sec: i32,
+    /// End of the window as a Unix timestamp in seconds.
+    pub end_time_sec: i32,
+    /// Cap on records returned. Leaving this unset lets the server apply its
+    /// own cap of 10,000, silently.
+    pub user_max_count: Option<i32>,
+    /// `Some(true)` lifts the server's 10,000 record cap, so the whole window
+    /// replays on this one request.
+    pub resume_bars: Option<bool>,
+}
+
+impl TickBarReplayRequest {
+    /// Start an empty request.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The trading symbol, e.g. `"ESU6"`.
+    pub fn symbol(mut self, symbol: impl Into<String>) -> Self {
+        self.symbol = symbol.into();
+        self
+    }
+
+    /// The exchange code, e.g. `"CME"`.
+    pub fn exchange(mut self, exchange: impl Into<String>) -> Self {
+        self.exchange = exchange.into();
+        self
+    }
+
+    /// How many trades go into each bar. 1 gives one bar per trade.
+    pub fn bar_length(mut self, bar_length: u32) -> Self {
+        self.bar_type_specifier = bar_length.to_string();
+        self
+    }
+
+    /// The raw `bar_type_specifier` Rithmic expects, for a value
+    /// [`bar_length`](Self::bar_length) cannot express.
+    pub fn bar_type_specifier(mut self, bar_type_specifier: impl Into<String>) -> Self {
+        self.bar_type_specifier = bar_type_specifier.into();
+        self
+    }
+
+    /// Start of the window as a Unix timestamp in seconds.
+    pub fn start_time_sec(mut self, start_time_sec: i32) -> Self {
+        self.start_time_sec = start_time_sec;
+        self
+    }
+
+    /// End of the window as a Unix timestamp in seconds.
+    pub fn end_time_sec(mut self, end_time_sec: i32) -> Self {
+        self.end_time_sec = end_time_sec;
+        self
+    }
+
+    /// Cap the records returned.
+    pub fn user_max_count(mut self, user_max_count: i32) -> Self {
+        self.user_max_count = Some(user_max_count);
+        self
+    }
+
+    /// Lift the server's 10,000 record cap so the whole window replays at once.
+    pub fn resume_bars(mut self, resume_bars: bool) -> Self {
+        self.resume_bars = Some(resume_bars);
+        self
+    }
+
+    /// Requires a symbol, an exchange, a bar length of at least 1, and an
+    /// ordered time window.
+    pub fn validate(&self) -> Result<(), RithmicError> {
+        validate_replay_window(
+            "tick bar replay",
+            &self.symbol,
+            &self.exchange,
+            self.start_time_sec,
+            self.end_time_sec,
+        )?;
+
+        match self.bar_type_specifier.parse::<u32>() {
+            Ok(length) if length >= 1 => Ok(()),
+            _ => Err(RithmicError::InvalidArgument(
+                "bar_length must be at least 1".to_string(),
+            )),
+        }
+    }
+
+    /// Requires a symbol, an exchange, a bar length of at least 1, and an
+    /// ordered time window.
+    pub fn build(self) -> Result<Self, RithmicError> {
+        self.validate()?;
+        Ok(self)
+    }
+}
+
+/// A time bar replay request, passed to [`load_time_bars`] and its siblings.
+///
+/// A time bar covers a fixed span: [`bar_type`](Self::bar_type) picks the unit
+/// and [`bar_type_period`](Self::bar_type_period) how many of them per bar.
+///
+/// # Example
+///
+/// ```
+/// use rithmic_rs::{TimeBarReplayRequest, rti::request_time_bar_replay::BarType};
+/// # fn main() -> Result<(), rithmic_rs::RithmicError> {
+/// let request = TimeBarReplayRequest::new()
+///     .symbol("ESU6")
+///     .exchange("CME")
+///     .bar_type(BarType::MinuteBar)
+///     .bar_type_period(5)
+///     .start_time_sec(1_750_000_000)
+///     .end_time_sec(1_750_003_600)
+///     .build()?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// [`load_time_bars`]: crate::RithmicHistoryPlantHandle::load_time_bars
+//
+// No serde derive: `bar_type` is a generated protobuf enum, which does not
+// implement `Serialize`.
+#[derive(Debug, Clone, Default, PartialEq)]
+#[non_exhaustive]
+#[must_use = "a request does nothing until passed to the history handle"]
+pub struct TimeBarReplayRequest {
+    /// The trading symbol, e.g. `"ESU6"`.
+    pub symbol: String,
+    /// The exchange code, e.g. `"CME"`.
+    pub exchange: String,
+    /// Second, minute, day or week. Required.
+    pub bar_type: Option<TimeBarType>,
+    /// How many of those units each bar covers.
+    pub bar_type_period: i32,
+    /// Start of the window as a Unix timestamp in seconds.
+    pub start_time_sec: i32,
+    /// End of the window as a Unix timestamp in seconds.
+    pub end_time_sec: i32,
+    /// Cap on records returned. Leaving this unset lets the server apply its
+    /// own cap of 10,000, silently.
+    pub user_max_count: Option<i32>,
+    /// `Some(true)` lifts the server's 10,000 record cap, so the whole window
+    /// replays on this one request.
+    pub resume_bars: Option<bool>,
+}
+
+impl TimeBarReplayRequest {
+    /// Start an empty request.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The trading symbol, e.g. `"ESU6"`.
+    pub fn symbol(mut self, symbol: impl Into<String>) -> Self {
+        self.symbol = symbol.into();
+        self
+    }
+
+    /// The exchange code, e.g. `"CME"`.
+    pub fn exchange(mut self, exchange: impl Into<String>) -> Self {
+        self.exchange = exchange.into();
+        self
+    }
+
+    /// Second, minute, day or week.
+    pub fn bar_type(mut self, bar_type: TimeBarType) -> Self {
+        self.bar_type = Some(bar_type);
+        self
+    }
+
+    /// How many of those units each bar covers.
+    pub fn bar_type_period(mut self, bar_type_period: i32) -> Self {
+        self.bar_type_period = bar_type_period;
+        self
+    }
+
+    /// Start of the window as a Unix timestamp in seconds.
+    pub fn start_time_sec(mut self, start_time_sec: i32) -> Self {
+        self.start_time_sec = start_time_sec;
+        self
+    }
+
+    /// End of the window as a Unix timestamp in seconds.
+    pub fn end_time_sec(mut self, end_time_sec: i32) -> Self {
+        self.end_time_sec = end_time_sec;
+        self
+    }
+
+    /// Cap the records returned.
+    pub fn user_max_count(mut self, user_max_count: i32) -> Self {
+        self.user_max_count = Some(user_max_count);
+        self
+    }
+
+    /// Lift the server's 10,000 record cap so the whole window replays at once.
+    pub fn resume_bars(mut self, resume_bars: bool) -> Self {
+        self.resume_bars = Some(resume_bars);
+        self
+    }
+
+    /// Requires a symbol, an exchange, a bar type, a bar period, and an ordered
+    /// time window.
+    pub fn validate(&self) -> Result<(), RithmicError> {
+        validate_replay_window(
+            "time bar replay",
+            &self.symbol,
+            &self.exchange,
+            self.start_time_sec,
+            self.end_time_sec,
+        )?;
+
+        if self.bar_type.is_none() {
             return Err(RithmicError::InvalidArgument(
-                "a volume-profile request requires an exchange".to_string(),
+                "a time bar replay request requires a bar_type".to_string(),
             ));
         }
 
@@ -761,25 +1065,11 @@ impl VolumeProfileMinuteBarsRequest {
                 "bar_type_period must be at least 1".to_string(),
             ));
         }
-
-        if self.start_time_sec < 1 || self.end_time_sec < 1 {
-            return Err(RithmicError::InvalidArgument(
-                "start_time_sec and end_time_sec are both required, as positive Unix \
-                 timestamps"
-                    .to_string(),
-            ));
-        }
-
-        if self.end_time_sec < self.start_time_sec {
-            return Err(RithmicError::InvalidArgument(
-                "end_time_sec must not precede start_time_sec".to_string(),
-            ));
-        }
         Ok(())
     }
 
-    /// Requires a symbol, an exchange, a bar period, and an ordered time
-    /// window.
+    /// Requires a symbol, an exchange, a bar type, a bar period, and an ordered
+    /// time window.
     pub fn build(self) -> Result<Self, RithmicError> {
         self.validate()?;
         Ok(self)
@@ -1027,5 +1317,100 @@ mod tests {
             "limit-if-touched".parse::<OrderType>().unwrap(),
             OrderType::LimitIfTouched
         );
+    }
+
+    fn tick_replay() -> TickBarReplayRequest {
+        TickBarReplayRequest::new()
+            .symbol("ESU6")
+            .exchange("CME")
+            .bar_length(1)
+            .start_time_sec(1_750_000_000)
+            .end_time_sec(1_750_003_600)
+    }
+
+    fn time_replay() -> TimeBarReplayRequest {
+        TimeBarReplayRequest::new()
+            .symbol("ESU6")
+            .exchange("CME")
+            .bar_type(TimeBarType::MinuteBar)
+            .bar_type_period(5)
+            .start_time_sec(1_750_000_000)
+            .end_time_sec(1_750_003_600)
+    }
+
+    #[test]
+    fn a_tick_replay_request_needs_an_instrument_and_an_ordered_window() {
+        assert!(tick_replay().validate().is_ok());
+
+        let err = TickBarReplayRequest {
+            symbol: String::new(),
+            ..tick_replay()
+        }
+        .validate()
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("tick bar replay request requires a symbol"),
+            "{err}"
+        );
+
+        let err = TickBarReplayRequest {
+            exchange: String::new(),
+            ..tick_replay()
+        }
+        .validate()
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("tick bar replay request requires an exchange"),
+            "{err}"
+        );
+
+        let err = tick_replay()
+            .end_time_sec(1_749_999_999)
+            .build()
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("must not precede"), "{err}");
+    }
+
+    /// `bar_length` reaches the wire as a string, so a zero or an unparseable
+    /// specifier both have to be caught before the request is sent.
+    #[test]
+    fn a_tick_replay_request_needs_a_bar_length_of_at_least_one() {
+        for specifier in ["0", "", "lots"] {
+            let err = tick_replay()
+                .bar_type_specifier(specifier)
+                .build()
+                .unwrap_err()
+                .to_string();
+            assert!(
+                err.contains("bar_length must be at least 1"),
+                "{specifier}: {err}"
+            );
+        }
+
+        assert_eq!(tick_replay().bar_length(5).bar_type_specifier, "5");
+    }
+
+    #[test]
+    fn a_time_replay_request_needs_a_bar_type_and_period() {
+        assert!(time_replay().validate().is_ok());
+
+        let err = TimeBarReplayRequest {
+            bar_type: None,
+            ..time_replay()
+        }
+        .validate()
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("requires a bar_type"), "{err}");
+
+        let err = time_replay()
+            .bar_type_period(0)
+            .build()
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("bar_type_period must be at least 1"), "{err}");
     }
 }


### PR DESCRIPTION
## What

Five functions carried `#[allow(clippy::too_many_arguments)]`, and all five were on the replay path:

| Function | Args |
|---|---|
| `SenderApi::request_tick_bar_replay` | 7 |
| `SenderApi::request_time_bar_replay` | 8 |
| `SenderApi::request_volume_profile_minute_bars` | 7 |
| `RithmicHistoryPlantHandle::tick_bar_page` | 7 |
| `RithmicHistoryPlantHandle::time_bar_page` | 8 |

Each threaded the same positional arguments through, and adding `resume_bars` in #91 is what pushed them over the limit. They now take a request struct instead, built the same way the order commands are: `new()`, chained setters, `validate()`, `build()`.

All five allows are gone.

## New types

- **`TickBarReplayRequest`** and **`TimeBarReplayRequest`** — the replay counterparts of the existing `VolumeProfileMinuteBarsRequest`, which now reaches its sender whole rather than being unpacked field by field at the call site.
- **`TimeBarType`** — an alias for the generated `request_time_bar_replay::BarType`, under a name that reads better on a request.

```rust
let request = TickBarReplayRequest::new()
    .symbol("ESU6")
    .exchange("CME")
    .bar_length(1)
    .start_time_sec(1_750_000_000)
    .end_time_sec(1_750_003_600)
    .resume_bars(true)
    .build()?;
```

## Internals

- `HistoryPlantCommand::LoadTicks` and `LoadTimeBars` carry the request instead of eight loose fields, matching `LoadVolumeProfileMinuteBars`.
- `tick_bar_page` / `time_bar_page` are renamed `tick_bar_replay` / `time_bar_replay` — nothing pages any more.
- The window and instrument checks the three requests share moved into one `validate_replay_window` helper.

## What callers see

The `load_*` methods keep their flat signatures and build the request internally, so ordinary use is unchanged. Validation is wider, though: an empty symbol or exchange, a bar length or period below 1, a non-positive timestamp, or a window that ends before it starts now fail with `InvalidArgument` before anything is sent. Only a zero `bar_length` was caught before.

That change caught four existing tests passing `start_time_sec: 0`, which is genuinely invalid — they now use real timestamps.

## One wart

`TimeBarReplayRequest` has no serde derive, because its `bar_type` is a generated protobuf enum with no `Serialize`. `TickBarReplayRequest` is all primitives and does derive it. A crate-owned bar-type enum would close the gap, but that's a wider API change than this PR.

## Checks

`cargo fmt`, `cargo test --all` (354 lib tests, 44 doctests) and `cargo clippy --all-targets --all-features` are clean.
