### PR TITLE
chore(deps): move tokio-tungstenite to 0.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 futures-util = "0.3"
 prost = "0.14.3"
 tokio = { version = "1.50.0", features = ["rt-multi-thread", "macros", "net", "time", "sync"] }
-tokio-tungstenite = { version = "0.29.0", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.30.0", features = ["native-tls"] }
 tracing = "0.1.44"
 
 [dev-dependencies]


### PR DESCRIPTION
Moves `tokio-tungstenite` from `0.29` to `0.30`. One line in `Cargo.toml`.

## Why this is the only change

`Cargo.lock` is gitignored (`.gitignore:6`), the normal setup for a library, so CI and downstream consumers already resolve fresh on every build. The manifest cap on `tokio-tungstenite` was the only thing this crate was actually holding back. After the bump, `cargo update --dry-run` reports nothing behind latest — every dependency sits at its newest release compatible with `rust-version = "1.85"`.

## Why the major bump is not breaking

No `tungstenite` type appears in the public API. `ws` is a private module (`src/lib.rs:284`) and the only item re-exported from it is `ConnectStrategy`, whose signature has no tungstenite in it. `tungstenite::{Error, Message}` are confined to `src/ws.rs` and `src/plants/core.rs`. A consumer pinning its own `tungstenite` is unaffected.

The 0.30 changelog has two entries, neither of which reaches us:

- Rejects non-compliant clients during the server-side handshake. This crate is client-only.
- Raises MSRV to 1.85, already this crate's floor.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features` — 354 unit tests, 44 doctests, 0 failed
- `cargo +1.85 test --all-features --all-targets` — 354 passed, matching the CI MSRV job
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean, matching the CI docs job
- `cargo audit --deny warnings` — 0 vulnerabilities, 0 warnings across 113 crates

One caveat on the audit: it scanned the local lockfile, which is not committed, so CI resolves its own versions and this result does not carry over. Adding a `cargo audit` CI job was considered and deliberately left out of this PR.

No changelog entry — this is invisible to downstream code.