### PR TITLE
chore(release): cut 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.0] - 2026-08-09
+## [3.0.0]
 
 Order commands are now built with `::new()` and chained setters, the generated
 protobuf enums are replaced by crate-owned ones, and every order call takes a
@@ -129,7 +129,7 @@ account.
   setters and `build()`** — they have no separate `validate()` — and neither
   implements `Default`; `TrailingStop` had one at 2.0.0.
   `TrailingStop` gains a required `trail_by_price_id: i32`; `build()` refuses a
-  zero id (Rithmic rejects it with rp_code 1112) and a `trail_by_ticks` below one.
+  zero id and a `trail_by_ticks` below one.
   `RithmicIfTouchedTrigger::price` is `Option<f64>` and its `build()` requires a
   symbol, an exchange and the price. An unset price is omitted rather than sent as
   `0.0`, which the default `GreaterThanEqualTo`/`TradePrice` condition would fire
@@ -414,8 +414,8 @@ account.
   fallback to the order's own price covered only the two stop types; it now covers
   the same four types `validate()` requires a trigger for.
 
-- **Single-order trailing stops omitted `trail_by_price_id`**, which Rithmic
-  rejected with rp_code 1112.
+- **Single-order trailing stops omitted `trail_by_price_id`**, so the trailing
+  stop was sent without the price-id it trails against.
 
 - **Bracket target/stop adjustments omitted the `level` field**, so on a multi-leg
   bracket every adjustment landed on the server's default leg and the other legs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,13 +33,6 @@ account.
 
 ### Breaking Changes
 
-- **The three replay senders take a request struct.**
-  `SenderApi::request_tick_bar_replay`, `request_time_bar_replay` and
-  `request_volume_profile_minute_bars` take a single `&TickBarReplayRequest`,
-  `&TimeBarReplayRequest` or `&VolumeProfileMinuteBarsRequest` instead of
-  positional arguments. The history handle's `load_*` methods are unchanged —
-  they build the request for you.
-
 - **The `load_*` replay methods validate before sending.** A missing symbol or
   exchange, a `bar_length` or `bar_type_period` below 1, a non-positive
   timestamp, or an `end_time_sec` before `start_time_sec` returns
@@ -87,7 +80,7 @@ account.
   | `BracketCondition` | `OrderCondition` |
   | `BracketPriceField` | `OrderPriceField` |
 
-  `BracketType` and `EasyToBorrowRequest` keep their names but now resolve to
+  The remaining two, `BracketType` and `EasyToBorrowRequest`, keep their names but now resolve to
   crate-owned enums rather than `rti::request_bracket_order::BracketType` and
   `rti::request_easy_to_borrow_list::Request`.
 
@@ -132,8 +125,9 @@ account.
 - **`load_volume_profile_minute_bars` takes a `VolumeProfileMinuteBarsRequest`**
   instead of seven positional arguments. See [MIGRATING.md](MIGRATING.md) §6.
 
-- **`TrailingStop` and `RithmicIfTouchedTrigger` are built like the order
-  commands**, and neither implements `Default` — `TrailingStop` had one at 2.0.0.
+- **`TrailingStop` and `RithmicIfTouchedTrigger` are built with `new()`, chained
+  setters and `build()`** — they have no separate `validate()` — and neither
+  implements `Default`; `TrailingStop` had one at 2.0.0.
   `TrailingStop` gains a required `trail_by_price_id: i32`; `build()` refuses a
   zero id (Rithmic rejects it with rp_code 1112) and a `trail_by_ticks` below one.
   `RithmicIfTouchedTrigger::price` is `Option<f64>` and its `build()` requires a
@@ -177,8 +171,8 @@ account.
 
 - **`show_fill_history(range, max_record_count)`** on the order handle — the
   account's fill history (templates 3512/3513), one response per fill. Pass a range
-  in either format the request accepts, and `None` for an uncapped count; above
-  10,000 is refused with `RithmicError::InvalidArgument`.
+  in either format the request accepts, and `None` for an uncapped count; anything
+  outside 0–10,000 is refused with `RithmicError::InvalidArgument`.
 
   ```rust
   let fills = handle
@@ -202,8 +196,8 @@ account.
       .await?;
   ```
 
-  The window is buffered before the call returns — a 23-hour ES session is roughly
-  800,000 records in memory.
+  The window is buffered before the call returns — a 23-hour ES session runs to
+  hundreds of thousands of records in memory.
 
 #### Command types and fields
 
@@ -217,16 +211,25 @@ account.
   and `if_touched` on `RithmicOrder`; group-level cancel timing on `RithmicOcoOrder`;
   `trigger_price`, `trail_by_ticks` and `if_touched` on `RithmicModifyOrder`; and
   `trading_algorithm` on `RithmicExitPosition`. With these, every field of the
-  eleven order request messages is reachable from a command type. On the OCO leg,
+  eleven order request messages that describes the order is reachable from a
+  command type. The session-scoped fields — `template_id`, `user_msg`, `fcm_id`,
+  `ib_id`, `account_id` and `user_type` — still come from the login and the
+  account. On the OCO leg,
   `window_name` is all-or-none across legs like `user_tag`: set it on one leg and
   every leg gets a slot.
 
 - **`validate()` on every command type that has something to check**, public as
-  well as called by `build()`. Every command needs a symbol, an exchange and a
-  positive quantity — plus the basket id on `RithmicModifyOrder`. On top of that,
-  `Limit`, `StopLimit` and `LimitIfTouched` need a price, and the stop and
-  if-touched types need a trigger; `Market` needs neither. Failures return
-  `RithmicError::InvalidArgument`. Nothing beyond this is checked locally.
+  well as called by `build()`. The commands that carry an instrument —
+  `RithmicOrder`, `RithmicBracketOrder`, `RithmicOcoOrderLeg` and
+  `RithmicModifyOrder` — need a symbol, an exchange and a positive quantity. The
+  ones that name an existing order — `RithmicModifyOrder`, `RithmicCancelOrder`,
+  `RithmicBracketLevelAdjustment` and `RithmicModifyOrderReferenceData` — need its
+  basket id, and `RithmicLinkOrders` needs at least two. On top of that, `Limit`,
+  `StopLimit` and `LimitIfTouched` need a price, and the stop and if-touched types
+  need a trigger; `Market` needs neither. On `RithmicModifyOrder` a `price` stands
+  in for a missing `trigger_price`, matching the fallback the sender applies.
+  Failures return `RithmicError::InvalidArgument`. Nothing beyond this is checked
+  locally.
 
 - **`RithmicExitPosition` can flatten the whole account.** `symbol` and `exchange`
   are `Option<String>` and come as a pair: set both to exit one instrument, set
@@ -311,7 +314,7 @@ account.
   lost struct-literal syntax, pre-filled from the same environment variables
   `RithmicConfig::from_env` reads so a single field can be overridden.
 
-- **Reconnect backoff is jittered** by a random factor in `[0.5, 1.5)`, applied
+- **Reconnect backoff is jittered** by a clock-derived factor in `[0.5, 1.5)`, applied
   after the cap, so plants that lost the same connection no longer retry in
   lockstep. The schedule is otherwise unchanged — 500 ms more per attempt, capped
   at 60 seconds — giving 30–90 s delays at the cap.
@@ -392,8 +395,8 @@ account.
 
 - **An order sent from a cloned handle alongside `disconnect()` could reach Rithmic
   while its caller saw `ConnectionClosed`** — a recorded failure for an order that
-  was live at the exchange. The order and PnL plants now reject queued commands once
-  a disconnect is in flight.
+  was live at the exchange. Every plant now rejects queued commands once a
+  disconnect is in flight.
 
 - **A failed logout made `disconnect()` return early without sending `Close`**,
   leaving the actor with `close_requested` set: no heartbeats, every later command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Order commands are now built with `::new()` and chained setters, the generated
 protobuf enums are replaced by crate-owned ones, and every order call takes a
-command struct. This ships as a major release.
+command struct.
 
-**[MIGRATING.md](MIGRATING.md) walks through the upgrade** with before/after code
-for each change below.
+**[MIGRATING.md](MIGRATING.md) has before/after code for every change below.**
 
-### Changes that compile but alter live order flow
+### Behavior changes the compiler will not catch
 
-These need no code change, so the compiler will not point at them. Read this list
-before the first run against a live account.
+Nothing here needs a code change. Read it before the first run against a live
+account.
 
 - **Orders route off the exchange's published trade route** instead of a hardcoded
   `"globex"`/`"simulator"`. With no route published and none set on the command,
@@ -26,7 +25,7 @@ before the first run against a live account.
   `.manual_or_auto(ManualOrAutoEntry::Manual)` to keep the old attribution.
 - **A target-only bracket now sends `TARGET_ONLY_STATIC`** rather than
   `TargetAndStopStatic`, which 2.x sent whatever legs you supplied.
-- **`get_account_list` and `get_account_rms_info` may return fewer accounts,** now
+- **`get_account_list` and `get_account_rms_info` may return fewer accounts**, now
   that requests are scoped with the real login info instead of a hardcoded `Trader`
   user type.
 - **Market orders no longer go out priced at `0.0`** — an unset price is omitted.
@@ -36,39 +35,49 @@ before the first run against a live account.
 
 - **The three replay senders take a request struct.**
   `SenderApi::request_tick_bar_replay`, `request_time_bar_replay` and
-  `request_volume_profile_minute_bars` each took seven or eight positional
-  arguments; they now take a single `&TickBarReplayRequest`,
-  `&TimeBarReplayRequest` or `&VolumeProfileMinuteBarsRequest`. The history
-  plant's `load_*` methods are unchanged — they build the request for you.
+  `request_volume_profile_minute_bars` take a single `&TickBarReplayRequest`,
+  `&TimeBarReplayRequest` or `&VolumeProfileMinuteBarsRequest` instead of
+  positional arguments. The history handle's `load_*` methods are unchanged —
+  they build the request for you.
 
 - **The `load_*` replay methods validate before sending.** A missing symbol or
   exchange, a `bar_length` or `bar_type_period` below 1, a non-positive
-  timestamp, or an `end_time_sec` before `start_time_sec` now returns
-  `RithmicError::InvalidArgument` without a round trip. Previously only a zero
-  `bar_length` was caught.
+  timestamp, or an `end_time_sec` before `start_time_sec` returns
+  `RithmicError::InvalidArgument` without a round trip.
 
 - **Order command types are their own builders and are `#[non_exhaustive]`.**
   `..Default::default()` no longer compiles on them outside this crate. `new()`
   takes no arguments, every field has a setter of the same name, and `build()`
-  runs `validate()` and returns `Result<_, RithmicError>`. The fields stay public,
-  so direct assignment still works — but the handles send what they are given, so a
-  command that skips `build()` skips validation and the derived `bracket_type`.
+  runs `validate()` and returns `Result<_, RithmicError>`.
+
+  ```rust
+  let order = RithmicOrder::new()
+      .symbol("ESM6")
+      .exchange("CME")
+      .quantity(1)
+      .transaction_type(OrderSide::Buy)
+      .price_type(OrderType::Limit)
+      .price(5000.0)
+      .build()?;
+  ```
+
+  Fields stay public, so direct assignment still works — but the handles send what
+  they are given, so a command that skips `build()` skips validation and the
+  derived `bracket_type`.
 
 - **`RithmicConfig`, `RithmicAccount`, `LoginConfig`, `InstrumentInfo`,
   `InstrumentInfoError`, `RithmicEnv`, `TrailingStop`, `RithmicIfTouchedTrigger`
-  and all 246 generated protobuf types are `#[non_exhaustive]`.** Rithmic added
-  fields to existing messages in 24 of its 35 template releases, so without this
-  every proto refresh would be a major bump here. Struct literals stop compiling
-  downstream, and matches on generated enums need a `_` arm.
+  and all 246 generated protobuf types are `#[non_exhaustive]`.** Struct literals
+  stop compiling downstream. Use the builder where there is one, `Default::default()`
+  plus field assignment on the generated types, and a `_` arm on matches over
+  generated enums.
 
 - **Fourteen generated enum re-exports leave the crate root, replaced by
-  crate-owned enums.** The per-request generated enums named the same concepts but
-  were mutually incompatible, so one order could not be expressed against two
-  request types. Variant names are unchanged, so the arms port over — but the
-  crate-owned enums are `#[non_exhaustive]`, so every `match` needs a `_` arm it
-  did not need before, and `OrderType` carries six variants where `OcoPriceType`
-  had four. The prost-specific surface (`as i32`, `try_from`, `from_str_name`,
-  derived `Ord`) does not carry over; `as_str_name` does.
+  crate-owned enums.** Variant names are unchanged, so the arms port over as
+  written. Two things do not: the crate-owned enums are `#[non_exhaustive]`, so
+  every `match` needs a `_` arm, and `OrderType` carries six variants where
+  `OcoPriceType` had four. The prost-specific surface (`as i32`, `try_from`,
+  `from_str_name`, derived `Ord`) does not carry over; `as_str_name` does.
 
   | removed | use instead |
   |---|---|
@@ -80,8 +89,7 @@ before the first run against a live account.
 
   `BracketType` and `EasyToBorrowRequest` keep their names but now resolve to
   crate-owned enums rather than `rti::request_bracket_order::BracketType` and
-  `rti::request_easy_to_borrow_list::Request` — the last raw generated types on the
-  curated surface, so a proto refresh can no longer change this crate's API.
+  `rti::request_easy_to_borrow_list::Request`.
 
 - **Seven handle method names change, covering ten methods** (`list_system_info`
   exists on all four plants). Each is now named after the request it sends.
@@ -118,19 +126,24 @@ before the first run against a live account.
   the command as a `.manual_or_auto(..)` field, defaulting to `Auto`.
 
 - **`adjust_target`/`adjust_stop` take a `RithmicBracketLevelAdjustment`** instead
-  of `(id, ticks)`, adding a `level` field that selects which bracket leg to
-  adjust — `level: None` keeps the old behavior. **`load_volume_profile_minute_bars`
-  takes a `VolumeProfileMinuteBarsRequest`** instead of seven positional arguments;
-  see [MIGRATING.md](MIGRATING.md) §6 for the call.
+  of `(id, ticks)`. The new `level` field selects which bracket leg to adjust;
+  `level: None` keeps the old behavior.
+
+- **`load_volume_profile_minute_bars` takes a `VolumeProfileMinuteBarsRequest`**
+  instead of seven positional arguments. See [MIGRATING.md](MIGRATING.md) §6.
 
 - **`TrailingStop` and `RithmicIfTouchedTrigger` are built like the order
-  commands,** and neither implements `Default` — `TrailingStop` had one at 2.0.0.
+  commands**, and neither implements `Default` — `TrailingStop` had one at 2.0.0.
   `TrailingStop` gains a required `trail_by_price_id: i32`; `build()` refuses a
   zero id (Rithmic rejects it with rp_code 1112) and a `trail_by_ticks` below one.
-  `RithmicIfTouchedTrigger::price` is `Option<f64>`, its `build()` requires a
-  symbol, an exchange and the price, and an unset price is omitted rather than sent
-  as `0.0` — which the default `GreaterThanEqualTo`/`TradePrice` condition would
-  have fired on immediately.
+  `RithmicIfTouchedTrigger::price` is `Option<f64>` and its `build()` requires a
+  symbol, an exchange and the price. An unset price is omitted rather than sent as
+  `0.0`, which the default `GreaterThanEqualTo`/`TradePrice` condition would fire
+  on immediately.
+
+  ```rust
+  let stop = TrailingStop::new().trail_by_ticks(15).trail_by_price_id(7).build()?;
+  ```
 
 - **`RithmicConfig` gains a required `request_timeout: Duration`.** Build it with
   `RithmicConfig::builder(env)` or `RithmicConfigBuilder::from_env(env)` — the type
@@ -149,8 +162,7 @@ before the first run against a live account.
   stays at the crate root: spell `rithmic_rs::ws::ConnectStrategy` as
   `rithmic_rs::ConnectStrategy`.
 
-- **Smaller changes.** The first four are mechanical; the last two change what the
-  server sees and are repeated at the top of this section.
+- **Smaller changes.** All mechanical.
 
   | change | what to do |
   |---|---|
@@ -158,16 +170,21 @@ before the first run against a live account.
   | `RithmicOrder::duration` is `TimeInForce`, not `Option<TimeInForce>` | unwrap; `None` already sent `Day`, so the wire is unchanged |
   | `ConfigError::InvalidValue` is `#[non_exhaustive]` at the variant | destructuring `{ var, reason }` needs a `..` |
   | new `Option` fields on the command types | leave `None` to keep old behavior |
-  | `cancel_all_orders` is attributed `Auto`, not `Manual` | set `.manual_or_auto(ManualOrAutoEntry::Manual)` to keep the old attribution |
-  | an empty `user_tag` echoes back as `None`, not `Some("")` | the field is no longer sent as `""` |
 
 ### Added
 
+#### New calls
+
 - **`show_fill_history(range, max_record_count)`** on the order handle — the
-  account's fill history (templates 3512/3513, new in 5.42), one response per fill.
-  `FillHistoryRange` takes either format the request accepts: `ssboe(start, finish)`
-  or `trade_date(start, finish)`. A `max_record_count` above 10,000 is refused with
-  `RithmicError::InvalidArgument`, since Rithmic rejects it.
+  account's fill history (templates 3512/3513), one response per fill. Pass a range
+  in either format the request accepts, and `None` for an uncapped count; above
+  10,000 is refused with `RithmicError::InvalidArgument`.
+
+  ```rust
+  let fills = handle
+      .show_fill_history(FillHistoryRange::trade_date(20260801, 20260809), None)
+      .await?;
+  ```
 
 - **`get_user_info(user)`** on the order handle — a user's profile, entitlement
   status and session limits (templates 3510/3511); pass `None` for the logged-in
@@ -176,71 +193,19 @@ before the first run against a live account.
   `ProtocolError`.
 
 - **`load_ticks_all`, `load_tick_bars_all` and `load_time_bars_all`** — replay
-  loaders that return the whole window instead of the first 10,000 records.
-  A plain replay stops at 10,000 and says nothing about it: the closing response
-  of a truncated replay is byte-identical to a complete one's. These loaders set
-  `resume_bars` on the request, which lifts the cap, so one request covers the
-  window. The whole window is buffered before it returns, so a full 23-hour ES
-  session is roughly 800,000 records in memory.
+  loaders that return the whole window. The plain loaders stop at 10,000 records
+  and give no sign they did, so prefer these unless you want the cap.
 
-- **`TickBarReplayRequest` and `TimeBarReplayRequest`**, the replay counterparts
-  of `VolumeProfileMinuteBarsRequest`. Same shape as the order commands: `new()`,
-  chained setters, `validate()` and `build()`. They carry `user_max_count` and
-  `resume_bars`, so a caller building requests directly can cap or uncap a replay
-  themselves.
+  ```rust
+  let bars = handle
+      .load_time_bars_all(symbol, exchange, TimeBarType::MinuteBar, 5, start, end)
+      .await?;
+  ```
 
-- **`TimeBarType`**, an alias for the generated `request_time_bar_replay::BarType`
-  under a name that reads better on a request.
+  The window is buffered before the call returns — a 23-hour ES session is roughly
+  800,000 records in memory.
 
-- **Per-order trade routes.** The new `trade_route` field on `RithmicOrder`,
-  `RithmicBracketOrder` and `RithmicOcoOrderLeg` overrides the route the plant
-  would pick, including one the server never published. **`trade_route_for(exchange)`**
-  reports the route an order would take now, **`record_trade_route(update)`** applies
-  a `TradeRoute` update to the cache, and **`RithmicError::NoTradeRoute`** is
-  returned when no route exists and the order set none.
-
-- **`validate()` on every command type that has something to check**, public as
-  well as called by `build()`. `Limit`, `StopLimit` and `LimitIfTouched` need a
-  price; the stop and if-touched types need a trigger; `Market` needs neither. It
-  also requires a symbol, an exchange and a positive quantity — and the basket id on
-  `RithmicModifyOrder`. It returns `RithmicError::InvalidArgument`. Market rules
-  beyond this are deliberately not enforced: Rithmic is the authority on what it
-  accepts.
-
-- **`RithmicExitPosition` can flatten the whole account.** Its `symbol` and
-  `exchange` are `Option<String>` and come as a pair — both set exits one
-  instrument, neither set sends the fields absent, which template 3504 reads as
-  every position on the account. The crate previously always sent them.
-
-- **Multi-leg OCO orders.** A `RithmicOcoOrder` now carries two or more legs
-  instead of a fixed pair, and each leg can carry its own trailing stop. Fewer than
-  two legs is rejected, since Rithmic has nothing to cancel a lone leg against.
-
-- **`RithmicBracketOrder::operation_type` and the `BracketOperationType` enum** —
-  the `order_operation_type` field Rithmic added in 5.37, selecting which event on
-  one order of the bracket cancels the rest. Leave it unset and it stays off the
-  wire, as before — async_rithmic, the Python client for the same API, tried
-  defaulting it to `OCA` and reverted after it broke bracket orders.
-
-- **`RithmicMessage::UnknownTemplate(UnknownTemplateMessage)`** — a frame whose
-  `template_id` has no definition here, body kept as received, with
-  **`decode_as<M>()`, `payload_hex()` and `from_payload_hex()`** to decode it into
-  your own `prost` type or capture it for replay. `Ok` from `decode_as` is not
-  proof the type was guessed right. **`RithmicMessage::RequestHeartbeat`**
-  (template 18) is now mapped too; the library does not reply to it.
-
-- **Request timeouts.** `rithmic_rs::DEFAULT_REQUEST_TIMEOUT` (30 seconds),
-  `RithmicConfigBuilder::request_timeout` and the `RITHMIC_REQUEST_TIMEOUT_SECS`
-  environment variable control how long a request waits before failing with the new
-  `RithmicError::RequestTimeout`.
-
-- **Crate-owned `ManualOrAutoEntry`, `OrderCondition`, `OrderPriceField` and
-  `RmsUpdateBits`** at the crate root, joining `OrderSide`, `OrderType` and
-  `TimeInForce`. `ManualOrAutoEntry` is new outright — origination was never
-  exposed before — defaults to `Auto` on every command, and converts into all seven
-  per-request `OrderPlacement` enums, which have no `Default` of their own.
-  `OrderCondition` defaults to `GreaterThanEqualTo` and `OrderPriceField` to
-  `TradePrice`, the values an unconfigured `RithmicIfTouchedTrigger` sends.
+#### Command types and fields
 
 - **`RithmicCancelAllOrders`, `RithmicExitPosition`, `RithmicLinkOrders`,
   `RithmicModifyOrderReferenceData` and `RithmicBracketLevelAdjustment`** — command
@@ -256,37 +221,107 @@ before the first run against a live account.
   `window_name` is all-or-none across legs like `user_tag`: set it on one leg and
   every leg gets a slot.
 
-- **RMS auto-liquidation streaming** — pass `RmsUpdateBits::AutoLiqThresholdCurrentValue`
-  to `subscribe_account_rms_updates`. An empty `Vec` omits `update_bits` rather
-  than sending `0`.
+- **`validate()` on every command type that has something to check**, public as
+  well as called by `build()`. Every command needs a symbol, an exchange and a
+  positive quantity — plus the basket id on `RithmicModifyOrder`. On top of that,
+  `Limit`, `StopLimit` and `LimitIfTouched` need a price, and the stop and
+  if-touched types need a trigger; `Market` needs neither. Failures return
+  `RithmicError::InvalidArgument`. Nothing beyond this is checked locally.
 
-- **`serde` derives on every order command type** behind the `serde` feature, so a
-  strategy can persist and replay any command.
+- **`RithmicExitPosition` can flatten the whole account.** `symbol` and `exchange`
+  are `Option<String>` and come as a pair: set both to exit one instrument, set
+  neither to exit every position on the account.
+
+  ```rust
+  handle.exit_position(RithmicExitPosition::new().build()?).await?; // flatten all
+  ```
+
+- **Multi-leg OCO orders.** A `RithmicOcoOrder` takes two or more legs instead of a
+  fixed pair, each able to carry its own trailing stop. Fewer than two legs is
+  rejected.
+
+- **`RithmicBracketOrder::operation_type` and the `BracketOperationType` enum** —
+  the `order_operation_type` field added in 5.37, selecting which event on one
+  order of the bracket cancels the rest. Left unset it stays off the wire.
+
+- **Per-order trade routes.** The new `trade_route` field on `RithmicOrder`,
+  `RithmicBracketOrder` and `RithmicOcoOrderLeg` overrides the route the crate
+  would pick, including one the server never published. On the order handle,
+  `trade_route_for(exchange)` reports the route an order would take now and
+  `record_trade_route(update)` applies a `TradeRoute` update to the cache.
+  `RithmicError::NoTradeRoute` comes back when no route exists and the order set
+  none.
+
+  ```rust
+  let route = handle.trade_route_for("CME").await?;      // what an order would use
+  let order = RithmicOrder::new().trade_route("globex"); // or pick one yourself
+  ```
+
+#### Types and re-exports
+
+- **Crate-owned `ManualOrAutoEntry`, `OrderCondition`, `OrderPriceField` and
+  `RmsUpdateBits`** at the crate root, joining `OrderSide`, `OrderType` and
+  `TimeInForce`. `ManualOrAutoEntry` sets order origination and defaults to `Auto`
+  on every command. `OrderCondition` defaults to `GreaterThanEqualTo` and
+  `OrderPriceField` to `TradePrice` — what an unconfigured `RithmicIfTouchedTrigger`
+  sends.
+
+- **`TickBarReplayRequest` and `TimeBarReplayRequest`**, the replay counterparts
+  of `VolumeProfileMinuteBarsRequest`. Same shape as the order commands: `new()`,
+  chained setters, `validate()` and `build()`. Set `user_max_count` to cap a
+  replay or `resume_bars` to uncap it.
+
+- **`TimeBarType`**, an alias for the generated `request_time_bar_replay::BarType`.
+
+- **`RithmicMessage::UnknownTemplate(UnknownTemplateMessage)`** — a frame whose
+  `template_id` has no definition here, body kept as received, with
+  **`decode_as<M>()`, `payload_hex()` and `from_payload_hex()`** to decode it into
+  your own `prost` type or capture it for replay. `Ok` from `decode_as` is not
+  proof the type was guessed right. **`RithmicMessage::RequestHeartbeat`**
+  (template 18) is now mapped too; the library does not reply to it.
+
+- **Trait impls and re-exports.**
+  - `Clone` on the order and PnL handles (ticker and history already had it). A
+    clone's `subscription_receiver` starts at the clone and does not replay
+    earlier updates.
+  - `PartialEq` on the command types and on `RithmicMessage`, `RithmicResponse`,
+    `LoginConfig` and `ConfigError`.
+  - `#[must_use]` on the command, trigger and request types.
+  - `SubscriptionFilter`, `rithmic_rs::prost` and the new order enums at the
+    crate root.
+
+- **The generated types pick up the fields Rithmic added through 5.42.**
+
+  | type | new fields |
+  |---|---|
+  | `ResponseLoginInfo` | contact, address, `order_copy_status`, per-plant session counts |
+  | `ResponseAccountList` | `loss_limit`, creation timestamps |
+  | `ExchangeOrderNotification` | `source_*` |
+  | `ResponseListExchangePermissions` | `level_1_market_data`, `level_2_market_data` (`entitlement_flag` now `#[deprecated]`) |
+  | `TickBar`, `ResponseTickBarReplay` | `data_bar_seq_num` |
+
+#### Connection and config
+
+- **Request timeouts.** `rithmic_rs::DEFAULT_REQUEST_TIMEOUT` (30 seconds),
+  `RithmicConfigBuilder::request_timeout` and the `RITHMIC_REQUEST_TIMEOUT_SECS`
+  environment variable control how long a request waits before failing with the new
+  `RithmicError::RequestTimeout`.
+
+- **`RithmicConfigBuilder::from_env(env)`** — a construction path for a type that
+  lost struct-literal syntax, pre-filled from the same environment variables
+  `RithmicConfig::from_env` reads so a single field can be overridden.
 
 - **Reconnect backoff is jittered** by a random factor in `[0.5, 1.5)`, applied
   after the cap, so plants that lost the same connection no longer retry in
   lockstep. The schedule is otherwise unchanged — 500 ms more per attempt, capped
   at 60 seconds — giving 30–90 s delays at the cap.
 
-- **`RithmicConfigBuilder::from_env(env)`** — a construction path for a type that
-  lost struct-literal syntax, pre-filled from the same environment variables
-  `RithmicConfig::from_env` reads so a single field can be overridden.
+- **RMS auto-liquidation streaming** — pass `RmsUpdateBits::AutoLiqThresholdCurrentValue`
+  to `subscribe_account_rms_updates`. An empty `Vec` omits `update_bits` rather
+  than sending `0`.
 
-- **Trait impls and re-exports.** `Clone` on the order and PnL handles (the ticker
-  and history handles already had it) — a clone's `subscription_receiver` starts at
-  the moment of the clone and does not replay earlier updates. `PartialEq` on the
-  command types and on `RithmicMessage`, `RithmicResponse`, `LoginConfig` and
-  `ConfigError`; `#[must_use]` on the command, trigger and request types; and
-  `SubscriptionFilter`, `rithmic_rs::prost` and the new order enums re-exported at
-  the crate root.
-
-- **The generated types pick up the fields Rithmic added through 5.42,** including
-  contact,
-  address, `order_copy_status` and per-plant session counts on `ResponseLoginInfo`;
-  `loss_limit` and creation timestamps on `ResponseAccountList`; `source_*` on
-  `ExchangeOrderNotification`; `level_1_market_data`/`level_2_market_data` on
-  `ResponseListExchangePermissions` (with `entitlement_flag` now `#[deprecated]`);
-  and `data_bar_seq_num` on `TickBar` and `ResponseTickBarReplay`.
+- **`serde` derives on every order command type** behind the `serde` feature, so a
+  strategy can persist and replay any command.
 
 ### Changed
 
@@ -296,7 +331,7 @@ before the first run against a live account.
   `RithmicMessage::Unknown` still compiles but no longer sees these frames —
   `Unknown` now means only that a frame failed to decode.
 
-- **A `Reject` is always surfaced as a rejection,** with `rp_code` passed through
+- **A `Reject` is always surfaced as a rejection**, with `rp_code` passed through
   element for element, so codes like `["0"]` no longer make a rejected request look
   like a success. An unsolicited `Reject` — one echoing no `user_msg` — is logged
   at `warn` and dropped instead of reaching the request handler.
@@ -308,26 +343,23 @@ before the first run against a live account.
 
 ### Fixed
 
-- **Login declared template version `5.30`,** the version of the 0.84.0.0 protos
-  the crate used to bundle, while the bundled protos are now 0.89.0.0 / template
-  5.42. It declares `5.42`. The field is a client declaration rather than a
-  negotiation — Rithmic's own samples send `3.9`, and the server answers with its
-  own version whatever you send (`5.54` at the time of writing) — so this changes
-  no server behavior. It just stops the login misreporting what the crate speaks.
+- **Login declared template version `5.30`** while the bundled protos were 5.42.
+  It declares `5.42`. Nothing about the session changes — the field is a client
+  declaration, not a negotiation.
 
-- **Market orders were sent with `price = 0.0`,** and multi-leg OCO orders
+- **Market orders were sent with `price = 0.0`**, and multi-leg OCO orders
   zero-filled `price` and `trigger_price`. Both now follow the all-or-none rule the
   trailing-stop fields already used: absent when no leg carries one, index-aligned
   once any leg does.
 
-- **Every order went out on `"globex"` or `"simulator"` regardless of exchange,**
+- **Every order went out on `"globex"` or `"simulator"` regardless of exchange**,
   ignoring the routes the server publishes. The plant now uses the published route
   for the order's exchange, preferring one marked default, read once at `login()`.
 
-- **Requests carried a hardcoded `Trader` user type,** and the account list request
+- **Requests carried a hardcoded `Trader` user type**, and the account list request
   carried no `fcm_id`/`ib_id`, so FCM and IB logins saw no accounts. `login()` now
   scopes requests with the real login info. As a result, **`get_account_list` and
-  `get_account_rms_info` may return fewer accounts than before,** including for
+  `get_account_rms_info` may return fewer accounts than before**, including for
   `Trader` logins.
 
 - **Requests could wait forever.** A request whose response never arrives now fails
@@ -343,43 +375,43 @@ before the first run against a live account.
   `request_modify_order_reference_data` still sends what it is given — an empty tag
   there is how a tag is cleared.
 
-- **A frame that fails to decode is no longer discarded.** The echoed `user_msg` is
-  read off the wire even when the body will not decode, so the failure resolves the
-  matching request with `ProtocolError` instead of leaving its caller waiting.
+- **A frame that failed to decode was discarded, leaving its caller waiting.** The
+  echoed `user_msg` is now read off the wire even when the body will not decode, so
+  the failure resolves the matching request with `ProtocolError`.
 
 - **A response that ended a request without being marked `multi_response` leaked
   the parts accumulated under its id.** They were kept for the life of the
   connection and prepended to a later request that reused the id.
 
-- **The order and PnL plants now reject queued commands once a disconnect is in
-  flight.** An order submitted from a cloned handle alongside `disconnect()` could
-  still reach Rithmic while its caller saw `ConnectionClosed` — a failure on record
-  for an order that was live at the exchange.
+- **An order sent from a cloned handle alongside `disconnect()` could reach Rithmic
+  while its caller saw `ConnectionClosed`** — a recorded failure for an order that
+  was live at the exchange. The order and PnL plants now reject queued commands once
+  a disconnect is in flight.
 
-- **`disconnect()` sends `Close` even when the logout fails.** It used to return
-  early, leaving the actor with `close_requested` set: no heartbeats, every later
-  command dropped, pending requests never drained.
+- **A failed logout made `disconnect()` return early without sending `Close`**,
+  leaving the actor with `close_requested` set: no heartbeats, every later command
+  dropped, pending requests never drained. It now always sends `Close`.
 
-- **A server `ForcedLogout` (template 77) now stops the plant actor,** failing
-  pending requests with `ConnectionClosed`. The plant used to keep heartbeating a
-  session the server had already ended.
+- **A server `ForcedLogout` (template 77) left the plant heartbeating a session the
+  server had already ended.** It now stops the actor and fails pending requests with
+  `ConnectionClosed`.
 
-- **The `heartbeat_interval` from the login response is now used as the heartbeat
-  period.** Plants used `hb.max(60)`, so a server asking for a heartbeat every 30
-  seconds got one every 60 and dropped the connection as idle.
+- **Plants clamped the heartbeat period with `hb.max(60)`**, so a server asking for
+  a heartbeat every 30 seconds got one every 60 and dropped the connection as idle.
+  The `heartbeat_interval` from the login response is now used as sent.
 
 - **A `MarketIfTouched` or `LimitIfTouched` modify omitted `trigger_price`.** The
   fallback to the order's own price covered only the two stop types; it now covers
   the same four types `validate()` requires a trigger for.
 
-- **Single-order trailing stops omitted `trail_by_price_id`,** which Rithmic
+- **Single-order trailing stops omitted `trail_by_price_id`**, which Rithmic
   rejected with rp_code 1112.
 
-- **Bracket target/stop adjustments omitted the `level` field,** so on a multi-leg
+- **Bracket target/stop adjustments omitted the `level` field**, so on a multi-leg
   bracket every adjustment landed on the server's default leg and the other legs
   were unreachable.
 
-- **`request_account_rms_updates` sent `update_bits: None`,** so
+- **`request_account_rms_updates` sent `update_bits: None`**, so
   `auto_liq_threshold_current_value` never streamed even when subscribed.
 
 - **Example fixes.** `examples/bracket_order.rs` no longer exits its listener on a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -339,7 +339,14 @@ account.
 - **Documentation pass across the crate.** The "Error Handling" docs now cover
   every way an error surfaces, the rustdoc examples on the command types compile
   instead of being fenced as `ignore`, docs.rs builds with all features, and the
-  README samples show correct API usage. No API changed.
+  README samples show correct API usage. The order handle gains examples on
+  `place_order`, `place_bracket_order`, `place_oco_order`, `cancel_order`,
+  `exit_position` and `subscribe_order_updates`. Four doc claims were wrong and are
+  corrected: the handle types named `connect()` as their constructor rather than
+  `get_handle()`; `connect()` documented an error it cannot return under
+  `ConnectStrategy::Retry`, which loops until it connects rather than failing;
+  `place_order`'s example had its call commented out; and `place_oco_order`'s
+  two-leg minimum was documented only in a source comment. No API changed.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.0.0] - 2026-08-09
 
 Order commands are now built with `::new()` and chained setters, the generated
 protobuf enums are replaced by crate-owned ones, and every order call takes a
@@ -1112,6 +1112,7 @@ Previous stable release. See git history for earlier changes.
 
 ## Version History Summary
 
+- **3.0.0** (2026-08-09): Breaking changes - order commands built with `new()` + setters, crate-owned enums replace fourteen generated re-exports, every order call takes a command struct, prices are `Option<f64>`, seven handle methods renamed, required `request_timeout`; orders route off the exchange's published trade route, uncapped replay loaders, protos at 0.89.0.0
 - **2.0.0**: Breaking changes - typed `RithmicError::RequestRejected`/`ProtocolError` replace `ServerError`, `RithmicResponse::rp_code_error` removed, `RithmicAccount` split from `RithmicConfig`, account-scoped `get_handle()`, `SubscriptionFilter`; advanced bracket orders, semantic ticker subscriptions, bounded WebSocket sends
 - **1.0.0**: Breaking changes - typed `RithmicError` enum, prost 0.14, async-trait removed, `LoginConfig` for advanced login, `await_shutdown()`, non_exhaustive annotations, MSRV 1.85
 - **0.7.2** (2026-02-07): New RithmicOrder API with trigger prices and trailing stops, ticker plant unsubscribe methods, serde-compatible order types
@@ -1126,7 +1127,8 @@ Previous stable release. See git history for earlier changes.
 - **0.5.0** (2025-11-16): Major stability and API improvements - Connection strategies, unified config, panic fixes, connection health monitoring
 - **0.4.2** (2025-11-15): Previous stable release
 
-[Unreleased]: https://github.com/pbeets/rithmic-rs/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/pbeets/rithmic-rs/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/pbeets/rithmic-rs/compare/v2.0.0...v3.0.0
 [2.0.0]: https://github.com/pbeets/rithmic-rs/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/pbeets/rithmic-rs/compare/v0.7.2...v1.0.0
 [0.7.2]: https://github.com/pbeets/rithmic-rs/compare/v0.7.1...v0.7.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rithmic-rs"
-version = "2.0.0"
+version = "3.0.0"
 description = "Rust client for the Rithmic R | Protocol API to build algo trading systems"
 license = "MIT OR Apache-2.0"
 edition = "2024"

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -7,7 +7,7 @@ crate-owned ones, and every order call takes a command struct.
 Most of the work is mechanical and the compiler finds it. Work through the
 sections in order — section 1 resolves the majority of the errors.
 
-Section 9 lists what the compiler will *not* find: six changes that compile
+Section 10 lists what the compiler will *not* find: six changes that compile
 untouched and alter what reaches the exchange. Read that one even if everything
 else builds.
 
@@ -213,10 +213,55 @@ a window whose end does not precede its start. The handle runs the same checks, 
 a request that skipped `build()` fails with `RithmicError::InvalidArgument` rather
 than reaching the server incomplete.
 
+The three `RithmicSenderApi` replay methods follow suit. `request_tick_bar_replay`,
+`request_time_bar_replay` and `request_volume_profile_minute_bars` each took seven
+or eight positional arguments and now take a single `&TickBarReplayRequest`,
+`&TimeBarReplayRequest` or `&VolumeProfileMinuteBarsRequest`. This only affects
+code calling the sender API directly — the history plant's `load_*` methods keep
+their flat signatures and build the request for you.
+
+`TimeBarType` is a new alias for `rti::request_time_bar_replay::BarType`, exported
+at the crate root. The old path still works.
+
 `subscribe_account_rms_updates` gains a required `update_bits` parameter. Pass
 `vec![]` for the old behavior.
 
-## 7. Config gains a required `request_timeout`
+## 7. Your replays were probably truncated
+
+Nothing here breaks, but it is the change most likely to have been quietly
+costing you data.
+
+Rithmic caps a replay at 10,000 records and gives no sign that it did: the
+closing response of a truncated replay is byte-identical to a complete one's.
+2.x never asked for the cap to be lifted, so `load_ticks`, `load_tick_bars` and
+`load_time_bars` returned the first 10,000 records of the window and looked like
+they had returned all of it. An hour of a liquid contract runs well past that,
+and one-second bars pass it in under three hours.
+
+`load_ticks_all`, `load_tick_bars_all` and `load_time_bars_all` set Rithmic's
+`resume_bars` flag, which lifts the cap — one request, whole window, no paging.
+Same signatures otherwise, so the switch is the method name.
+
+```rust
+// Before — first 10,000 bars, silently
+let bars = handle.load_time_bars(symbol, exchange, BarType::MinuteBar, 5, start, end).await?;
+
+// After — the whole window
+let bars = handle.load_time_bars_all(symbol, exchange, TimeBarType::MinuteBar, 5, start, end).await?;
+```
+
+The whole window is buffered before the call returns, so a full 23-hour ES
+session is roughly 800,000 records in memory. The capped methods remain for when
+that is what you want.
+
+The `load_*` methods also validate now. An empty symbol or exchange, a
+`bar_length` or `bar_type_period` below 1, a non-positive timestamp, or an
+`end_time_sec` before `start_time_sec` returns `RithmicError::InvalidArgument`
+without a round trip. Only a zero `bar_length` was caught before, so a call that
+appeared to work and came back empty may now surface as an error — which is the
+point.
+
+## 8. Config gains a required `request_timeout`
 
 `RithmicConfig` has a required `request_timeout: Duration`. Build it with
 `RithmicConfig::builder(env)` or `RithmicConfigBuilder::from_env(env)`, which
@@ -230,7 +275,7 @@ A request whose response never arrives now fails with `RithmicError::RequestTime
 instead of blocking its caller forever. Reconcile a timed-out order rather than
 re-sending it.
 
-## 8. Field and module changes
+## 9. Field and module changes
 
 | change | what to do |
 |---|---|
@@ -245,7 +290,7 @@ The new fields are `trade_route` on `RithmicOrder`/`RithmicBracketOrder`/`Rithmi
 `cancel_after_secs` and `if_touched` on `RithmicOrder`; and `manual_or_auto` on
 every order command.
 
-## 9. Behavior changes that need no code change
+## 10. Behavior changes that need no code change
 
 These compile as-is but change what goes on the wire or what the server records.
 
@@ -270,7 +315,7 @@ These compile as-is but change what goes on the wire or what the server records.
   after the cap, so plants that lost the same connection no longer retry in
   lockstep. The schedule is otherwise unchanged.
 
-## 10. Protos move to 0.89.0.0
+## 11. Protos move to 0.89.0.0
 
 The bundled protos track R | Protocol API 0.89.0.0 (template version 5.42).
 
@@ -291,6 +336,8 @@ generated `UpdateType`/`AccessType` enums no longer exist.
 - [ ] Wrap prices in `Some(..)`; pass `None` for market orders
 - [ ] Move off `RithmicAdvancedBracketOrder`
 - [ ] Convert loose-argument order calls to command structs
+- [ ] Pass a request struct to the `RithmicSenderApi::request_*_replay` methods
+- [ ] Switch replays to `load_ticks_all` / `load_tick_bars_all` / `load_time_bars_all` (section 7)
 - [ ] Build `RithmicConfig` through the builder; pick a `request_timeout`
 - [ ] Add a `_` arm to matches on generated enums
 - [ ] Handle `RithmicError::NoTradeRoute` and `RithmicError::RequestTimeout`

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -52,8 +52,8 @@ they are given, so a command assembled by field access skips those checks — ca
 `validate()` yourself if you want them.
 
 `TrailingStop` and `RithmicIfTouchedTrigger` follow the same pattern, and neither
-implements `Default`. `TrailingStop` now requires `trail_by_price_id`; Rithmic
-rejects a zero id with rp_code 1112, so `build()` refuses it first.
+implements `Default`. `TrailingStop` now requires `trail_by_price_id`, and
+`build()` refuses a zero id.
 
 ```rust
 let stop = TrailingStop::new().trail_by_ticks(15).trail_by_price_id(7).build()?;

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -46,14 +46,15 @@ let mut order = RithmicOrder::new();
 order.symbol = "ESH6".into();
 ```
 
-`build()` is the opt-in strict path. It requires a symbol, an exchange, a positive
-quantity, and the prices the command's price type needs. The handles send what
+`build()` is the opt-in strict path. Commands carrying an instrument need a symbol,
+an exchange and a positive quantity; commands naming an existing order need its
+basket id; and every price type needs the prices it uses. The handles send what
 they are given, so a command assembled by field access skips those checks — call
 `validate()` yourself if you want them.
 
-`TrailingStop` and `RithmicIfTouchedTrigger` follow the same pattern, and neither
-implements `Default`. `TrailingStop` now requires `trail_by_price_id`, and
-`build()` refuses a zero id.
+`TrailingStop` and `RithmicIfTouchedTrigger` are built the same way, though they
+have no separate `validate()`, and neither implements `Default`. `TrailingStop`
+now requires `trail_by_price_id`, and `build()` refuses a zero id.
 
 ```rust
 let stop = TrailingStop::new().trail_by_ticks(15).trail_by_price_id(7).build()?;
@@ -213,13 +214,6 @@ a window whose end does not precede its start. The handle runs the same checks, 
 a request that skipped `build()` fails with `RithmicError::InvalidArgument` rather
 than reaching the server incomplete.
 
-The three `RithmicSenderApi` replay methods follow suit. `request_tick_bar_replay`,
-`request_time_bar_replay` and `request_volume_profile_minute_bars` each took seven
-or eight positional arguments and now take a single `&TickBarReplayRequest`,
-`&TimeBarReplayRequest` or `&VolumeProfileMinuteBarsRequest`. This only affects
-code calling the sender API directly — the history plant's `load_*` methods keep
-their flat signatures and build the request for you.
-
 `TimeBarType` is a new alias for `rti::request_time_bar_replay::BarType`, exported
 at the crate root. The old path still works.
 
@@ -251,7 +245,7 @@ let bars = handle.load_time_bars_all(symbol, exchange, TimeBarType::MinuteBar, 5
 ```
 
 The whole window is buffered before the call returns, so a full 23-hour ES
-session is roughly 800,000 records in memory. The capped methods remain for when
+session runs to hundreds of thousands of records in memory. The capped methods remain for when
 that is what you want.
 
 The `load_*` methods also validate now. An empty symbol or exchange, a
@@ -311,7 +305,7 @@ These compile as-is but change what goes on the wire or what the server records.
   `RithmicMessage::UnknownTemplate` with the body intact. Code matching
   `RithmicMessage::Unknown` still compiles but no longer sees these frames —
   `Unknown` now means only that a frame failed to decode.
-- **Reconnect delays are jittered** by a random factor in `[0.5, 1.5)`, applied
+- **Reconnect delays are jittered** by a clock-derived factor in `[0.5, 1.5)`, applied
   after the cap, so plants that lost the same connection no longer retry in
   lockstep. The schedule is otherwise unchanged.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Unofficial rust client for connecting to Rithmic's R | Protocol API.
 
-Supported version: **0.89.0.0**
+Supported version: **0.89.0.0** (template 5.42)
 
 ## Quick Start
 
@@ -17,7 +17,8 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rithmic-rs = "2.0.0"
+rithmic-rs = "3.0.0"
+tokio = { version = "1", features = ["full"] }
 ```
 
 Set your environment variables:
@@ -73,7 +74,47 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-See [`examples/`](examples/) for more usage patterns including [error handling](examples/error_handling.rs), [reconnection handling](examples/reconnect.rs), [order routing](examples/trade_routes.rs), and historical data loading.
+Nine runnable examples cover the rest — order routing, historical data, error
+handling and reconnection. See [Examples](#examples).
+
+## Migrating from 2.x
+
+3.0.0 reshapes the order surface. **[MIGRATING.md](MIGRATING.md)** works through
+it section by section with before/after code — section 1 alone resolves most of
+the compiler errors.
+
+The headline changes:
+
+| Change | What it means for you |
+|---|---|
+| Commands are built with `new()` + setters | `..Default::default()` no longer compiles; `build()` validates and returns a `Result` |
+| Fourteen generated enums replaced by crate-owned ones | `OrderSide`, `OrderType`, `TimeInForce` and friends; variant names are unchanged, but matches now need a `_` arm |
+| Every order call takes a command struct | `cancel_all_orders`, `exit_position`, `adjust_target`/`adjust_stop` no longer take loose arguments |
+| Prices are `Option<f64>` | Wrap in `Some(..)`; pass `None` for market orders |
+| Seven handle methods renamed | Each is now named after the request it sends |
+| `RithmicConfig` requires a `request_timeout` | Build it through `RithmicConfig::builder(env)` or `RithmicConfigBuilder::from_env(env)` |
+
+The compiler finds all of the above. **It will not find these**, which compile
+untouched and change what reaches the exchange:
+
+- Orders route off the exchange's published trade route instead of a hardcoded
+  `"globex"`/`"simulator"`. No route and no override means the order is **not
+  sent** — you get `RithmicError::NoTradeRoute`.
+- `cancel_all_orders` is now attributed `Auto`, not `Manual`.
+- A target-only bracket now sends `TARGET_ONLY_STATIC` rather than
+  `TargetAndStopStatic`.
+- `get_account_list` and `get_account_rms_info` may return fewer accounts, now
+  that requests carry the real login info.
+- Market orders no longer go out priced at `0.0` — an unset price is omitted.
+- An empty `user_tag` echoes back as `None`, not `Some("")`.
+
+Go through that list before the first run against a live account.
+[Section 10](MIGRATING.md#10-behavior-changes-that-need-no-code-change) explains
+each one and what to set to keep the old behavior.
+
+One more worth acting on even though nothing breaks: 2.x replays stopped at
+10,000 records and gave no sign they had. Switch to the `_all` loaders — see
+[History Plant](#history-plant).
 
 ## Architecture
 
@@ -108,8 +149,9 @@ let front_month = handle.get_front_month_contract("ES", "CME", false).await?;
 
 ```rust
 use rithmic_rs::{
-    ConnectStrategy, OrderSide, OrderType, RithmicAccount, RithmicCancelOrder, RithmicConfig,
-    RithmicEnv, RithmicExitPosition, RithmicOrder, RithmicOrderPlant,
+    ConnectStrategy, OrderSide, OrderType, RithmicAccount, RithmicBracketOrder, RithmicCancelOrder,
+    RithmicConfig, RithmicEnv, RithmicExitPosition, RithmicOcoOrder, RithmicOcoOrderLeg,
+    RithmicOrder, RithmicOrderPlant,
 };
 
 let config = RithmicConfig::from_env(RithmicEnv::Demo)?;
@@ -135,14 +177,10 @@ let order = RithmicOrder::new()
 
 handle.place_order(order).await?;
 
-// Bracket and OCO orders build the same way
-handle.place_bracket_order(bracket_order).await?;
-handle.place_oco_order(oco_order).await?;
-
 // Cancel by the `basket_id` carried on the order notification
 handle.cancel_order(RithmicCancelOrder::new().id(basket_id).build()?).await?;
 
-// Flatten by instrument, not by order
+// Flatten by instrument. With no symbol/exchange set it flattens the whole account.
 handle.exit_position(RithmicExitPosition::new().symbol("ESM6").exchange("CME").build()?).await?;
 ```
 
@@ -156,25 +194,112 @@ the login's profile, entitlements, and session limits (both new in 0.89).
 For multi-account workflows, create one `RithmicAccount` per account and call
 `get_handle(&account)` for each handle you need.
 
+#### Bracket and OCO orders
+
+Brackets build the same way. `.target(n)`/`.stop(n)` size their leg from the
+entry quantity at the moment they are called, so set `.quantity()` first.
+
+```rust
+let bracket = RithmicBracketOrder::new()
+    .symbol("ESM6")
+    .exchange("CME")
+    .quantity(1)
+    .action(OrderSide::Buy)
+    .price_type(OrderType::Limit)
+    .price(5000.0)
+    .target(20) // take profit 20 ticks above entry
+    .stop(10)   // stop loss 10 ticks below entry
+    .build()?;
+
+handle.place_bracket_order(bracket).await?;
+```
+
+Leave `bracket_type` unset and `build()` derives it from the legs you supplied.
+Use `.targets(..)`/`.stops(..)` with explicit `(quantity, ticks)` pairs for
+multi-leg brackets, then `adjust_target`/`adjust_stop` to move a level.
+
+An OCO order carries two or more legs, and the first to fill cancels the rest:
+
+```rust
+let oco = RithmicOcoOrder::new()
+    .leg(RithmicOcoOrderLeg::new()
+        .symbol("ESM6").exchange("CME").quantity(1)
+        .transaction_type(OrderSide::Buy)
+        .price_type(OrderType::Limit)
+        .price(4990.0)
+        .build()?)
+    .leg(RithmicOcoOrderLeg::new()
+        .symbol("ESM6").exchange("CME").quantity(1)
+        .transaction_type(OrderSide::Sell)
+        .price_type(OrderType::Limit)
+        .price(5010.0)
+        .build()?)
+    .build()?;
+
+handle.place_oco_order(oco).await?;
+```
+
+#### Trade routes
+
+Orders route off the trade route the exchange publishes, read once at `login()`.
+Check one with `trade_route_for("CME")`, or set `.trade_route(..)` on the command
+to override it. If no route exists and the command sets none, the order is **not
+sent** and you get `RithmicError::NoTradeRoute`. See
+[`examples/trade_routes.rs`](examples/trade_routes.rs).
+
 ### History Plant
 
 ```rust
-use rithmic_rs::rti::request_time_bar_replay::BarType;
+use rithmic_rs::TimeBarType;
 
 let symbol = "ESM6".to_string(); // Update to current front-month ES contract
 let exchange = "CME".to_string();
 
-// start_time / end_time are i32 unix seconds
+// start / end are i32 unix seconds
 let bars = handle
-    .load_time_bars(symbol.clone(), exchange.clone(), BarType::MinuteBar, 5, start, end)
+    .load_time_bars_all(symbol.clone(), exchange.clone(), TimeBarType::MinuteBar, 5, start, end)
     .await?;
 let ticks = handle
-    .load_ticks(symbol.clone(), exchange.clone(), start, end)
+    .load_ticks_all(symbol.clone(), exchange.clone(), start, end)
     .await?;
 
-// Load N-tick bars (e.g., 5-tick bars)
-let tick_bars = handle.load_tick_bars(symbol, exchange, 5, start, end).await?;
+// Bars aggregating a fixed number of trades (e.g. one bar per 5 trades)
+let tick_bars = handle.load_tick_bars_all(symbol, exchange, 5, start, end).await?;
 ```
+
+**Use the `_all` loaders.** Rithmic caps a replay at 10,000 records and gives no
+sign that it did — the closing response of a truncated replay is identical to a
+complete one's. The `_all` variants set `resume_bars`, which lifts the cap, so
+one request covers the window. `load_ticks`, `load_tick_bars` and
+`load_time_bars` leave the cap in place; reach for them only when you want at
+most 10,000 records.
+
+The whole window is buffered before the call returns. A full 23-hour ES session
+is roughly 800,000 records, so ask for the window you need rather than a day at
+a time.
+
+Volume profile bars take a request struct:
+
+```rust
+use rithmic_rs::VolumeProfileMinuteBarsRequest;
+
+let request = VolumeProfileMinuteBarsRequest::new()
+    .symbol("ESM6")
+    .exchange("CME")
+    .bar_type_period(5)
+    .start_time_sec(start)
+    .end_time_sec(end)
+    .build()?;
+
+let bars = handle.load_volume_profile_minute_bars(request).await?;
+```
+
+All of these validate before sending: an empty symbol or exchange, a bar length
+below 1, a non-positive timestamp, or a window that ends before it starts comes
+back as `RithmicError::InvalidArgument` with no round trip.
+
+Live bars stream through `subscribe_time_bar_updates` and
+`subscribe_tick_bar_updates`.
 
 ### PnL Plant
 
@@ -244,9 +369,42 @@ Three strategies for initial connection:
 
 If you need to handle disconnections and automatically reconnect, you must implement your own reconnection loop. See [`examples/reconnect.rs`](examples/reconnect.rs) for a complete example that tracks subscriptions and re-subscribes after reconnect.
 
-## Upgrading
+## Feature Flags
 
-See [CHANGELOG.md](CHANGELOG.md) for version history.
+| Flag | Default | What it adds |
+|---|---|---|
+| `serde` | off | `Serialize`/`Deserialize` on the config types, the trading enums, every order command and the history request types — enough to persist and replay a command |
+
+The crate uses `native-tls` (via `tokio-tungstenite`) for all WebSocket
+connections. There is no `rustls` option.
+
+MSRV is 1.85 (edition 2024).
+
+## Examples
+
+Every example is runnable against a Demo account once `.env` is filled in from
+[`examples/.env.blank`](examples/.env.blank).
+
+| Example | Shows |
+|---|---|
+| [`connect.rs`](examples/connect.rs) | Connect, log in, disconnect |
+| [`ticker.rs`](examples/ticker.rs) | Streaming quotes and trades |
+| [`bracket_order.rs`](examples/bracket_order.rs) | Placing a bracket and reading order notifications |
+| [`trade_routes.rs`](examples/trade_routes.rs) | Inspecting the routes orders will take |
+| [`load_historical_bars.rs`](examples/load_historical_bars.rs) | Time bar replay |
+| [`load_historical_ticks.rs`](examples/load_historical_ticks.rs) | Tick replay |
+| [`pnl.rs`](examples/pnl.rs) | Position and P&L updates |
+| [`error_handling.rs`](examples/error_handling.rs) | Every error the crate can hand you, in one file |
+| [`reconnect.rs`](examples/reconnect.rs) | A reconnection loop that restores subscriptions |
+
+```sh
+cargo run --example ticker
+```
+
+## Version History
+
+[CHANGELOG.md](CHANGELOG.md) has the full history. Coming from 2.x, start at
+[Migrating from 2.x](#migrating-from-2x).
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -275,8 +275,8 @@ one request covers the window. `load_ticks`, `load_tick_bars` and
 most 10,000 records.
 
 The whole window is buffered before the call returns. A full 23-hour ES session
-is roughly 800,000 records, so ask for the window you need rather than a day at
-a time.
+runs to hundreds of thousands of records, so ask for the window you need rather
+than a day at a time.
 
 Volume profile bars take a request struct:
 

--- a/examples/load_historical_bars.rs
+++ b/examples/load_historical_bars.rs
@@ -8,8 +8,8 @@ use std::{env, time::SystemTime};
 use tracing::info;
 
 use rithmic_rs::{
-    ConnectStrategy, RithmicConfig, RithmicEnv, RithmicHistoryPlant,
-    rti::{messages::RithmicMessage, request_time_bar_replay::BarType},
+    ConnectStrategy, RithmicConfig, RithmicEnv, RithmicHistoryPlant, TimeBarType,
+    rti::messages::RithmicMessage,
 };
 
 fn default_start_time() -> i32 {
@@ -54,7 +54,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .load_time_bars_all(
             symbol,
             exchange,
-            BarType::MinuteBar,
+            TimeBarType::MinuteBar,
             5,
             start_time,
             end_time,

--- a/src/api/commands/bracket.rs
+++ b/src/api/commands/bracket.rs
@@ -12,9 +12,8 @@ use crate::{
 
 /// Entry order with linked profit target and stop loss orders.
 ///
-/// Maps directly to `RequestBracketOrder`, so it carries the full venue-native
-/// surface: multiple target and stop legs, triggered entry, break-even, trailing
-/// stop management, and timed release/cancel.
+/// Supports multiple target and stop legs, triggered entry, break-even, trailing
+/// stops, and timed release/cancel.
 ///
 /// # Example: one target, one stop
 ///

--- a/src/api/commands/modify.rs
+++ b/src/api/commands/modify.rs
@@ -55,9 +55,8 @@ pub struct RithmicModifyOrder {
     pub window_name: Option<String>,
     /// Ticks to trail behind the market price.
     ///
-    /// A bare distance rather than a [`TrailingStop`](crate::TrailingStop):
-    /// `RequestModifyOrder` declares `trailing_stop` and `trail_by_ticks` but
-    /// no `trail_by_price_id`, so there is no price-id field to set.
+    /// A bare distance, not a [`TrailingStop`](crate::TrailingStop) — a modify
+    /// takes no price-id.
     pub trail_by_ticks: Option<i32>,
     /// Conditional trigger on the resulting order.
     pub if_touched: Option<RithmicIfTouchedTrigger>,

--- a/src/api/commands/order.rs
+++ b/src/api/commands/order.rs
@@ -13,9 +13,6 @@ use crate::{
 /// For orders with automatic profit targets and stop losses, use
 /// [`RithmicBracketOrder`](crate::RithmicBracketOrder) instead.
 ///
-/// This struct carries every field [`RequestNewOrder`](crate::rti::RequestNewOrder)
-/// accepts, most of which a given order does not use.
-///
 /// # Example: limit order
 ///
 /// ```

--- a/src/api/commands/triggers.rs
+++ b/src/api/commands/triggers.rs
@@ -32,8 +32,7 @@ use crate::{
 pub struct TrailingStop {
     /// Number of ticks to trail behind the market price
     pub trail_by_ticks: i32,
-    /// Rithmic price-id to trail against. Rithmic rejects a trailing stop with
-    /// rp_code 1112 when this is unset.
+    /// Rithmic price-id to trail against. `build()` requires a non-zero id.
     pub trail_by_price_id: i32,
 }
 
@@ -68,9 +67,7 @@ impl TrailingStop {
         }
         if self.trail_by_price_id < 1 {
             return Err(RithmicError::InvalidArgument(
-                "trail_by_price_id must be at least 1; Rithmic rejects a trailing stop \
-                 without one with rp_code 1112"
-                    .to_string(),
+                "trail_by_price_id must be at least 1".to_string(),
             ));
         }
         Ok(self)

--- a/src/plants/history_plant.rs
+++ b/src/plants/history_plant.rs
@@ -197,7 +197,10 @@ impl RithmicHistoryPlant {
     /// A `Result` containing the connected `RithmicHistoryPlant` instance, or an error if the connection fails.
     ///
     /// # Errors
-    /// Returns an error if unable to establish WebSocket connection to the server.
+    /// [`RithmicError::ConnectionFailed`] under [`ConnectStrategy::Simple`] only.
+    /// `Retry` and `AlternateWithRetry` never return an error — they retry until
+    /// they connect, so this call can block indefinitely if the server is
+    /// unreachable. Wrap it in `tokio::time::timeout` if you need a deadline.
     pub async fn connect(
         config: &RithmicConfig,
         strategy: ConnectStrategy,

--- a/src/plants/history_plant.rs
+++ b/src/plants/history_plant.rs
@@ -693,8 +693,8 @@ impl RithmicHistoryPlantHandle {
     /// # Cost
     ///
     /// The whole window is collected in memory before it returns. A full 23-hour
-    /// ES session is roughly 800,000 records, so ask for the window you actually
-    /// need rather than a day at a time.
+    /// ES session runs to hundreds of thousands of records, so ask for the window
+    /// you actually need rather than a day at a time.
     ///
     /// The first record's open time carries the same quirk described on
     /// [`load_ticks`](Self::load_ticks).

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -338,7 +338,10 @@ impl RithmicOrderPlant {
     /// A `Result` containing the connected `RithmicOrderPlant` instance, or an error if the connection fails.
     ///
     /// # Errors
-    /// Returns an error if unable to establish WebSocket connection to the server.
+    /// [`RithmicError::ConnectionFailed`] under [`ConnectStrategy::Simple`] only.
+    /// `Retry` and `AlternateWithRetry` never return an error — they retry until
+    /// they connect, so this call can block indefinitely if the server is
+    /// unreachable. Wrap it in `tokio::time::timeout` if you need a deadline.
     pub async fn connect(
         config: &RithmicConfig,
         strategy: ConnectStrategy,
@@ -1050,9 +1053,10 @@ impl PlantActor for OrderPlant {
 
 /// Handle for sending commands to a [`RithmicOrderPlant`] and receiving order updates.
 ///
-/// Obtained from [`RithmicOrderPlant::connect()`]. Use the methods on this handle to
-/// log in, place/modify/cancel orders, and query account information. Real-time order
-/// updates arrive on [`subscription_receiver`](Self::subscription_receiver).
+/// Obtained from [`RithmicOrderPlant::get_handle`], one per account. Use the methods
+/// on this handle to log in, place/modify/cancel orders, and query account
+/// information. Real-time order updates arrive on
+/// [`subscription_receiver`](Self::subscription_receiver).
 pub struct RithmicOrderPlantHandle {
     account: Arc<RithmicAccount>,
     /// Set by the first successful login on any handle from this plant.
@@ -1265,10 +1269,30 @@ impl RithmicOrderPlantHandle {
         await_all_responses(rx).await
     }
 
-    /// Subscribe to order status updates
+    /// Subscribe to order status updates for this handle's account.
     ///
-    /// # Returns
-    /// The subscription response or an error message
+    /// Updates arrive on [`subscription_receiver`](Self::subscription_receiver) as
+    /// [`RithmicOrderNotification`] and [`ExchangeOrderNotification`]. Requires
+    /// [`login`](Self::login) first. Bracket-specific updates need
+    /// [`subscribe_bracket_updates`](Self::subscribe_bracket_updates) as well.
+    ///
+    /// ```no_run
+    /// # use rithmic_rs::{RithmicOrderPlantHandle, rti::messages::RithmicMessage};
+    /// # async fn example(handle: RithmicOrderPlantHandle) -> Result<(), Box<dyn std::error::Error>> {
+    /// handle.subscribe_order_updates().await?;
+    /// let mut updates = handle.subscription_receiver.resubscribe();
+    ///
+    /// while let Ok(response) = updates.recv().await {
+    ///     if let RithmicMessage::ExchangeOrderNotification(order) = &response.message {
+    ///         println!("{:?} filled {:?}", order.status, order.fill_size);
+    ///     }
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`RithmicOrderNotification`]: crate::rti::messages::RithmicMessage::RithmicOrderNotification
+    /// [`ExchangeOrderNotification`]: crate::rti::messages::RithmicMessage::ExchangeOrderNotification
     pub async fn subscribe_order_updates(&self) -> Result<RithmicResponse, RithmicError> {
         let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, RithmicError>>();
 
@@ -1299,13 +1323,43 @@ impl RithmicOrderPlantHandle {
         await_first_response(rx).await
     }
 
-    /// Place a bracket order (entry order with profit target and stop loss)
+    /// Place a bracket order — entry with linked profit target and stop loss.
     ///
-    /// # Arguments
-    /// * `bracket_order` - The bracket order parameters
+    /// Build the order with [`RithmicBracketOrder::build`], which validates it. This
+    /// method does not re-validate: an order assembled without `build()` goes to the
+    /// exchange as-is.
     ///
-    /// # Returns
-    /// The order placement responses or an error message
+    /// `Ok` means the request was sent, not that it was accepted — check `error` on
+    /// each response.
+    ///
+    /// ```no_run
+    /// # use rithmic_rs::{OrderSide, OrderType, RithmicBracketOrder, RithmicOrderPlantHandle};
+    /// # async fn example(handle: RithmicOrderPlantHandle) -> Result<(), Box<dyn std::error::Error>> {
+    /// let order = RithmicBracketOrder::new()
+    ///     .symbol("ESH6")
+    ///     .exchange("CME")
+    ///     .quantity(1)
+    ///     .action(OrderSide::Buy)
+    ///     .price_type(OrderType::Limit)
+    ///     .price(5000.0)
+    ///     .target(20)
+    ///     .stop(10)
+    ///     .localid("my-order-1")
+    ///     .build()?;
+    ///
+    /// for response in handle.place_bracket_order(order).await? {
+    ///     if let Some(err) = &response.error {
+    ///         eprintln!("rejected: {err}");
+    ///     }
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    /// * [`RithmicError::NoTradeRoute`] if no route covers the order's exchange and
+    ///   the order named none. Nothing is sent.
+    /// * [`RithmicError::ConnectionClosed`] if the plant has shut down.
     pub async fn place_bracket_order(
         &self,
         bracket_order: RithmicBracketOrder,
@@ -1357,11 +1411,18 @@ impl RithmicOrderPlantHandle {
     ///
     /// [`RithmicOrderNotification`]: crate::rti::messages::RithmicMessage::RithmicOrderNotification
     ///
-    /// # Arguments
-    /// * `order` - The cancel order parameters
+    /// ```no_run
+    /// # use rithmic_rs::{RithmicCancelOrder, RithmicOrderPlantHandle};
+    /// # async fn example(handle: RithmicOrderPlantHandle) -> Result<(), Box<dyn std::error::Error>> {
+    /// // "123456" is the basket_id from the order notification.
+    /// let cancel = RithmicCancelOrder::new().id("123456").build()?;
+    /// handle.cancel_order(cancel).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     ///
-    /// # Returns
-    /// A vector of cancellation responses or an error message
+    /// # Errors
+    /// [`RithmicError::ConnectionClosed`] if the plant has shut down.
     pub async fn cancel_order(
         &self,
         order: RithmicCancelOrder,
@@ -1689,12 +1750,18 @@ impl RithmicOrderPlantHandle {
     /// # Returns
     /// A vector of order placement responses or an error message
     ///
+    /// Build the order with [`RithmicOrder::build`], which validates it. This method
+    /// does not re-validate: an order assembled without `build()` goes to the
+    /// exchange as-is.
+    ///
+    /// `Ok` means the request was sent, not that it was accepted — check `error` on
+    /// each response.
+    ///
     /// # Example
     ///
-    /// ```
-    /// use rithmic_rs::api::{OrderSide, OrderType, RithmicOrder};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// ```no_run
+    /// # use rithmic_rs::{OrderSide, OrderType, RithmicOrder, RithmicOrderPlantHandle};
+    /// # async fn example(handle: RithmicOrderPlantHandle) -> Result<(), Box<dyn std::error::Error>> {
     /// let order = RithmicOrder::new()
     ///     .symbol("ESH6")
     ///     .exchange("CME")
@@ -1705,10 +1772,19 @@ impl RithmicOrderPlantHandle {
     ///     .user_tag("my-order")
     ///     .build()?;
     ///
-    /// // handle.place_order(order).await?;
+    /// for response in handle.place_order(order).await? {
+    ///     if let Some(err) = &response.error {
+    ///         eprintln!("rejected: {err}");
+    ///     }
+    /// }
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// # Errors
+    /// * [`RithmicError::NoTradeRoute`] if no route covers the order's exchange and
+    ///   the order named none. Nothing is sent.
+    /// * [`RithmicError::ConnectionClosed`] if the plant has shut down.
     pub async fn place_order(
         &self,
         order: RithmicOrder,
@@ -1726,15 +1802,42 @@ impl RithmicOrderPlantHandle {
         await_all_responses(rx).await
     }
 
-    /// Place an OCO (One Cancels Other) order
+    /// Place an OCO (One Cancels Other) order.
     ///
-    /// When one leg is filled, the others are automatically cancelled.
+    /// When one leg is filled, the others are automatically cancelled. See
+    /// [`RithmicOcoOrder`] for building the legs.
     ///
-    /// # Arguments
-    /// * `order` - The order legs (at least two)
+    /// ```no_run
+    /// # use rithmic_rs::{OrderSide, OrderType, RithmicOcoOrder, RithmicOcoOrderLeg, RithmicOrderPlantHandle};
+    /// # async fn example(handle: RithmicOrderPlantHandle) -> Result<(), Box<dyn std::error::Error>> {
+    /// let take_profit = RithmicOcoOrderLeg::new()
+    ///     .symbol("ESH6")
+    ///     .exchange("CME")
+    ///     .quantity(1)
+    ///     .transaction_type(OrderSide::Sell)
+    ///     .price_type(OrderType::Limit)
+    ///     .price(5020.0)
+    ///     .build()?;
+    /// let stop_loss = RithmicOcoOrderLeg::new()
+    ///     .symbol("ESH6")
+    ///     .exchange("CME")
+    ///     .quantity(1)
+    ///     .transaction_type(OrderSide::Sell)
+    ///     .price_type(OrderType::StopMarket)
+    ///     .trigger_price(4980.0)
+    ///     .build()?;
     ///
-    /// # Returns
-    /// A vector of order placement responses or an error message
+    /// let order = RithmicOcoOrder::new().legs([take_profit, stop_loss]).build()?;
+    /// handle.place_oco_order(order).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    /// * [`RithmicError::InvalidArgument`] if the group has fewer than two legs —
+    ///   [`RithmicOcoOrder::build`] does not check the count, this does.
+    /// * [`RithmicError::NoTradeRoute`] if no route covers a leg's exchange.
+    /// * [`RithmicError::ConnectionClosed`] if the plant has shut down.
     pub async fn place_oco_order(
         &self,
         order: RithmicOcoOrder,
@@ -1803,11 +1906,21 @@ impl RithmicOrderPlantHandle {
     /// Resolves when the final frame of the response sequence arrives. That
     /// result describes the request, not the resulting orders.
     ///
-    /// # Arguments
-    /// * `command` - The position to exit and how the exit is attributed
+    /// ```no_run
+    /// # use rithmic_rs::{RithmicExitPosition, RithmicOrderPlantHandle};
+    /// # async fn example(handle: RithmicOrderPlantHandle) -> Result<(), Box<dyn std::error::Error>> {
+    /// // One instrument.
+    /// let one = RithmicExitPosition::new().symbol("ESM6").exchange("CME").build()?;
+    /// handle.exit_position(one).await?;
     ///
-    /// # Returns
-    /// A vector of exit position responses or an error message
+    /// // Every open position on the account.
+    /// handle.exit_position(RithmicExitPosition::new().build()?).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    /// [`RithmicError::ConnectionClosed`] if the plant has shut down.
     pub async fn exit_position(
         &self,
         command: RithmicExitPosition,

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -1488,13 +1488,32 @@ impl RithmicOrderPlantHandle {
         await_first_response(rx).await
     }
 
-    /// Request a list of all open orders
+    /// Ask Rithmic to replay the account's open orders onto the update stream.
     ///
-    /// The response is a `ResponseShowOrders`, which has no field for the
-    /// orders themselves.
+    /// The returned `RithmicResponse` is only an acknowledgement —
+    /// `ResponseShowOrders` carries a response code and nothing else. Each open
+    /// order arrives separately as a
+    /// [`RithmicMessage::RithmicOrderNotification`] or
+    /// [`RithmicMessage::ExchangeOrderNotification`] on the subscription stream,
+    /// so subscribe before calling this or the orders are missed.
     ///
-    /// # Returns
-    /// The order list response or an error message
+    /// The crate surfaces no end-of-list signal, so the replayed orders are
+    /// indistinguishable from live activity on the stream.
+    ///
+    /// ```no_run
+    /// # use rithmic_rs::{rti::messages::RithmicMessage, RithmicOrderPlantHandle};
+    /// # async fn example(handle: RithmicOrderPlantHandle) -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut updates = handle.subscription_receiver.resubscribe();
+    /// handle.show_orders().await?;
+    ///
+    /// while let Ok(response) = updates.recv().await {
+    ///     if let RithmicMessage::RithmicOrderNotification(order) = response.message {
+    ///         println!("{:?} {:?}", order.symbol, order.status);
+    ///     }
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn show_orders(&self) -> Result<RithmicResponse, RithmicError> {
         let (tx, rx) = oneshot::channel::<Result<Vec<RithmicResponse>, RithmicError>>();
 

--- a/src/plants/pnl_plant.rs
+++ b/src/plants/pnl_plant.rs
@@ -122,7 +122,10 @@ impl RithmicPnlPlant {
     /// A `Result` containing the connected `RithmicPnlPlant` instance, or an error if the connection fails.
     ///
     /// # Errors
-    /// Returns an error if unable to establish WebSocket connection to the server.
+    /// [`RithmicError::ConnectionFailed`] under [`ConnectStrategy::Simple`] only.
+    /// `Retry` and `AlternateWithRetry` never return an error — they retry until
+    /// they connect, so this call can block indefinitely if the server is
+    /// unreachable. Wrap it in `tokio::time::timeout` if you need a deadline.
     pub async fn connect(
         config: &RithmicConfig,
         strategy: ConnectStrategy,
@@ -308,7 +311,7 @@ impl PlantActor for PnlPlant {
 
 /// Handle for sending commands to a [`RithmicPnlPlant`] and receiving P&L updates.
 ///
-/// Obtained from [`RithmicPnlPlant::connect()`]. Use the methods on this handle to
+/// Obtained from [`RithmicPnlPlant::get_handle`], one per account. Use the methods on this handle to
 /// log in and subscribe to real-time P&L and position updates. Updates arrive on
 /// [`subscription_receiver`](Self::subscription_receiver).
 pub struct RithmicPnlPlantHandle {

--- a/src/plants/subscription.rs
+++ b/src/plants/subscription.rs
@@ -4,10 +4,8 @@ use tokio::sync::broadcast;
 
 /// Filters a shared plant subscription stream down to a single account.
 ///
-/// Order and PnL plants share one upstream connection per login session while
-/// updates remain account-specific. This type keeps the familiar `.recv().await`
-/// API while forwarding connection-level and other non-account-tagged messages to
-/// every handle.
+/// Yields only updates tagged with this handle's account. Connection-health
+/// events and untagged messages reach every handle.
 pub struct SubscriptionFilter {
     account: Arc<RithmicAccount>,
     receiver: broadcast::Receiver<RithmicResponse>,

--- a/src/plants/ticker_plant.rs
+++ b/src/plants/ticker_plant.rs
@@ -216,10 +216,10 @@ impl RithmicTickerPlant {
     /// A `Result` containing the connected `RithmicTickerPlant` instance, or an error if the connection fails.
     ///
     /// # Errors
-    /// Returns an error if:
-    /// - Unable to establish WebSocket connection to the server
-    /// - Network timeout occurs
-    /// - Server rejects the connection
+    /// [`RithmicError::ConnectionFailed`] under [`ConnectStrategy::Simple`] only.
+    /// `Retry` and `AlternateWithRetry` never return an error — they retry until
+    /// they connect, so this call can block indefinitely if the server is
+    /// unreachable. Wrap it in `tokio::time::timeout` if you need a deadline.
     ///
     /// # Example
     /// ```no_run
@@ -576,7 +576,7 @@ impl PlantActor for TickerPlant {
 
 /// Handle for sending commands to a [`RithmicTickerPlant`] and receiving market data updates.
 ///
-/// Obtained from [`RithmicTickerPlant::connect()`]. Use the methods on this handle to
+/// Obtained from [`RithmicTickerPlant::get_handle`]. Use the methods on this handle to
 /// log in, subscribe to symbols, and request reference data. Real-time updates arrive
 /// on [`subscription_receiver`](Self::subscription_receiver).
 pub struct RithmicTickerPlantHandle {


### PR DESCRIPTION
Prep for the 3.0.0 release: version bump, plus a pass over the docs a third-party consumer actually reads and a fact-check of every claim in them.

`Cargo.toml` was still on `2.0.0`.

## CHANGELOG

`[Unreleased]` becomes `[3.0.0]`, with the compare link added and the `[Unreleased]` range repointed at `v3.0.0`.

The section was then restructured for someone reading it cold: `Added` was 130 unbroken lines and is now grouped under **New calls**, **Command types and fields**, **Types and re-exports**, and **Connection and config**. Six compile-checked examples were added, the generated-field list became a table, and the `Fixed` entries were normalized to lead with the bug rather than the fix.

## MIGRATING

The gap was the last two commits (b51ecac, 4f61e5f), which nothing documented.

- **New section 7, "Your replays were probably truncated."** Rithmic caps a replay at 10,000 records and gives no sign that it did — the closing response of a truncated replay is byte-identical to a complete one's. 2.x never asked for the cap to be lifted, so a 2.x caller has likely been losing data silently. This is the change most likely to have cost someone real data, and nothing pointed at it.
- Sections renumbered, intro cross-reference updated, checklist items added.

## README

- **New `## Migrating from 2.x` section** under Quick Start: the breaking changes as a table, then the six that compile untouched and change what reaches the exchange, spelled out inline rather than only linked. Those six can move real money, so they shouldn't need a click to see.
- The order plant snippet referenced `bracket_order` and `oco_order` variables it never defined. Replaced with real bracket and OCO examples, plus a trade-routes subsection — `NoTradeRoute` is a new way for an order not to send.
- History Plant showed only the capped loaders and imported `BarType` through the raw `rti::` path. Now leads with the `_all` loaders, uses `TimeBarType`, and explains the cap.
- Added feature flags, MSRV, and a table of the nine examples.

## Rustdoc on the order handle

The order plant is the largest public surface and had the thinnest docs.

- Six methods gained compile-checked examples: `place_order`, `place_bracket_order`, `place_oco_order`, `cancel_order`, `exit_position`, `subscribe_order_updates`. `place_order`'s existing example had the call itself commented out, so it was neither copy-pasteable nor compile-checked.
- Fixed four wrong claims: three handle docs named `connect()` as the way to get a handle instead of `get_handle`; `connect`'s `# Errors` on all four plants promised an error that is unreachable under `Retry`/`AlternateWithRetry` (those retry forever — the doc now says so, and says to wrap in `tokio::time::timeout` if you need a deadline); and `place_oco_order`'s two-leg minimum was documented only in a `//` comment.
- Noted on both placement methods that the plant does not re-validate, so an order assembled without `build()` reaches the exchange unchecked.

## Accuracy pass

Every factual claim in the three docs was checked against the source. **All numbers were correct** — 246 `#[non_exhaustive]` types, fourteen removed enum re-exports, seven renames over ten methods, the template ids, the 500 ms/60 s/30–90 s backoff, the 30 s timeout, API 0.89.0.0 / template 5.42, eleven order request protos, "six changes that compile untouched", "24 of the 35 template releases". The errors were all in prose.

Two claims were **wrong**:

- The lead bullet under Breaking Changes described `SenderApi::request_tick_bar_replay` and friends. There is no `SenderApi` — it is `RithmicSenderApi`, and the module is `pub(crate)` in both 2.0.0 and 3.0.0, so nothing downstream breaks. It was sending upgraders hunting for calls they could not have written. The same paragraph in MIGRATING §6 also claimed "seven or eight positional arguments"; the three methods took 5, 6 and 7. Both removed.
- "Every command needs a symbol, an exchange and a positive quantity" held for 4 of the 11 command types. `RithmicCancelAllOrders::build()` returns `Ok(self)` unconditionally, five types check only a basket id, and `RithmicExitPosition` accepts neither symbol nor exchange — which the flatten-all example six lines below depends on. Replaced with the actual per-type rules, in both CHANGELOG and MIGRATING.

Six more were defensible but would be misread, and are fixed in every file that carried them:

- "every field ... is reachable from a command type" omitted the session-scoped fields (`user_type` is the real gap), contradicting the hardcoded-Trader entry.
- `TrailingStop`/`RithmicIfTouchedTrigger` were said to be built like the order commands; they have no `validate()` at all.
- A `price` stands in for a missing `trigger_price` on a modify.
- The fill-history guard is `!(0..=10_000).contains(count)`, so it refuses negatives too.
- All four plants reject queued commands during a disconnect, not two.
- Reconnect jitter is derived from clock nanos, not an RNG.

Three claims were **removed for being unverifiable rather than reworded**:

- `rp_code 1112` appeared in five places explaining why `build()` refuses a zero `trail_by_price_id`. It asserts how Rithmic's server responds, and nothing on disk confirms it — the only other statement of 1112 in the repo was the error string it was cited from, and the vendored Reference Guide is a scanned PDF with no extractable text. The validation is unchanged; it just no longer explains itself with a code we cannot check.
- The "roughly 800,000 records" figure for a 23-hour ES session was never measured. Softened to "hundreds of thousands" in CHANGELOG, MIGRATING, README and the `load_time_bars_all` rustdoc.
- The release date on the `[3.0.0]` header. Nothing consumes it, and `[2.0.0]` and `[1.0.0]` carry none either.

`show_orders` was also rewritten. It said the response "has no field for the orders themselves" and stopped there, leaving no way to reach them. Traced: the request is template 320, and `ResponseShowOrders` (321) decodes with `has_more`/`multi_response` false carrying only `user_msg` and `rp_code` — an acknowledgement. The orders arrive as templates 351/352 with an empty `request_id` and `is_update: true` (`receiver_api.rs:1200,1214`), which `core.rs:369` routes to the broadcast. The doc now says to subscribe first, and shows it.

## Verification

- 354 unit tests + 50 doctests pass.
- `cargo clippy --all-features --all-targets` clean; `cargo doc --all-features --no-deps` builds with no warnings.
- `cargo publish --dry-run --all-features` packages 63 files and compiles from the packaged copy. `README.md`, `CHANGELOG.md` and `MIGRATING.md` all ship and their cross-links resolve inside the package.
- Every README and CHANGELOG snippet was compiled against the real API as a throwaway example, then deleted. The new rustdoc examples are `no_run`, so CI compiles them on every run.

## Known open

- `show_orders`' "no end-of-list signal" is stated as what the crate surfaces, not as a claim about Rithmic's wire behavior, because the latter is not confirmable here.
- No behavior changed in this PR. It is docs plus the version bump.

Not done here: tagging `v3.0.0` and the actual `cargo publish`.
