### PR TITLE
fix(diagnostics): say which frame was dropped and why

### DIFF
--- a/src/api/receiver_api.rs
+++ b/src/api/receiver_api.rs
@@ -113,7 +113,24 @@ impl RithmicReceiverApi {
         }
 
         self.decode_body(data.slice(4..), parsed_message.template_id)
-            .map_err(|response| route_decode_failure(payload, response))
+            .map_err(|response| {
+                let response = route_decode_failure(payload, response);
+
+                error!(
+                    "{}: template {} failed to decode: {:?}; recovered request_id {:?}, routing it {}",
+                    self.source,
+                    parsed_message.template_id,
+                    response.error,
+                    response.request_id,
+                    if response.is_update {
+                        "onto the subscription"
+                    } else {
+                        "to the request waiting on it"
+                    }
+                );
+
+                response
+            })
     }
 
     /// Decode the body against the message type its `template_id` selects.
@@ -1571,8 +1588,6 @@ fn has_multiple(rq_handler_rp_code: &[String]) -> bool {
 }
 
 fn decode_error(source: &str, e: prost::DecodeError, is_update: bool) -> RithmicResponse {
-    error!("Failed to decode protobuf message: {}", e);
-
     RithmicResponse {
         request_id: "".to_string(),
         message: RithmicMessage::Unknown,
@@ -1865,6 +1880,45 @@ mod tests {
         ));
         assert!(!response.is_update);
         assert_eq!(response.request_id, "req-7");
+    }
+
+    #[test]
+    fn a_correlated_decode_failure_names_the_request_in_the_log() {
+        let api = RithmicReceiverApi {
+            source: "test".to_string(),
+        };
+
+        let (_, logged) = crate::request_handler::log_capture::capture(|| {
+            let _ = api.buf_to_message(encode_with_header(&malformed_response_login(&["req-7"])));
+        });
+
+        assert!(logged.contains("template 11 failed to decode"), "{logged}");
+        assert!(
+            logged.contains(r#"recovered request_id "req-7""#),
+            "{logged}"
+        );
+        assert!(
+            logged.contains("routing it to the request waiting on it"),
+            "{logged}"
+        );
+    }
+
+    #[test]
+    fn an_uncorrelatable_decode_failure_says_so_in_the_log() {
+        let api = RithmicReceiverApi {
+            source: "test".to_string(),
+        };
+
+        let (_, logged) = crate::request_handler::log_capture::capture(|| {
+            let _ = api.buf_to_message(encode_with_header(&malformed_response_login(&[])));
+        });
+
+        assert!(logged.contains("template 11 failed to decode"), "{logged}");
+        assert!(logged.contains(r#"recovered request_id """#), "{logged}");
+        assert!(
+            logged.contains("routing it onto the subscription"),
+            "{logged}"
+        );
     }
 
     #[test]

--- a/src/request_handler.rs
+++ b/src/request_handler.rs
@@ -207,6 +207,72 @@ impl RithmicRequestHandler {
     }
 }
 
+/// Capture of emitted log lines, so a test can assert a diagnostic really
+/// reaches production logs instead of trusting that the call is there.
+#[cfg(test)]
+pub(crate) mod log_capture {
+    use std::{cell::RefCell, io, sync::OnceLock};
+
+    use tracing_subscriber::fmt::MakeWriter;
+
+    thread_local! {
+        /// `Some` only while this thread is inside `capture`; events emitted on
+        /// any other thread are written nowhere.
+        static BUFFER: RefCell<Option<Vec<u8>>> = const { RefCell::new(None) };
+    }
+
+    struct Writer;
+
+    impl io::Write for Writer {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            BUFFER.with_borrow_mut(|buffer| {
+                if let Some(buffer) = buffer {
+                    buffer.extend_from_slice(buf);
+                }
+            });
+
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct PerThread;
+
+    impl<'a> MakeWriter<'a> for PerThread {
+        type Writer = Writer;
+
+        fn make_writer(&'a self) -> Writer {
+            Writer
+        }
+    }
+
+    /// Run `f` and return what it logged. Capped at INFO, because a diagnostic
+    /// that only appears at debug is filtered out in production. The subscriber
+    /// is global: `tracing` caches a callsite's interest on first resolve.
+    pub(crate) fn capture<T>(f: impl FnOnce() -> T) -> (T, String) {
+        static INSTALLED: OnceLock<()> = OnceLock::new();
+
+        INSTALLED.get_or_init(|| {
+            let subscriber = tracing_subscriber::fmt()
+                .with_writer(PerThread)
+                .with_max_level(tracing::Level::INFO)
+                .finish();
+
+            tracing::subscriber::set_global_default(subscriber)
+                .expect("nothing else installs a global subscriber in the test binary");
+        });
+
+        BUFFER.set(Some(Vec::new()));
+        let out = f();
+        let logged = BUFFER.take().unwrap_or_default();
+
+        (out, String::from_utf8(logged).unwrap())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Background

On 2026-08-18 a bracket order placement timed out at the 30s request timeout. The broker's acknowledgement arrived 11 seconds later, found no caller waiting on the request id, and was destroyed. It carried the fill.

That particular frame was traceable after the fact — `handle_response` already logs `error!("No responder found for response: {:#?}", response)` with the whole struct. The decode path is not so lucky: its log sits somewhere that cannot see the request id at all.

This PR does not fix the lost acknowledgement. It makes the decode path traceable. The actual fix is stage 2, `fix/orphan-routing`.

## What's wrong today

`decode_error` in `src/api/receiver_api.rs` logs `"Failed to decode protobuf message: {e}"` and nothing else. It is a leaf helper called from about ninety match arms, and it runs **before** `route_decode_failure` recovers the echoed `user_msg` — so at that point the request id does not exist yet. No amount of adding fields at that call site would have produced it. The line names no source, no template, no request, and no routing outcome.

So a frame that fails to decode is visible as "something failed" and nothing more. The request it belonged to then times out, which in the logs is indistinguishable from a reply that never arrived.

## What this changes

Moves the decode-failure log out of `decode_error` and up into `buf_to_message`, after `route_decode_failure` has run. It now logs, at `error`, the source, the template id it choked on, the decode error, the request id it recovered from the envelope, and whether the frame went onto the subscription or to the request waiting on it.

One supporting change:

- A test-only `log_capture` module in `src/request_handler.rs`. The two new tests assert against real `tracing` output captured through a global subscriber capped at `INFO`, so a diagnostic that only showed up at `debug` fails the test rather than quietly vanishing in production. The subscriber is global rather than thread-scoped because `tracing` resolves a callsite's interest once, on whichever thread reaches it first; a thread-scoped subscriber loses that race and the capture comes back empty.

## What this does not change

- No routing decision changes. The decode-failure frame is still routed exactly as before; only the log line moved.
- No orphaned acknowledgement is recovered. A late ack with no caller waiting is still lost. That is stage 2.
- No new logging on a hot path. The line fires once per decode failure, replacing one that already fired there.
- No public API change. `decode_error` is private and `log_capture` is `#[cfg(test)]`. The version bump ships with the release notes in stage 5.

## Verification

On `f13b906`:

- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features` — 356 unit tests pass, 50 doctests pass (8 ignored, as before)

2 files changed, +123 / −3.

## Stack

Stage 1 of 5. The remaining branches are not pushed yet; merge order is:

1. **`fix/decode-diagnostics`** — this PR
2. `fix/orphan-routing` — the actual fix for the lost acknowledgement
3. `fix/orphan-ordering`
4. `feat/placement-ack`
5. `feat/open-orders`