### PR TITLE
fix(request-handler): stop timing out requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0]
+
+### Requests no longer time out
+
+The library used to give up on a request after 30 seconds and hand back a
+`RequestTimeout` error. It no longer does. A request finishes when Rithmic
+answers it, or when the connection drops.
+
+The old timeout caused a problem it could not fix. Giving up on our side does
+not tell Rithmic to stop — the request was already sent, and the answer still
+turns up later. By then we had told you the call failed and thrown away the
+record needed to match the answer to it, so the answer went nowhere.
+
+If you want a time limit, set it yourself with `tokio::time::timeout`. You know
+what each call is worth waiting for and the library does not. See
+`examples/request_timeout.rs`.
+
+### Deprecated
+
+These still compile and are still accepted, but the library ignores them.
+They go away in 4.0.0.
+
+- `RithmicConfig::request_timeout`
+- `RithmicConfigBuilder::request_timeout()`
+- `DEFAULT_REQUEST_TIMEOUT`
+- `RithmicError::RequestTimeout` — never returned any more
+- `RITHMIC_REQUEST_TIMEOUT_SECS` — still checked for a bad value, then ignored
+
+### Added
+
+- `examples/request_timeout.rs` — how to put your own time limit on a request.
+
+### Fixed
+
+- When part of a multi-part response arrives for a request that is no longer
+  waiting, it is now logged. It used to be thrown away silently.
+
 ## [3.0.0]
 
 Order commands are now built with `::new()` and chained setters, the generated

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -255,19 +255,11 @@ without a round trip. Only a zero `bar_length` was caught before, so a call that
 appeared to work and came back empty may now surface as an error — which is the
 point.
 
-## 8. Config gains a required `request_timeout`
+## 8. Build `RithmicConfig` through the builder
 
-`RithmicConfig` has a required `request_timeout: Duration`. Build it with
-`RithmicConfig::builder(env)` or `RithmicConfigBuilder::from_env(env)`, which
+Use `RithmicConfig::builder(env)` or `RithmicConfigBuilder::from_env(env)`, which
 pre-fills from the same environment variables `RithmicConfig::from_env` reads so a
 single field can be overridden.
-
-The default is `DEFAULT_REQUEST_TIMEOUT`, 30 seconds, and
-`RITHMIC_REQUEST_TIMEOUT_SECS` sets it from the environment (plain digits only).
-
-A request whose response never arrives now fails with `RithmicError::RequestTimeout`
-instead of blocking its caller forever. Reconcile a timed-out order rather than
-re-sending it.
 
 ## 9. Field and module changes
 
@@ -332,9 +324,9 @@ generated `UpdateType`/`AccessType` enums no longer exist.
 - [ ] Convert loose-argument order calls to command structs
 - [ ] Pass a request struct to the `RithmicSenderApi::request_*_replay` methods
 - [ ] Switch replays to `load_ticks_all` / `load_tick_bars_all` / `load_time_bars_all` (section 7)
-- [ ] Build `RithmicConfig` through the builder; pick a `request_timeout`
+- [ ] Build `RithmicConfig` through the builder
 - [ ] Add a `_` arm to matches on generated enums
-- [ ] Handle `RithmicError::NoTradeRoute` and `RithmicError::RequestTimeout`
+- [ ] Handle `RithmicError::NoTradeRoute`
 - [ ] Re-check account lists if you rely on `get_account_list` returning everything
 - [ ] Decide whether `cancel_all_orders` should stay `Manual` — it is now `Auto`
 - [ ] Check target-only brackets: they now send `TARGET_ONLY_STATIC`

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The headline changes:
 | Every order call takes a command struct | `cancel_all_orders`, `exit_position`, `adjust_target`/`adjust_stop` no longer take loose arguments |
 | Prices are `Option<f64>` | Wrap in `Some(..)`; pass `None` for market orders |
 | Seven handle methods renamed | Each is now named after the request it sends |
-| `RithmicConfig` requires a `request_timeout` | Build it through `RithmicConfig::builder(env)` or `RithmicConfigBuilder::from_env(env)` |
+| `RithmicConfig` gains fields | Build it through `RithmicConfig::builder(env)` or `RithmicConfigBuilder::from_env(env)` rather than a struct literal |
 
 The compiler finds all of the above. **It will not find these**, which compile
 untouched and change what reaches the exchange:

--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -58,7 +58,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     match handle.get_front_month_contract("ES", "CME", false).await {
         Ok(resp) => info!("front month: {:?}", resp.message),
-        Err(RithmicError::RequestTimeout) => warn!("front month: no response"),
         Err(e) => error!("front month: {e}"),
     }
 

--- a/examples/request_timeout.rs
+++ b/examples/request_timeout.rs
@@ -1,0 +1,53 @@
+//! Example: giving a request a deadline of your own.
+//!
+//! The crate does not time out requests — a call is resolved when Rithmic
+//! answers it or when the connection drops. Wrap it if you want a ceiling.
+//!
+//! Run with: cargo run --example request_timeout
+
+use std::time::Duration;
+
+use tracing::{error, info, warn};
+
+use rithmic_rs::{ConnectStrategy, RithmicConfig, RithmicEnv, RithmicTickerPlant};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenvy::dotenv().ok();
+    tracing_subscriber::fmt().init();
+
+    let config = RithmicConfig::from_env(RithmicEnv::Demo)?;
+    let plant = RithmicTickerPlant::connect(&config, ConnectStrategy::Retry).await?;
+    let handle = plant.get_handle();
+
+    handle.login().await?;
+
+    // Three outcomes, not two: the wrapper adds one the call itself cannot
+    // return.
+    let request = handle.get_front_month_contract("ES", "CME", false);
+
+    match tokio::time::timeout(Duration::from_secs(10), request).await {
+        Ok(Ok(resp)) => info!("front month: {:?}", resp.message),
+        Ok(Err(e)) => error!("front month: {e}"),
+        // Nothing was cancelled. The request is still registered, and if the
+        // reply arrives it is dropped, because this future owned the receiver.
+        Err(_elapsed) => warn!("front month: gave up waiting"),
+    }
+
+    // Pick the number per call. A quote lookup that is slow is worth
+    // abandoning; a login is worth waiting on.
+    let slow = handle.get_front_month_contract("NQ", "CME", false);
+
+    if let Ok(Ok(resp)) = tokio::time::timeout(Duration::from_millis(50), slow).await {
+        info!("front month: {:?}", resp.message);
+    } else {
+        warn!("front month: not worth 50ms");
+    }
+
+    // On a write, expiry means the outcome is unknown rather than failed:
+    // Rithmic never learned you gave up, so the order may well be working.
+    // Reconcile it against the order plant instead of sending it again.
+
+    handle.disconnect().await?;
+    Ok(())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,7 @@
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 
+#[allow(deprecated)]
 use crate::request_handler::DEFAULT_REQUEST_TIMEOUT;
 use std::{env, fmt, str::FromStr, time::Duration};
 
@@ -274,12 +275,18 @@ pub struct RithmicConfig {
     pub app_name: String,
     /// Application version string.
     pub app_version: String,
-    /// How long to wait for a response before a request times out.
-    /// A zero duration selects [`DEFAULT_REQUEST_TIMEOUT`].
+    /// No longer used. The library does not time out requests; wrap the call
+    /// in [`tokio::time::timeout`] to set a deadline of your own. Still
+    /// readable so existing code keeps compiling; removed in 4.0.0.
+    #[deprecated(
+        since = "3.1.0",
+        note = "the library no longer times out requests; wrap the call in tokio::time::timeout"
+    )]
     pub request_timeout: Duration,
 }
 
 impl fmt::Debug for RithmicConfig {
+    #[allow(deprecated)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RithmicConfig")
             .field("url", &self.url)
@@ -331,8 +338,8 @@ impl RithmicConfig {
     ///   to. Defaults to "Rithmic Paper Trading" (Demo), "Rithmic 01" (Live),
     ///   or "Rithmic Test" (Test). Set it on Live to select another provider,
     ///   e.g. Thrive Trading.
-    /// - `RITHMIC_REQUEST_TIMEOUT_SECS`: Seconds a request waits for a
-    ///   response (default 30; 0 selects the default)
+    /// - `RITHMIC_REQUEST_TIMEOUT_SECS`: no longer used. Still read and still
+    ///   rejected if it is not plain digits, then ignored.
     ///
     /// # Example
     /// ```no_run
@@ -344,6 +351,7 @@ impl RithmicConfig {
     /// let account = RithmicAccount::from_env(RithmicEnv::Demo)?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    #[allow(deprecated)]
     pub fn from_env(env: RithmicEnv) -> Result<Self, ConfigError> {
         let prefix = env.var_prefix();
 
@@ -443,6 +451,7 @@ impl RithmicConfigBuilder {
     ///     .build()?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    #[allow(deprecated)]
     pub fn from_env(env: RithmicEnv) -> Result<Self, ConfigError> {
         let config = RithmicConfig::from_env(env)?;
 
@@ -460,6 +469,7 @@ impl RithmicConfigBuilder {
     }
 
     /// Create a new builder for the specified environment.
+    #[allow(deprecated)]
     pub fn new(env: RithmicEnv) -> Self {
         let system_name = env.default_system_name().to_string();
 
@@ -512,10 +522,14 @@ impl RithmicConfigBuilder {
         self
     }
 
-    /// Set how long to wait for a response before a request times out.
-    ///
-    /// A zero duration selects the default,
-    /// [`DEFAULT_REQUEST_TIMEOUT`].
+    /// No longer used. The library does not time out requests; wrap the call
+    /// in [`tokio::time::timeout`] to set a deadline of your own. The value is
+    /// still recorded on the config and still ignored; removed in 4.0.0.
+    #[deprecated(
+        since = "3.1.0",
+        note = "the library no longer times out requests; wrap the call in tokio::time::timeout"
+    )]
+    #[allow(deprecated)]
     pub fn request_timeout(mut self, request_timeout: Duration) -> Self {
         self.request_timeout = if request_timeout.is_zero() {
             DEFAULT_REQUEST_TIMEOUT
@@ -534,6 +548,7 @@ impl RithmicConfigBuilder {
     /// Build the configuration.
     ///
     /// Returns an error if any required fields are missing.
+    #[allow(deprecated)]
     pub fn build(self) -> Result<RithmicConfig, ConfigError> {
         Ok(RithmicConfig {
             env: self.env,
@@ -564,6 +579,7 @@ impl RithmicConfigBuilder {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
 
     use super::*;

--- a/src/error.rs
+++ b/src/error.rs
@@ -115,7 +115,14 @@ pub enum RithmicError {
     SendFailed,
     /// Server returned an empty response where at least one was expected.
     EmptyResponse,
-    /// The request was sent but no response came back in time.
+    /// No longer produced. The library does not time out requests; a caller
+    /// that wants a deadline wraps the call in [`tokio::time::timeout`], which
+    /// reports expiry through its own `Elapsed` rather than this variant.
+    /// Removed in 4.0.0.
+    #[deprecated(
+        since = "3.1.0",
+        note = "the library no longer times out requests; wrap the call in tokio::time::timeout"
+    )]
     RequestTimeout,
     /// The server turned the request down, with the code and message it gave.
     /// Request-level only — not a reason to reconnect.
@@ -172,6 +179,7 @@ impl RithmicError {
 }
 
 impl fmt::Display for RithmicError {
+    #[allow(deprecated)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             RithmicError::ConnectionFailed(msg) => write!(f, "connection failed: {msg}"),
@@ -225,6 +233,7 @@ impl std::error::Error for RithmicError {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use std::error::Error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,17 +164,15 @@
 //!   connection problem rather than retrying in a loop.
 //! - [`ConnectionClosed`](RithmicError::ConnectionClosed) — the plant is gone.
 //!   Reconnect; calling again will not work.
-//! - [`RequestTimeout`](RithmicError::RequestTimeout) — no response came back in
-//!   time. The plant keeps running; check the subscription channel for
-//!   connection health.
 //!
 //! When a connection drops, everything in flight fails with `ConnectionClosed`
 //! whatever the real cause was. The cause goes out on the subscription channel,
 //! so look there if you need to tell a heartbeat timeout from a dead socket.
 //!
-//! Requests time out after 30 seconds by default; set
-//! [`RithmicConfigBuilder::request_timeout`] or the
-//! `RITHMIC_REQUEST_TIMEOUT_SECS` environment variable to change it.
+//! A request has no deadline of its own: Rithmic answers it or the connection
+//! drops. Wrap the call in [`tokio::time::timeout`] if you want a ceiling —
+//! see `examples/request_timeout.rs`. Giving up cancels nothing on Rithmic's
+//! side, so reconcile an order rather than re-sending it.
 //!
 //! ([`ConnectionFailed`](RithmicError::ConnectionFailed) comes from `connect()`
 //! rather than a handle method, and only under [`ConnectStrategy::Simple`] —
@@ -296,6 +294,7 @@ pub use plants::ticker_plant::{RithmicTickerPlant, RithmicTickerPlantHandle};
 
 // Re-export modern configuration types for convenience
 pub use config::{ConfigError, RithmicAccount, RithmicConfig, RithmicConfigBuilder, RithmicEnv};
+#[allow(deprecated)]
 pub use request_handler::DEFAULT_REQUEST_TIMEOUT;
 
 // Re-export error types

--- a/src/plants/core.rs
+++ b/src/plants/core.rs
@@ -111,7 +111,7 @@ impl PlantCore<WsSink> {
             logged_in: false,
             ping_interval,
             ping_manager,
-            request_handler: RithmicRequestHandler::new(config.request_timeout),
+            request_handler: RithmicRequestHandler::new(),
             rithmic_reader,
             rithmic_receiver_api,
             rithmic_sender,
@@ -199,13 +199,11 @@ where
         let ping_interval = &mut self.ping_interval;
         let ping_manager = &mut self.ping_manager;
         let reader = &mut self.rithmic_reader;
-        let request_handler = &mut self.request_handler;
 
         tokio::select! {
             _ = interval.tick()      => SelectResult::HeartbeatFired,
             _ = ping_interval.tick() => SelectResult::PingFired,
             _ = ping_manager.timed_out() => SelectResult::PingTimeout,
-            _ = request_handler.fail_timed_out() => unreachable!(),
             Some(cmd) = receiver.recv() => SelectResult::Command(cmd),
             msg = reader.next() => match msg {
                 Some(m) => SelectResult::RithmicMessage(m),
@@ -652,10 +650,7 @@ mod tests {
     };
 
     use futures_util::StreamExt;
-    use tokio::{
-        sync::{broadcast, oneshot},
-        time::Instant,
-    };
+    use tokio::sync::{broadcast, oneshot};
     use tokio_tungstenite::tungstenite::{Error, Message, error::ProtocolError};
 
     use super::*;
@@ -841,7 +836,7 @@ mod tests {
             source: "test".to_string(),
         };
 
-        let request_handler = RithmicRequestHandler::new(config.request_timeout);
+        let request_handler = RithmicRequestHandler::new();
 
         let core = PlantCore {
             config,
@@ -1065,60 +1060,20 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn the_configured_request_timeout_is_the_one_applied() {
-        let config = RithmicConfig::builder(RithmicEnv::Demo)
-            .user("u")
-            .password("p")
-            .url("ws://localhost:9999")
-            .beta_url("ws://localhost:9998")
-            .app_name("a")
-            .app_version("1")
-            .request_timeout(Duration::from_secs(5))
-            .build()
-            .unwrap();
-
+    async fn next_event_never_fails_a_request_that_is_still_waiting() {
+        // Ten 60s interval ticks of simulated time — far past the 30s timeout
+        // the loop used to enforce. Nothing may resolve the request but a
+        // response, a failure, or a disconnect.
         let (reader, _peer) = make_open_ws_reader().await;
-        let (mut core, _sub_rx) =
-            make_test_core_with_config(MockMessageSink::ready(), reader, config);
+        let (mut core, _sub_rx) = make_test_core(MockMessageSink::ready(), reader);
         let mut rx = register_request(&mut core, "req-1");
         let (_cmd_tx, mut cmd_rx) = mpsc::channel::<()>(1);
 
-        let started = Instant::now();
+        for _ in 0..10 {
+            core.next_event(&mut cmd_rx).await;
+        }
 
-        // Race the caller against the loop: the request must fail at 5s, well
-        // before the 60s tick that would otherwise end next_event.
-        let elapsed = tokio::select! {
-            _ = core.next_event(&mut cmd_rx) => panic!("returned before the timeout"),
-            received = &mut rx => {
-                assert_eq!(received.unwrap().unwrap_err(), RithmicError::RequestTimeout);
-                Instant::now() - started
-            }
-        };
-
-        assert_eq!(elapsed, Duration::from_secs(5));
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn next_event_times_out_a_request_while_waiting() {
-        // The only plant-level fact worth asserting: next_event polls the
-        // timeout loop. Timing semantics are covered in request_handler.
-        let (reader, _peer) = make_open_ws_reader().await;
-        let (mut core, mut sub_rx) = make_test_core(MockMessageSink::ready(), reader);
-        let mut rx = register_request(&mut core, "req-1");
-        let (_cmd_tx, mut cmd_rx) = mpsc::channel::<()>(1);
-
-        // The return is ignored on purpose: both 60s intervals come ready at
-        // the same instant, so which one `select!` reports is random.
-        core.next_event(&mut cmd_rx).await;
-
-        assert_eq!(
-            rx.try_recv().unwrap().unwrap_err(),
-            RithmicError::RequestTimeout
-        );
-        assert!(
-            sub_rx.try_recv().is_err(),
-            "timing a request out is not a connection-health event"
-        );
+        assert!(rx.try_recv().is_err(), "the request must still be waiting");
     }
 
     #[tokio::test]

--- a/src/plants/test_support.rs
+++ b/src/plants/test_support.rs
@@ -60,7 +60,7 @@ pub(crate) async fn core_with_wire(source: &str) -> (PlantCore, TcpStream) {
     let (subscription_sender, _sub_rx) = broadcast::channel(16);
     let rithmic_sender_api = RithmicSenderApi::new(&config);
 
-    let request_handler = RithmicRequestHandler::new(config.request_timeout);
+    let request_handler = RithmicRequestHandler::new();
 
     let core = PlantCore {
         config,

--- a/src/request_handler.rs
+++ b/src/request_handler.rs
@@ -1,20 +1,18 @@
-use std::{collections::HashMap, convert::Infallible, time::Duration};
+use std::{collections::HashMap, time::Duration};
 use tracing::{error, warn};
 
-use tokio::{
-    sync::oneshot,
-    time::{Instant, sleep_until},
-};
+use tokio::sync::oneshot;
 
 use crate::{
     api::receiver_api::RithmicResponse, error::RithmicError, rti::messages::RithmicMessage,
 };
 
-/// Default time a request may go without progress before it is failed with
-/// [`RithmicError::RequestTimeout`].
-///
-/// Set [`RithmicConfigBuilder::request_timeout`](crate::RithmicConfigBuilder::request_timeout)
-/// to change it for a connection.
+/// No longer used. The library does not time out requests; wrap the call in
+/// [`tokio::time::timeout`] to set a deadline of your own. Removed in 4.0.0.
+#[deprecated(
+    since = "3.1.0",
+    note = "the library no longer times out requests; wrap the call in tokio::time::timeout"
+)]
 pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug)]
@@ -23,86 +21,29 @@ pub struct RithmicRequest {
     pub responder: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
 }
 
-/// A registered request awaiting its response, and the instant it times out.
-#[derive(Debug)]
-struct PendingRequest {
-    responder: oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>,
-    timeout_at: Instant,
-}
+type Responder = oneshot::Sender<Result<Vec<RithmicResponse>, RithmicError>>;
 
 /// Matches Rithmic responses to the callers waiting on them.
 ///
-/// Each registered request times out, so a response that never arrives does
-/// not park its caller forever. See [`Self::fail_timed_out`].
-#[derive(Debug)]
+/// A registered request is resolved by a response carrying its id, by
+/// [`Self::fail_request`], or by [`Self::drain_and_drop`] on disconnect. It is
+/// never failed on a clock: the caller owns its own deadline.
+#[derive(Debug, Default)]
 pub struct RithmicRequestHandler {
-    handle_map: HashMap<String, PendingRequest>,
+    handle_map: HashMap<String, Responder>,
     response_vec_map: HashMap<String, Vec<RithmicResponse>>,
-    request_timeout: Duration,
 }
 
 impl RithmicRequestHandler {
-    /// Create a handler that fails requests after `request_timeout` of silence.
-    ///
-    /// A zero `request_timeout` selects [`DEFAULT_REQUEST_TIMEOUT`], so a
-    /// zeroed-out config cannot fail every request on arrival.
-    pub fn new(request_timeout: Duration) -> Self {
-        let request_timeout = if request_timeout.is_zero() {
-            DEFAULT_REQUEST_TIMEOUT
-        } else {
-            request_timeout
-        };
-
-        Self {
-            handle_map: HashMap::new(),
-            response_vec_map: HashMap::new(),
-            request_timeout,
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 
-    /// Register a request; it times out `request_timeout` from now.
+    /// Register a request. It waits until a response carries its id, until it
+    /// is failed, or until the connection drops.
     pub fn register_request(&mut self, request: RithmicRequest) {
-        self.handle_map.insert(
-            request.request_id,
-            PendingRequest {
-                responder: request.responder,
-                timeout_at: Instant::now() + self.request_timeout,
-            },
-        );
-    }
-
-    /// Fail requests as they time out, forever.
-    ///
-    /// This never resolves — drive it from a `select!` arm. Dropping it loses
-    /// nothing, since the timeouts live in `self`.
-    ///
-    /// Waking on the soonest timeout and then failing everything already timed
-    /// out means each pass removes at least that request, so this cannot stall.
-    pub async fn fail_timed_out(&mut self) -> Infallible {
-        loop {
-            let Some(soonest) = self.handle_map.values().map(|p| p.timeout_at).min() else {
-                std::future::pending::<()>().await;
-                continue;
-            };
-
-            sleep_until(soonest).await;
-
-            let timed_out = self
-                .handle_map
-                .iter()
-                .filter(|(_, pending)| pending.timeout_at <= soonest)
-                .map(|(request_id, _)| request_id.clone())
-                .collect::<Vec<_>>();
-
-            for request_id in &timed_out {
-                warn!(
-                    "No response for request_id {} within {:?}: failing it as timed out",
-                    request_id, self.request_timeout
-                );
-
-                self.fail_request(request_id, RithmicError::RequestTimeout);
-            }
-        }
+        self.handle_map
+            .insert(request.request_id, request.responder);
     }
 
     fn send_to_responder(
@@ -132,8 +73,8 @@ impl RithmicRequestHandler {
     /// Returns `true` if the request was found and the error was sent.
     pub fn fail_request(&mut self, request_id: &str, error: RithmicError) -> bool {
         self.response_vec_map.remove(request_id);
-        if let Some(pending) = self.handle_map.remove(request_id) {
-            let _ = pending.responder.send(Err(error));
+        if let Some(responder) = self.handle_map.remove(request_id) {
+            let _ = responder.send(Err(error));
             true
         } else {
             false
@@ -144,8 +85,8 @@ impl RithmicRequestHandler {
         match response.message {
             RithmicMessage::ResponseHeartbeat(_) => {
                 // Handle heartbeat response if a callback is registered
-                if let Some(pending) = self.handle_map.remove(&response.request_id) {
-                    self.send_to_responder(pending.responder, vec![response]);
+                if let Some(responder) = self.handle_map.remove(&response.request_id) {
+                    self.send_to_responder(responder, vec![response]);
                 }
             }
             _ => {
@@ -155,8 +96,8 @@ impl RithmicRequestHandler {
                     // multi-part response early and lands here.
                     self.response_vec_map.remove(&response.request_id);
 
-                    if let Some(pending) = self.handle_map.remove(&response.request_id) {
-                        self.send_to_responder(pending.responder, vec![response]);
+                    if let Some(responder) = self.handle_map.remove(&response.request_id) {
+                        self.send_to_responder(responder, vec![response]);
                     } else {
                         error!("No responder found for response: {:#?}", response);
                     }
@@ -165,16 +106,19 @@ impl RithmicRequestHandler {
                     if response.has_more {
                         // Accumulate only while a responder is waiting: parts for
                         // a gone id would re-create an entry nothing removes.
-                        if let Some(pending) = self.handle_map.get_mut(&response.request_id) {
-                            // The part is progress, so the timeout restarts.
-                            pending.timeout_at = Instant::now() + self.request_timeout;
-
+                        if self.handle_map.contains_key(&response.request_id) {
                             self.response_vec_map
                                 .entry(response.request_id.clone())
                                 .or_default()
                                 .push(response);
+                        } else {
+                            warn!(
+                                "Dropping part of a multi-part response: no request waiting on \
+                                 request_id {}",
+                                response.request_id
+                            );
                         }
-                    } else if let Some(pending) = self.handle_map.remove(&response.request_id) {
+                    } else if let Some(responder) = self.handle_map.remove(&response.request_id) {
                         let response_vec = match self.response_vec_map.remove(&response.request_id)
                         {
                             Some(mut vec) => {
@@ -185,7 +129,7 @@ impl RithmicRequestHandler {
                                 vec![response]
                             }
                         };
-                        self.send_to_responder(pending.responder, response_vec);
+                        self.send_to_responder(responder, response_vec);
                     } else {
                         error!("No responder found for response: {:#?}", response);
                     }
@@ -200,8 +144,8 @@ impl RithmicRequestHandler {
     /// Call this during an unclean shutdown (e.g., abort) to unblock any tasks that are
     /// waiting for a response that will never arrive.
     pub fn drain_and_drop(&mut self) {
-        for (_, pending) in self.handle_map.drain() {
-            let _ = pending.responder.send(Err(RithmicError::ConnectionClosed));
+        for (_, responder) in self.handle_map.drain() {
+            let _ = responder.send(Err(RithmicError::ConnectionClosed));
         }
         self.response_vec_map.clear();
     }
@@ -308,7 +252,7 @@ mod tests {
 
     #[test]
     fn single_response_delivered_to_responder() {
-        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
+        let mut handler = RithmicRequestHandler::new();
         let (tx, mut rx) = oneshot::channel();
 
         handler.register_request(RithmicRequest {
@@ -325,7 +269,7 @@ mod tests {
 
     #[test]
     fn single_response_removes_request_from_handler() {
-        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
+        let mut handler = RithmicRequestHandler::new();
         let (tx, mut rx) = oneshot::channel();
 
         handler.register_request(RithmicRequest {
@@ -346,7 +290,7 @@ mod tests {
 
     #[test]
     fn multi_response_collects_all_parts() {
-        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
+        let mut handler = RithmicRequestHandler::new();
         let (tx, mut rx) = oneshot::channel();
 
         handler.register_request(RithmicRequest {
@@ -374,7 +318,7 @@ mod tests {
 
     #[test]
     fn multi_response_single_message_no_has_more() {
-        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
+        let mut handler = RithmicRequestHandler::new();
         let (tx, mut rx) = oneshot::channel();
 
         handler.register_request(RithmicRequest {
@@ -398,7 +342,7 @@ mod tests {
 
     #[test]
     fn heartbeat_delivered_when_responder_registered() {
-        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
+        let mut handler = RithmicRequestHandler::new();
         let (tx, mut rx) = oneshot::channel();
 
         handler.register_request(RithmicRequest {
@@ -414,7 +358,7 @@ mod tests {
 
     #[test]
     fn heartbeat_without_responder_does_not_panic() {
-        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
+        let mut handler = RithmicRequestHandler::new();
         // No responder registered — should silently ignore
         handler.handle_response(make_response("hb", heartbeat_message()));
     }
@@ -425,7 +369,7 @@ mod tests {
 
     #[test]
     fn fail_request_sends_error_and_returns_true() {
-        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
+        let mut handler = RithmicRequestHandler::new();
         let (tx, mut rx) = oneshot::channel();
 
         handler.register_request(RithmicRequest {
@@ -441,7 +385,7 @@ mod tests {
 
     #[test]
     fn fail_request_returns_false_for_unknown_id() {
-        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
+        let mut handler = RithmicRequestHandler::new();
         assert!(!handler.fail_request("unknown", RithmicError::SendFailed));
     }
 
@@ -451,7 +395,7 @@ mod tests {
 
     #[test]
     fn drain_and_drop_sends_connection_closed_to_all_pending() {
-        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
+        let mut handler = RithmicRequestHandler::new();
         let (tx1, rx1) = oneshot::channel();
         let (tx2, rx2) = oneshot::channel();
 
@@ -475,7 +419,7 @@ mod tests {
 
     #[test]
     fn drain_and_drop_clears_partial_multi_responses() {
-        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
+        let mut handler = RithmicRequestHandler::new();
         let (tx, _rx) = oneshot::channel();
 
         handler.register_request(RithmicRequest {
@@ -517,12 +461,8 @@ mod tests {
     }
 
     // =========================================================================
-    // fail_timed_out
+    // Requests with no caller waiting
     // =========================================================================
-
-    fn timeout_handler() -> RithmicRequestHandler {
-        RithmicRequestHandler::new(Duration::from_secs(30))
-    }
 
     fn register(
         handler: &mut RithmicRequestHandler,
@@ -538,170 +478,9 @@ mod tests {
         rx
     }
 
-    /// Run the timeout loop until `rx` resolves. Time is paused, so the elapsed
-    /// figure is exactly what a caller would have waited.
-    async fn time_out_until(
-        handler: &mut RithmicRequestHandler,
-        rx: oneshot::Receiver<Result<Vec<RithmicResponse>, RithmicError>>,
-    ) -> (RithmicError, Duration) {
-        let started = Instant::now();
-
-        let err = tokio::select! {
-            _ = handler.fail_timed_out() => unreachable!(),
-            received = rx => received.unwrap().unwrap_err(),
-        };
-
-        (err, Instant::now() - started)
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn a_zero_timeout_falls_back_to_the_default() {
-        // A config built by hand can carry Duration::ZERO; that must mean
-        // "default", not "fail every request on arrival".
-        let mut handler = RithmicRequestHandler::new(Duration::ZERO);
-        let rx = register(&mut handler, "zero");
-
-        let (err, elapsed) = time_out_until(&mut handler, rx).await;
-
-        assert_eq!(err, RithmicError::RequestTimeout);
-        assert_eq!(elapsed, DEFAULT_REQUEST_TIMEOUT);
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn a_silent_request_fails_exactly_at_its_timeout() {
-        let mut handler = timeout_handler();
-        let rx = register(&mut handler, "late");
-
-        let (err, elapsed) = time_out_until(&mut handler, rx).await;
-
-        assert_eq!(err, RithmicError::RequestTimeout);
-        assert_eq!(elapsed, Duration::from_secs(30));
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn the_request_that_times_out_soonest_fails_first() {
-        let mut handler = timeout_handler();
-        let soon = register(&mut handler, "soon");
-
-        tokio::time::advance(Duration::from_secs(10)).await;
-
-        let late = register(&mut handler, "late");
-
-        let (_, elapsed) = time_out_until(&mut handler, soon).await;
-        assert_eq!(elapsed, Duration::from_secs(20), "registered 10s earlier");
-
-        let (_, elapsed) = time_out_until(&mut handler, late).await;
-        assert_eq!(elapsed, Duration::from_secs(10), "10s behind the first");
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn every_request_due_at_the_same_time_fails_together() {
-        let mut handler = timeout_handler();
-        let mut receivers: Vec<_> = (0..5)
-            .map(|i| register(&mut handler, &format!("req-{i}")))
-            .collect();
-
-        let last = receivers.pop().unwrap();
-        let (_, elapsed) = time_out_until(&mut handler, last).await;
-
-        assert_eq!(elapsed, Duration::from_secs(30));
-        assert!(
-            handler.handle_map.is_empty(),
-            "one pass, not one per request"
-        );
-
-        for mut rx in receivers {
-            assert_eq!(
-                rx.try_recv().unwrap().unwrap_err(),
-                RithmicError::RequestTimeout
-            );
-        }
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn a_drained_request_is_not_timed_out_afterwards() {
-        let mut handler = timeout_handler();
-        let mut rx = register(&mut handler, "req-1");
-
-        handler.drain_and_drop();
-
-        assert_eq!(
-            rx.try_recv().unwrap().unwrap_err(),
-            RithmicError::ConnectionClosed
-        );
-
-        // Nothing left to time out, so the loop parks instead of firing.
-        tokio::select! {
-            _ = handler.fail_timed_out() => panic!("fired on a drained request"),
-            _ = tokio::time::sleep(Duration::from_secs(3600)) => {}
-        }
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn a_response_just_before_the_timeout_still_wins() {
-        let mut handler = timeout_handler();
-        let mut rx = register(&mut handler, "close-call");
-
-        tokio::time::advance(Duration::from_secs(29)).await;
-        handler.handle_response(make_response("close-call", login_message()));
-
-        assert_eq!(rx.try_recv().unwrap().unwrap().len(), 1);
-
-        tokio::select! {
-            _ = handler.fail_timed_out() => panic!("fired on an answered request"),
-            _ = tokio::time::sleep(Duration::from_secs(3600)) => {}
-        }
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn a_timed_out_request_is_removed() {
-        let mut handler = timeout_handler();
-        let rx = register(&mut handler, "late");
-
-        time_out_until(&mut handler, rx).await;
-
-        assert!(handler.handle_map.is_empty());
-        assert!(!handler.fail_request("late", RithmicError::SendFailed));
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn a_request_answered_in_time_is_never_failed() {
-        let mut handler = timeout_handler();
-        let mut rx = register(&mut handler, "ok");
-
-        handler.handle_response(make_response("ok", login_message()));
-
-        assert_eq!(rx.try_recv().unwrap().unwrap().len(), 1);
-
-        // Nothing registered, so the loop parks rather than firing.
-        tokio::select! {
-            _ = handler.fail_timed_out() => unreachable!(),
-            _ = tokio::time::sleep(Duration::from_secs(3600)) => {}
-        }
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn a_multi_response_part_restarts_the_timeout() {
-        let mut handler = timeout_handler();
-        let rx = register(&mut handler, "stream");
-
-        // A part arrives 20s in, moving the timeout to 20s + 30s.
-        tokio::time::advance(Duration::from_secs(20)).await;
-
-        let mut part = make_response("stream", ref_data_message());
-        part.multi_response = true;
-        part.has_more = true;
-        handler.handle_response(part);
-
-        let (err, elapsed) = time_out_until(&mut handler, rx).await;
-
-        assert_eq!(err, RithmicError::RequestTimeout);
-        assert_eq!(elapsed, Duration::from_secs(30), "measured from the part");
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn a_timeout_clears_partial_multi_responses() {
-        let mut handler = timeout_handler();
+    #[test]
+    fn a_failed_request_clears_its_partial_multi_response() {
+        let mut handler = RithmicRequestHandler::new();
         let rx = register(&mut handler, "m");
 
         let mut part = make_response("m", ref_data_message());
@@ -709,11 +488,12 @@ mod tests {
         part.has_more = true;
         handler.handle_response(part);
 
-        time_out_until(&mut handler, rx).await;
+        handler.fail_request("m", RithmicError::ConnectionClosed);
+        drop(rx);
 
         assert!(handler.response_vec_map.is_empty());
 
-        // A new request reusing the ID must not inherit the stale part. Only a
+        // A new request reusing the id must not inherit the stale part. Only a
         // terminal multi-part response merges the map, so probe with one.
         let mut rx2 = register(&mut handler, "m");
 
@@ -725,9 +505,9 @@ mod tests {
         assert_eq!(rx2.try_recv().unwrap().unwrap().len(), 1);
     }
 
-    #[tokio::test(start_paused = true)]
-    async fn parts_arriving_after_a_timeout_do_not_re_create_the_partial_buffer() {
-        let mut handler = timeout_handler();
+    #[test]
+    fn parts_arriving_after_a_failure_do_not_re_create_the_partial_buffer() {
+        let mut handler = RithmicRequestHandler::new();
         let rx = register(&mut handler, "42");
 
         let mut first = make_response("42", ref_data_message());
@@ -735,7 +515,8 @@ mod tests {
         first.has_more = true;
         handler.handle_response(first);
 
-        time_out_until(&mut handler, rx).await;
+        handler.fail_request("42", RithmicError::ConnectionClosed);
+        drop(rx);
 
         // The server resumes streaming the request that was just failed.
         for _ in 0..3 {
@@ -750,7 +531,6 @@ mod tests {
             "parts for an unregistered id must not re-create the buffer"
         );
 
-        // The terminal part finds no responder and must not leave one behind.
         let mut terminal = make_response("42", ref_data_message());
         terminal.multi_response = true;
         terminal.has_more = false;
@@ -761,7 +541,7 @@ mod tests {
 
     #[test]
     fn parts_for_a_never_registered_id_do_not_accumulate() {
-        let mut handler = timeout_handler();
+        let mut handler = RithmicRequestHandler::new();
 
         for _ in 0..3 {
             let mut part = make_response("ghost", ref_data_message());
@@ -776,25 +556,21 @@ mod tests {
         );
     }
 
-    #[tokio::test(start_paused = true)]
-    async fn a_caller_that_walked_away_does_not_stall_the_loop() {
-        let mut handler = timeout_handler();
-        let (tx, rx) = oneshot::channel();
+    #[test]
+    fn a_part_whose_request_is_gone_says_so_in_the_log() {
+        let mut handler = RithmicRequestHandler::new();
 
-        handler.register_request(RithmicRequest {
-            request_id: "gone".to_string(),
-            responder: tx,
+        let (_, logged) = log_capture::capture(|| {
+            let mut part = make_response("gone", ref_data_message());
+            part.multi_response = true;
+            part.has_more = true;
+            handler.handle_response(part);
         });
 
-        // The caller gave up and dropped its receiver, so nothing observes the
-        // failure. The entry must still be removed rather than retried forever.
-        drop(rx);
-
-        let live = register(&mut handler, "live");
-        let (_, elapsed) = time_out_until(&mut handler, live).await;
-
-        assert_eq!(elapsed, Duration::from_secs(30));
-        assert!(handler.handle_map.is_empty());
+        assert!(
+            logged.contains("no request waiting on request_id gone"),
+            "{logged}"
+        );
     }
 
     // =========================================================================
@@ -803,14 +579,14 @@ mod tests {
 
     #[test]
     fn response_for_unregistered_id_does_not_panic() {
-        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
+        let mut handler = RithmicRequestHandler::new();
 
         handler.handle_response(make_response("ghost", login_message()));
     }
 
     #[test]
     fn dropped_receiver_does_not_panic() {
-        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
+        let mut handler = RithmicRequestHandler::new();
         let (tx, rx) = oneshot::channel();
 
         handler.register_request(RithmicRequest {
@@ -826,7 +602,7 @@ mod tests {
     #[test]
     fn single_response_clears_partial_multi_responses_for_the_same_id() {
         // Mirrors a decode failure landing mid multi-part response.
-        let mut handler = RithmicRequestHandler::new(DEFAULT_REQUEST_TIMEOUT);
+        let mut handler = RithmicRequestHandler::new();
         let (tx, mut rx) = oneshot::channel();
 
         handler.register_request(RithmicRequest {


### PR DESCRIPTION
## What changed

The library no longer times out requests. A request is resolved by a response carrying its id, by `fail_request`, or by `drain_and_drop` on disconnect.

The 30s window added in 3e42fdd measured silence between frames rather than total duration, and `place_order` has nothing between the send and the first frame to reset it, so it could fire on a request whose reply was still in flight. When it fired, `fail_request` consumed the `oneshot::Sender` and removed the `handle_map` entry, leaving nothing to match the reply against: the caller got `RequestTimeout` and the response was dropped.

Cancelling the future cancels nothing on Rithmic's side — the request had already been sent. Of the four paths that remove a `handle_map` entry, only the timeout could strand a reply on a live connection.

A caller who wants a limit sets one:

```rust
match tokio::time::timeout(Duration::from_secs(30), request).await {
    Ok(Ok(resp))  => println!("{:?}", resp.message),
    Ok(Err(e))    => eprintln!("request failed: {e}"),
    Err(_elapsed) => eprintln!("gave up waiting; the request may still land"),
}
```

`examples/request_timeout.rs` is new and shows this end to end. Nothing in `src/` sets a deadline over a request.

## Code

- `fail_timed_out` and its `select!` arm in `next_event` are removed. The `select!` has no `biased` keyword, so removing an arm does not change how the remaining ones are selected.
- `PendingRequest` held nothing but the responder once `timeout_at` was removed, so it collapses into a `Responder` type alias.
- `LEGACY_REQUEST_TIMEOUT` is removed. `DEFAULT_REQUEST_TIMEOUT` holds the 30-second literal and is the only definition.
- A part of a multi-part response whose request is no longer waiting is now logged. The guard is unchanged; it discarded them with no record.

## API surface

3.1.0. Nothing breaking — the reaper lived in the private `request_handler` module. Four public items are deprecated, still accepted and still readable, removed in 4.0.0:

- `RithmicConfig::request_timeout`
- `RithmicConfigBuilder::request_timeout()`
- `DEFAULT_REQUEST_TIMEOUT`
- `RithmicError::RequestTimeout`

`RITHMIC_REQUEST_TIMEOUT_SECS` is still read and still rejected if it is not plain digits, then ignored.

A call with no caller-side limit waits until the connection drops.

## Tests

`cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo build --examples` are clean. 346 unit tests and 50 doctests pass.

Thirteen timeout tests are deleted and four added, covering a failed request clearing its partial buffer, parts arriving after a failure not re-creating it, parts for a never-registered id not accumulating, and the new log. Both of `next_event`'s tests were timeout tests; the replacement drives ten 60s ticks of paused time and asserts a registered request is still waiting.