### PR TITLE
feat(order-plant): add open_orders to read the account's open orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ If you want a time limit, set it yourself with `tokio::time::timeout`. You know
 what each call is worth waiting for and the library does not. See
 `examples/request_timeout.rs`.
 
+### A way to check what the broker thinks you have open
+
+`open_orders()` asks Rithmic for the account's open orders and hands them back
+as two lists. `show_orders()` already asked the same question, but the answer
+came back on the update stream mixed in with live activity and nothing marked
+where it ended, so you could not tell the two apart.
+
+This is what to call when you gave up waiting on an order and do not know
+whether it went through. Re-sending it can leave you with two orders; reading
+the open orders back tells you which it was.
+
+If the update stream overflows while the list is being read, you get
+`SnapshotIncomplete` instead of a list that is quietly missing orders.
+
 ### Deprecated
 
 These still compile and are still accepted, but the library ignores them.
@@ -35,6 +49,12 @@ They go away in 4.0.0.
 
 ### Added
 
+- `RithmicOrderPlantHandle::open_orders()` — the account's open orders, as a
+  list of `RithmicOrderNotification` and a list of `ExchangeOrderNotification`.
+- `RithmicError::SnapshotIncomplete` — the update stream overflowed while
+  `open_orders()` was reading, so the list would have been short.
+- `SubscriptionFilter::try_recv()` — takes an update if one is already waiting
+  instead of blocking for the next one.
 - `examples/request_timeout.rs` — how to put your own time limit on a request.
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rithmic-rs"
-version = "3.0.0"
+version = "3.1.0"
 description = "Rust client for the Rithmic R | Protocol API to build algo trading systems"
 license = "MIT OR Apache-2.0"
 edition = "2024"

--- a/src/error.rs
+++ b/src/error.rs
@@ -145,6 +145,20 @@ pub enum RithmicError {
         /// The exchanges that do have a route.
         cached: Vec<String>,
     },
+    /// A snapshot was being collected off the subscription broadcast and the
+    /// broadcast overflowed, dropping `lost` messages before they were read.
+    ///
+    /// Returned instead of a short list, because a snapshot that is missing
+    /// orders is worse than no snapshot at all. Nothing changed on the server,
+    /// but the broker state for this account is unknown and has to be re-read.
+    /// `lost` is not a number of missing orders.
+    #[non_exhaustive]
+    SnapshotIncomplete {
+        /// Messages the broadcast dropped, as `tokio::sync::broadcast` counted
+        /// them. Includes messages for other accounts on the same plant, so
+        /// this is a measure of how much was missed, not of how many orders.
+        lost: u64,
+    },
     /// Keep-alive detected the connection is dead.
     HeartbeatTimeout,
     /// Server terminated the session with a reason string.
@@ -214,6 +228,9 @@ impl fmt::Display for RithmicError {
                         write!(f, "; cached: {}", cached.join(", "))
                     }
                 }
+            }
+            RithmicError::SnapshotIncomplete { lost } => {
+                write!(f, "snapshot incomplete: {lost} updates were dropped")
             }
             RithmicError::HeartbeatTimeout => write!(f, "heartbeat timeout"),
             RithmicError::ForcedLogout(reason) => {
@@ -429,6 +446,23 @@ mod tests {
             RithmicError::RequestTimeout.to_string(),
             "request timed out"
         );
+    }
+
+    #[test]
+    fn snapshot_incomplete_display_names_the_loss() {
+        let err = RithmicError::SnapshotIncomplete { lost: 12 };
+
+        assert_eq!(
+            err.to_string(),
+            "snapshot incomplete: 12 updates were dropped"
+        );
+    }
+
+    #[test]
+    fn snapshot_incomplete_is_not_a_connection_issue() {
+        // The connection is fine; the reader fell behind. Reconnecting would
+        // cost the subscriptions and fix nothing.
+        assert!(!RithmicError::SnapshotIncomplete { lost: 1 }.is_connection_issue());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,10 @@
 //!   connection problem rather than retrying in a loop.
 //! - [`ConnectionClosed`](RithmicError::ConnectionClosed) — the plant is gone.
 //!   Reconnect; calling again will not work.
+//! - [`SnapshotIncomplete`](RithmicError::SnapshotIncomplete) — only from
+//!   [`open_orders`](plants::order_plant::RithmicOrderPlantHandle::open_orders).
+//!   The subscription channel overflowed while the snapshot was being read, so
+//!   the list would have been short. Nothing changed on the server; call again.
 //!
 //! When a connection drops, everything in flight fails with `ConnectionClosed`
 //! whatever the real cause was. The cause goes out on the subscription channel,
@@ -172,7 +176,9 @@
 //! A request has no deadline of its own: Rithmic answers it or the connection
 //! drops. Wrap the call in [`tokio::time::timeout`] if you want a ceiling —
 //! see `examples/request_timeout.rs`. Giving up cancels nothing on Rithmic's
-//! side, so reconcile an order rather than re-sending it.
+//! side, so reconcile with
+//! [`open_orders`](plants::order_plant::RithmicOrderPlantHandle::open_orders)
+//! rather than re-sending.
 //!
 //! ([`ConnectionFailed`](RithmicError::ConnectionFailed) comes from `connect()`
 //! rather than a handle method, and only under [`ConnectStrategy::Simple`] —

--- a/src/plants/order_plant.rs
+++ b/src/plants/order_plant.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, OnceLock};
 use tracing::{debug, error, info, warn};
 
 use tokio::{
-    sync::{broadcast, mpsc, oneshot},
+    sync::{broadcast, broadcast::error::TryRecvError, mpsc, oneshot},
     task::JoinHandle,
 };
 
@@ -25,7 +25,10 @@ use crate::{
         subscription::SubscriptionFilter,
         trade_routes::TradeRouteCache,
     },
-    rti::{TradeRoute, messages::RithmicMessage, request_login::SysInfraType},
+    rti::{
+        ExchangeOrderNotification, RithmicOrderNotification, TradeRoute, messages::RithmicMessage,
+        request_login::SysInfraType,
+    },
     types::{EasyToBorrowRequest, FillHistoryRange, RmsUpdateBits},
 };
 
@@ -1498,7 +1501,9 @@ impl RithmicOrderPlantHandle {
     /// so subscribe before calling this or the orders are missed.
     ///
     /// The crate surfaces no end-of-list signal, so the replayed orders are
-    /// indistinguishable from live activity on the stream.
+    /// indistinguishable from live activity on the stream. Use
+    /// [`open_orders`](Self::open_orders) to get them collected into lists
+    /// instead.
     ///
     /// ```no_run
     /// # use rithmic_rs::{rti::messages::RithmicMessage, RithmicOrderPlantHandle};
@@ -1525,6 +1530,152 @@ impl RithmicOrderPlantHandle {
         let _ = self.sender.send(command).await;
 
         await_first_response(rx).await
+    }
+
+    /// Ask the broker what orders it currently holds for this account, and
+    /// return them as two lists.
+    ///
+    /// This is how you answer "does the broker think this order exists?". The
+    /// library does not time out requests, so if you wrapped an order command
+    /// in [`tokio::time::timeout`] and it expired, the outcome is unknown
+    /// rather than failed — the order may be live at the exchange with nothing
+    /// tracking it. Call this rather than re-sending, which can double the
+    /// order.
+    ///
+    /// It is also the recovery path after `RecvError::Lagged` on
+    /// [`subscription_receiver`](Self::subscription_receiver). A lagged
+    /// broadcast gives back a count and nothing else, and the dropped messages
+    /// are exactly the order notifications that carry `basket_id`, so there is
+    /// no way to replay them. Re-read the whole set instead.
+    ///
+    /// # The two lists
+    ///
+    /// Rithmic replays two views of an order: its own, as
+    /// [`RithmicOrderNotification`] (template 351), and the exchange's, as
+    /// [`ExchangeOrderNotification`] (template 352). Both are returned — the
+    /// Rithmic view first, the exchange view second — and nothing seen in the
+    /// replay window is discarded. Both types carry `basket_id`,
+    /// `original_basket_id` and `linked_basket_ids`, so either list can be
+    /// keyed by basket id.
+    ///
+    /// <div class="warning">
+    ///
+    /// Which template(s) `show_orders` actually replays has **not** been
+    /// verified against a live session. The reference Python client
+    /// (`async_rithmic`) collects only `ExchangeOrderNotification` frames with
+    /// `is_snapshot` set, while this crate's tests were written assuming
+    /// `RithmicOrderNotification`. Treat the exact split between the two lists
+    /// as unverified until you have exercised it against a live or paper
+    /// session — read both, and do not assume either one is populated.
+    ///
+    /// </div>
+    ///
+    /// # Completion
+    ///
+    /// Rithmic replays each open order as its own notification and then closes
+    /// the sequence with `ResponseShowOrders`. That closing frame resolves the
+    /// request rather than reaching the subscription broadcast, so this cannot
+    /// watch for it on the stream: it waits for the ack and then takes
+    /// everything the broadcast has buffered. Every replayed notification is
+    /// broadcast before the ack is delivered, so none of them are missed, and
+    /// two empty `Vec`s mean the broker reported no open orders rather than
+    /// that the snapshot is still arriving.
+    ///
+    /// The end of the list is not a hard boundary. A live notification for this
+    /// account arriving between the ack and the end of the collection is taken
+    /// as well. The error runs one way: the lists can carry an order that has
+    /// just closed, and cannot drop an order that was open when the snapshot
+    /// was taken. Read `notify_type` and `status` on each entry rather than
+    /// reading membership as "open" — a closed order says so itself. An order
+    /// placed while the snapshot is in flight may or may not appear; this is a
+    /// point in time, not a live view.
+    ///
+    /// If the connection drops mid-snapshot the pending request is failed and
+    /// this returns [`RithmicError::ConnectionClosed`]; a partial list is never
+    /// returned. A server rejection is an `Err` too, not an empty list. If the
+    /// broadcast overflows while the snapshot is being collected the result is
+    /// [`RithmicError::SnapshotIncomplete`], again rather than a short list.
+    /// And a replayed frame that failed to decode is an `Err` as well: a
+    /// snapshot that might be missing an order fails loudly rather than
+    /// quietly dropping it.
+    ///
+    /// # Caveats
+    ///
+    /// Key each list by `basket_id` rather than assuming one entry per order:
+    /// a replayed order whose live update lands in the same window appears
+    /// twice, and the later entry is the current one. The same order also
+    /// appears in both lists whenever the replay emits both views of it.
+    ///
+    /// ```no_run
+    /// # use rithmic_rs::RithmicOrderPlantHandle;
+    /// # async fn example(handle: RithmicOrderPlantHandle) -> Result<(), Box<dyn std::error::Error>> {
+    /// let (rithmic_view, exchange_view) = handle.open_orders().await?;
+    ///
+    /// for order in &rithmic_view {
+    ///     println!("rithmic {:?} {:?} {:?}", order.basket_id, order.symbol, order.status);
+    /// }
+    /// for order in &exchange_view {
+    ///     println!("exchange {:?} {:?} {:?}", order.basket_id, order.symbol, order.status);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`RithmicOrderNotification`]: crate::rti::RithmicOrderNotification
+    /// [`ExchangeOrderNotification`]: crate::rti::ExchangeOrderNotification
+    pub async fn open_orders(
+        &self,
+    ) -> Result<
+        (
+            Vec<RithmicOrderNotification>,
+            Vec<ExchangeOrderNotification>,
+        ),
+        RithmicError,
+    > {
+        // Resubscribe before the request goes out. The replayed orders are
+        // broadcast before the ack that ends them, so a receiver created after
+        // the ack would have missed every one of them.
+        let mut updates = self.subscription_receiver.resubscribe();
+
+        let ack = self.show_orders().await?;
+
+        if let Some(error) = ack.error {
+            return Err(error);
+        }
+
+        let mut rithmic_orders = Vec::new();
+        let mut exchange_orders = Vec::new();
+
+        loop {
+            match updates.try_recv() {
+                Ok(response) => {
+                    // A frame that failed to decode arrives as `Unknown` with
+                    // the error set. Skipping it would hand back a snapshot
+                    // silently missing an order.
+                    if let Some(error) = response.error {
+                        return Err(error);
+                    }
+
+                    match response.message {
+                        RithmicMessage::RithmicOrderNotification(order) => {
+                            rithmic_orders.push(order);
+                        }
+                        RithmicMessage::ExchangeOrderNotification(order) => {
+                            exchange_orders.push(order);
+                        }
+                        _ => {}
+                    }
+                }
+                // Empty means the replay is drained; Closed means the plant is
+                // gone, but the ack already arrived so the replay is drained too.
+                Err(TryRecvError::Empty | TryRecvError::Closed) => {
+                    return Ok((rithmic_orders, exchange_orders));
+                }
+                Err(TryRecvError::Lagged(lost)) => {
+                    return Err(RithmicError::SnapshotIncomplete { lost });
+                }
+            }
+        }
     }
 
     async fn update_heartbeat(&self, seconds: u64) {

--- a/src/plants/order_plant/tests.rs
+++ b/src/plants/order_plant/tests.rs
@@ -16,9 +16,21 @@ use crate::{
 };
 
 fn test_handle() -> (RithmicOrderPlantHandle, mpsc::Receiver<OrderPlantCommand>) {
+    let (handle, command_receiver, _) = subscribed_test_handle();
+
+    (handle, command_receiver)
+}
+
+/// A handle whose subscription broadcast is kept alive, so a test can push
+/// updates onto it the way the plant actor would.
+fn subscribed_test_handle() -> (
+    RithmicOrderPlantHandle,
+    mpsc::Receiver<OrderPlantCommand>,
+    broadcast::Sender<RithmicResponse>,
+) {
     let account = test_account();
     let (sender, command_receiver) = mpsc::channel(4);
-    let (_, subscription_receiver) = broadcast::channel(4);
+    let (subscription_sender, subscription_receiver) = broadcast::channel(SUBSCRIPTION_CAPACITY);
 
     let handle = RithmicOrderPlantHandle {
         account: account.clone(),
@@ -27,7 +39,7 @@ fn test_handle() -> (RithmicOrderPlantHandle, mpsc::Receiver<OrderPlantCommand>)
         subscription_receiver: SubscriptionFilter::new(account, subscription_receiver),
     };
 
-    (handle, command_receiver)
+    (handle, command_receiver, subscription_sender)
 }
 
 fn adjustment(id: &str, ticks: i32, level: Option<i32>) -> RithmicBracketLevelAdjustment {
@@ -1310,4 +1322,278 @@ async fn exit_position_encodes_auto_placement_by_default() {
         request.manual_or_auto,
         Some(crate::rti::request_exit_position::OrderPlacement::Auto as i32)
     );
+}
+
+// =========================================================================
+// open_orders
+// =========================================================================
+
+/// Small enough that a test can overflow it on purpose.
+const SUBSCRIPTION_CAPACITY: usize = 4;
+
+fn order_notification(basket_id: &str, account_id: &str) -> RithmicResponse {
+    subscription_update(RithmicMessage::RithmicOrderNotification(
+        RithmicOrderNotification {
+            template_id: 351,
+            account_id: Some(account_id.to_string()),
+            basket_id: Some(basket_id.to_string()),
+            ..RithmicOrderNotification::default()
+        },
+    ))
+}
+
+fn exchange_notification(basket_id: &str, account_id: &str) -> RithmicResponse {
+    subscription_update(RithmicMessage::ExchangeOrderNotification(
+        ExchangeOrderNotification {
+            template_id: 352,
+            account_id: Some(account_id.to_string()),
+            basket_id: Some(basket_id.to_string()),
+            ..ExchangeOrderNotification::default()
+        },
+    ))
+}
+
+fn subscription_update(message: RithmicMessage) -> RithmicResponse {
+    RithmicResponse {
+        request_id: String::new(),
+        message,
+        is_update: true,
+        has_more: false,
+        multi_response: false,
+        error: None,
+        source: "order_plant".to_string(),
+    }
+}
+
+/// The shape a notification that would not decode arrives in: no message to
+/// read, the decode failure in `error`, still flagged as an update.
+fn undecodable_update() -> RithmicResponse {
+    RithmicResponse {
+        error: Some(RithmicError::ProtocolError("decode failed".to_string())),
+        ..subscription_update(RithmicMessage::Unknown)
+    }
+}
+
+fn show_orders_ack(error: Option<RithmicError>) -> RithmicResponse {
+    RithmicResponse {
+        request_id: "1".to_string(),
+        message: RithmicMessage::ResponseShowOrders(crate::rti::ResponseShowOrders {
+            template_id: 321,
+            rp_code: vec!["0".to_string()],
+            ..crate::rti::ResponseShowOrders::default()
+        }),
+        is_update: false,
+        has_more: false,
+        multi_response: false,
+        error,
+        source: "order_plant".to_string(),
+    }
+}
+
+/// Takes the `ShowOrders` the call under test sent and hands back its responder,
+/// so the test can replay orders before ending the snapshot.
+async fn take_show_orders(command_receiver: &mut mpsc::Receiver<OrderPlantCommand>) -> Responder {
+    match next_command(command_receiver).await {
+        OrderPlantCommand::ShowOrders {
+            response_sender, ..
+        } => response_sender,
+        _ => panic!("open_orders must send ShowOrders"),
+    }
+}
+
+fn basket_ids(orders: &[RithmicOrderNotification]) -> Vec<&str> {
+    orders
+        .iter()
+        .map(|order| order.basket_id.as_deref().unwrap_or_default())
+        .collect()
+}
+
+fn exchange_basket_ids(orders: &[ExchangeOrderNotification]) -> Vec<&str> {
+    orders
+        .iter()
+        .map(|order| order.basket_id.as_deref().unwrap_or_default())
+        .collect()
+}
+
+#[tokio::test]
+async fn open_orders_collects_the_replay_up_to_the_ack() {
+    let (handle, mut commands, subscription) = subscribed_test_handle();
+
+    let (orders, ()) = tokio::join!(handle.open_orders(), async {
+        let responder = take_show_orders(&mut commands).await;
+
+        subscription
+            .send(order_notification("basket-1", "ACCOUNT_A"))
+            .unwrap();
+        subscription
+            .send(order_notification("basket-2", "ACCOUNT_A"))
+            .unwrap();
+
+        let _ = responder.send(Ok(vec![show_orders_ack(None)]));
+    });
+
+    let (rithmic, exchange) = orders.expect("a completed snapshot is not an error");
+
+    assert_eq!(basket_ids(&rithmic), vec!["basket-1", "basket-2"]);
+    assert!(exchange.is_empty());
+}
+
+/// Rithmic replays two views of an order and the caller gets both, split by
+/// which template carried it. Nothing in the replay window is discarded.
+#[tokio::test]
+async fn open_orders_returns_both_views_of_the_replay() {
+    let (handle, mut commands, subscription) = subscribed_test_handle();
+
+    let (orders, ()) = tokio::join!(handle.open_orders(), async {
+        let responder = take_show_orders(&mut commands).await;
+
+        subscription
+            .send(order_notification("basket-1", "ACCOUNT_A"))
+            .unwrap();
+        subscription
+            .send(exchange_notification("basket-1", "ACCOUNT_A"))
+            .unwrap();
+
+        let _ = responder.send(Ok(vec![show_orders_ack(None)]));
+    });
+
+    let (rithmic, exchange) = orders.expect("a completed snapshot is not an error");
+
+    assert_eq!(basket_ids(&rithmic), vec!["basket-1"]);
+    assert_eq!(exchange_basket_ids(&exchange), vec!["basket-1"]);
+}
+
+#[tokio::test]
+async fn open_orders_returns_an_empty_list_when_the_account_has_none() {
+    // The ack is the end of the list, so an account with nothing open answers
+    // immediately rather than blocking until some unrelated update arrives.
+    let (handle, mut commands, _subscription) = subscribed_test_handle();
+
+    let (orders, ()) = tokio::join!(handle.open_orders(), async {
+        let responder = take_show_orders(&mut commands).await;
+        let _ = responder.send(Ok(vec![show_orders_ack(None)]));
+    });
+
+    let (rithmic, exchange) = orders.expect("an empty snapshot is not an error");
+
+    assert!(rithmic.is_empty());
+    assert!(exchange.is_empty());
+}
+
+#[tokio::test]
+async fn open_orders_ignores_updates_from_before_the_request() {
+    // Live activity that happened before the call is not part of the snapshot.
+    let (handle, mut commands, subscription) = subscribed_test_handle();
+
+    subscription
+        .send(order_notification("earlier", "ACCOUNT_A"))
+        .unwrap();
+
+    let (orders, ()) = tokio::join!(handle.open_orders(), async {
+        let responder = take_show_orders(&mut commands).await;
+        let _ = responder.send(Ok(vec![show_orders_ack(None)]));
+    });
+
+    let (rithmic, exchange) = orders.unwrap();
+
+    assert!(rithmic.is_empty());
+    assert!(exchange.is_empty());
+}
+
+#[tokio::test]
+async fn open_orders_skips_notifications_for_other_accounts() {
+    let (handle, mut commands, subscription) = subscribed_test_handle();
+
+    let (orders, ()) = tokio::join!(handle.open_orders(), async {
+        let responder = take_show_orders(&mut commands).await;
+
+        subscription
+            .send(order_notification("theirs", "ACCOUNT_B"))
+            .unwrap();
+        subscription
+            .send(order_notification("ours", "ACCOUNT_A"))
+            .unwrap();
+
+        let _ = responder.send(Ok(vec![show_orders_ack(None)]));
+    });
+
+    assert_eq!(basket_ids(&orders.unwrap().0), vec!["ours"]);
+}
+
+#[tokio::test]
+async fn open_orders_reports_a_rejected_snapshot_as_an_error() {
+    // A rejection must not look like an account with no open orders.
+    let (handle, mut commands, _subscription) = subscribed_test_handle();
+
+    let rejection = RithmicError::RequestRejected(RithmicRequestError {
+        rp_code: vec!["3".to_string(), "bad request".to_string()],
+        code: Some("3".to_string()),
+        message: Some("bad request".to_string()),
+    });
+
+    let (orders, ()) = tokio::join!(handle.open_orders(), async {
+        let responder = take_show_orders(&mut commands).await;
+        let _ = responder.send(Ok(vec![show_orders_ack(Some(rejection.clone()))]));
+    });
+
+    assert!(matches!(orders, Err(RithmicError::RequestRejected(_))));
+}
+
+/// A notification that would not decode reaches the drain as `Unknown` with the
+/// failure attached. Skipping it would hand back a snapshot quietly missing an
+/// order, so the whole snapshot fails instead.
+#[tokio::test]
+async fn open_orders_fails_on_a_replayed_frame_that_would_not_decode() {
+    let (handle, mut commands, subscription) = subscribed_test_handle();
+
+    let (orders, ()) = tokio::join!(handle.open_orders(), async {
+        let responder = take_show_orders(&mut commands).await;
+
+        subscription
+            .send(order_notification("basket-1", "ACCOUNT_A"))
+            .unwrap();
+        subscription.send(undecodable_update()).unwrap();
+
+        let _ = responder.send(Ok(vec![show_orders_ack(None)]));
+    });
+
+    assert!(matches!(orders, Err(RithmicError::ProtocolError(_))));
+}
+
+#[tokio::test]
+async fn open_orders_fails_when_the_connection_drops_mid_snapshot() {
+    // Half a snapshot is worse than none: the caller would read the missing
+    // orders as closed.
+    let (handle, mut commands, subscription) = subscribed_test_handle();
+
+    let (orders, ()) = tokio::join!(handle.open_orders(), async {
+        let responder = take_show_orders(&mut commands).await;
+
+        subscription
+            .send(order_notification("basket-1", "ACCOUNT_A"))
+            .unwrap();
+
+        drop(responder);
+    });
+
+    assert_eq!(orders, Err(RithmicError::ConnectionClosed));
+}
+
+#[tokio::test]
+async fn open_orders_reports_a_lagged_snapshot_instead_of_a_short_list() {
+    let (handle, mut commands, subscription) = subscribed_test_handle();
+
+    let (orders, ()) = tokio::join!(handle.open_orders(), async {
+        let responder = take_show_orders(&mut commands).await;
+
+        for index in 0..SUBSCRIPTION_CAPACITY + 2 {
+            subscription
+                .send(order_notification(&format!("basket-{index}"), "ACCOUNT_A"))
+                .unwrap();
+        }
+
+        let _ = responder.send(Ok(vec![show_orders_ack(None)]));
+    });
+
+    assert_eq!(orders, Err(RithmicError::SnapshotIncomplete { lost: 2 }));
 }

--- a/src/plants/subscription.rs
+++ b/src/plants/subscription.rs
@@ -23,9 +23,30 @@ impl SubscriptionFilter {
     ///
     /// When `RecvError::Lagged(n)` is returned, `n` counts all skipped messages
     /// on the shared broadcast stream, including messages for other accounts.
+    /// The skipped messages are gone — for order updates, re-read the set with
+    /// [`RithmicOrderPlantHandle::open_orders`](crate::RithmicOrderPlantHandle::open_orders).
     pub async fn recv(&mut self) -> Result<RithmicResponse, broadcast::error::RecvError> {
         loop {
             let response = self.receiver.recv().await?;
+            if self.should_forward(&response) {
+                return Ok(response);
+            }
+        }
+    }
+
+    /// Take the next already-buffered update for this account, without waiting.
+    ///
+    /// `TryRecvError::Empty` means nothing more is buffered right now, not that
+    /// the stream has ended. That is what lets a caller drain everything the
+    /// plant has broadcast so far instead of blocking until the next live
+    /// update — see
+    /// [`RithmicOrderPlantHandle::open_orders`](crate::RithmicOrderPlantHandle::open_orders).
+    ///
+    /// `Lagged(n)` counts every skipped message on the shared broadcast stream,
+    /// including messages for other accounts, the same way [`Self::recv`] does.
+    pub fn try_recv(&mut self) -> Result<RithmicResponse, broadcast::error::TryRecvError> {
+        loop {
+            let response = self.receiver.try_recv()?;
             if self.should_forward(&response) {
                 return Ok(response);
             }
@@ -158,6 +179,46 @@ mod tests {
         assert!(matches!(
             response.message,
             RithmicMessage::UpdateEasyToBorrowList(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn try_recv_takes_buffered_updates_and_then_reports_empty() {
+        // Empty is what ends a snapshot drain, so it has to arrive once the
+        // buffer is done rather than the call blocking for the next live update.
+        let (sender, receiver) = broadcast::channel(16);
+        let mut filter = SubscriptionFilter::new(account("ACCOUNT_A"), receiver);
+
+        sender
+            .send(response(RithmicMessage::AccountPnLPositionUpdate(
+                AccountPnLPositionUpdate {
+                    template_id: 0,
+                    account_id: Some("ACCOUNT_B".to_string()),
+                    ..AccountPnLPositionUpdate::default()
+                },
+            )))
+            .unwrap();
+        sender
+            .send(response(RithmicMessage::AccountPnLPositionUpdate(
+                AccountPnLPositionUpdate {
+                    template_id: 0,
+                    account_id: Some("ACCOUNT_A".to_string()),
+                    ..AccountPnLPositionUpdate::default()
+                },
+            )))
+            .unwrap();
+
+        let response = filter.try_recv().expect("the buffered update is ours");
+        match response.message {
+            RithmicMessage::AccountPnLPositionUpdate(update) => {
+                assert_eq!(update.account_id.as_deref(), Some("ACCOUNT_A"));
+            }
+            other => panic!("unexpected message: {other:?}"),
+        }
+
+        assert!(matches!(
+            filter.try_recv(),
+            Err(broadcast::error::TryRecvError::Empty)
         ));
     }
 


### PR DESCRIPTION
## What this adds

`RithmicOrderPlantHandle::open_orders()` — the account's open orders, returned
as two lists.

`show_orders()` sends template 320. Rithmic answers it with a 321 ack and
replays the account's open orders as 351 (`RithmicOrderNotification`) and 352
(`ExchangeOrderNotification`) frames on the subscription stream. The crate
surfaces no end-of-list marker, so a caller reading that stream cannot tell a
replayed order from live activity and has no way to know it has seen them all.

`open_orders()` resubscribes before the request goes out, awaits the ack, then
drains what the broadcast buffered.

## Why the drain is complete when the ack lands

`PlantCore::handle_response` (`src/plants/core.rs:367-375`) dispatches in wire
order from a single actor loop. Templates 351 and 352 are updates, so they go to
the broadcast; 321 is not, so it resolves the oneshot. Every replayed
notification is therefore broadcast before the ack is delivered. Once the ack is
in hand the replay is already sitting in the receiver's buffer, and a `try_recv`
loop that stops on the first `Empty` has it all.

The resubscribe has to happen before the request is sent. A receiver created
after the ack arrives would have missed the whole replay.

## Both lists

Both templates carry a view of the same order. Which one the replay emits is not
settled: `rundef/async_rithmic`'s `list_orders` expects 352 with
`is_snapshot=True`, which is shipped code and so real-world evidence for 352,
but it is not proof 351 is absent — they may simply filter. Rithmic's own
reference clients under `rapi/` never send 320, so they cannot settle it either.

Returning both means the empty-forever failure mode does not exist regardless of
which is right. The exact split is still unverified against a live session, and
the rustdoc says so.

## Nothing returns a short list

- Server rejection on the ack → `Err`, not an empty list.
- A replayed frame that failed to decode (arrives as `Unknown` with `error` set)
  → `Err`, rather than a snapshot silently missing an order.
- Broadcast overflow → `RithmicError::SnapshotIncomplete { lost }`.

`lost` is the count `tokio::sync::broadcast` reports. It includes messages for
other accounts on the same plant, so it measures how much was missed, not how
many orders.

## Supporting changes

- `SubscriptionFilter::try_recv()` — takes a buffered update if one is there,
  reports `Empty` otherwise, applying the same account filter as `recv`.
- `RithmicError::SnapshotIncomplete { lost: u64 }`, `#[non_exhaustive]`.
- `Cargo.toml` 3.0.0 → 3.1.0. `main` already carries a `## [3.1.0]` changelog
  entry and four `#[deprecated(since = "3.1.0")]` attributes, so the manifest
  was the odd one out. Say the word and I will pull it back out.

## Semver

Additive. New method, new enum variant on an already-`#[non_exhaustive]` enum,
new method on `SubscriptionFilter`. Nothing removed, nothing changed shape.

## Tests

Nine new tests on `open_orders`: collects the replay up to the ack, returns both
views, empty account, ignores updates from before the request, skips other
accounts, rejected ack, undecodable frame, connection drop mid-snapshot, lagged
broadcast. Two on `SnapshotIncomplete` (display, and that it is not a connection
issue). One on `try_recv`.

358 unit tests and 51 doctests pass. `cargo fmt --check`, `cargo clippy
--all-features --all-targets -- -D warnings`, and `cargo doc` are clean.
