### PR TITLE
docs: rework the request timeout example, and prepare 3.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets -- -D warnings
+      - run: cargo clippy --all-targets --all-features -- -D warnings
 
   test:
     name: Test
@@ -58,6 +59,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo doc --no-deps
+      - run: cargo doc --no-deps --all-features
         env:
           RUSTDOCFLAGS: -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ They go away in 4.0.0.
 
 ### Added
 
-- `examples/request_timeout.rs` — how to put your own time limit on a request.
+- `examples/request_timeout.rs` — how to put your own time limit on a request
+  without losing the answer when the limit runs out.
 
 ### Fixed
 
@@ -1206,7 +1207,8 @@ Previous stable release. See git history for earlier changes.
 - **0.5.0** (2025-11-16): Major stability and API improvements - Connection strategies, unified config, panic fixes, connection health monitoring
 - **0.4.2** (2025-11-15): Previous stable release
 
-[Unreleased]: https://github.com/pbeets/rithmic-rs/compare/v3.0.0...HEAD
+[Unreleased]: https://github.com/pbeets/rithmic-rs/compare/v3.1.0...HEAD
+[3.1.0]: https://github.com/pbeets/rithmic-rs/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/pbeets/rithmic-rs/compare/v2.0.0...v3.0.0
 [2.0.0]: https://github.com/pbeets/rithmic-rs/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/pbeets/rithmic-rs/compare/v0.7.2...v1.0.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rithmic-rs"
-version = "3.0.0"
+version = "3.1.0"
 description = "Rust client for the Rithmic R | Protocol API to build algo trading systems"
 license = "MIT OR Apache-2.0"
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rithmic-rs = "3.0.0"
+rithmic-rs = "3.1.0"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -26,9 +26,6 @@ Set your environment variables:
 ```sh
 RITHMIC_APP_NAME=your_app_name
 RITHMIC_APP_VERSION=1
-
-# Optional: seconds a request waits for a response (default 30; 0 selects the default)
-RITHMIC_REQUEST_TIMEOUT_SECS=30
 
 RITHMIC_DEMO_USER=your_username
 RITHMIC_DEMO_PW=your_password

--- a/examples/.env.blank
+++ b/examples/.env.blank
@@ -1,10 +1,6 @@
 RITHMIC_APP_NAME=<your_registered_app_name>
 RITHMIC_APP_VERSION=<your_app_version>
 
-# Optional: seconds a request waits for a response (default 30; digits only,
-# so leave this commented out rather than empty)
-# RITHMIC_REQUEST_TIMEOUT_SECS=30
-
 RITHMIC_TEST_ACCOUNT_ID=
 RITHMIC_TEST_FCM_ID=
 RITHMIC_TEST_IB_ID=

--- a/examples/request_timeout.rs
+++ b/examples/request_timeout.rs
@@ -1,15 +1,18 @@
-//! Example: giving a request a deadline of your own.
+//! Example: adding your own timeout to a request.
 //!
-//! The crate does not time out requests — a call is resolved when Rithmic
-//! answers it or when the connection drops. Wrap it if you want a ceiling.
+//! The crate does not time out requests. This example shows how to add one.
 //!
 //! Run with: cargo run --example request_timeout
 
 use std::time::Duration;
 
+use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
-use rithmic_rs::{ConnectStrategy, RithmicConfig, RithmicEnv, RithmicTickerPlant};
+use rithmic_rs::{
+    ConnectStrategy, OrderSide, OrderType, RithmicAccount, RithmicBracketOrder, RithmicConfig,
+    RithmicEnv, RithmicError, RithmicOrderPlant, RithmicResponse, TimeInForce,
+};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -17,37 +20,88 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt().init();
 
     let config = RithmicConfig::from_env(RithmicEnv::Demo)?;
-    let plant = RithmicTickerPlant::connect(&config, ConnectStrategy::Retry).await?;
-    let handle = plant.get_handle();
+    let account = RithmicAccount::from_env(RithmicEnv::Demo)?;
+
+    let plant = RithmicOrderPlant::connect(&config, ConnectStrategy::Retry).await?;
+    let handle = plant.get_handle(&account);
 
     handle.login().await?;
+    handle.subscribe_order_updates().await?;
+    handle.subscribe_bracket_updates().await?;
 
-    // Three outcomes, not two: the wrapper adds one the call itself cannot
-    // return.
-    let request = handle.get_front_month_contract("ES", "CME", false);
+    let request = handle.get_account_rms_info();
 
     match tokio::time::timeout(Duration::from_secs(10), request).await {
-        Ok(Ok(resp)) => info!("front month: {:?}", resp.message),
-        Ok(Err(e)) => error!("front month: {e}"),
-        // Nothing was cancelled. The request is still registered, and if the
-        // reply arrives it is dropped, because this future owned the receiver.
-        Err(_elapsed) => warn!("front month: gave up waiting"),
+        Ok(Ok(responses)) => info!("rms info: {} frames", responses.len()),
+        Ok(Err(e)) => error!("rms info: {e}"),
+        Err(_elapsed) => warn!("rms info: gave up; the late reply is discarded"),
     }
 
-    // Pick the number per call. A quote lookup that is slow is worth
-    // abandoning; a login is worth waiting on.
-    let slow = handle.get_front_month_contract("NQ", "CME", false);
+    let worker = handle.clone();
+    let order = build_order("example-timeout-1")?;
+    let mut task = tokio::spawn(async move { worker.place_bracket_order(order).await });
 
-    if let Ok(Ok(resp)) = tokio::time::timeout(Duration::from_millis(50), slow).await {
-        info!("front month: {:?}", resp.message);
-    } else {
-        warn!("front month: not worth 50ms");
+    match tokio::time::timeout(Duration::from_secs(30), &mut task).await {
+        Ok(joined) => match joined? {
+            Ok(responses) => info!("bracket acked in time: {} frames", responses.len()),
+            Err(e) => error!("bracket rejected: {e}"),
+        },
+        Err(_elapsed) => {
+            warn!("bracket: gave up waiting; the task still holds the reply");
+
+            match task.await? {
+                Ok(responses) => info!("bracket acked late: {} frames", responses.len()),
+                Err(e) => error!("bracket failed: {e}"),
+            }
+        }
     }
 
-    // On a write, expiry means the outcome is unknown rather than failed:
-    // Rithmic never learned you gave up, so the order may well be working.
-    // Reconcile it against the order plant instead of sending it again.
+    let (outcomes_tx, mut outcomes) = mpsc::channel::<(String, Outcome)>(64);
+
+    for tag in ["example-timeout-2", "example-timeout-3"] {
+        let worker = handle.clone();
+        let report = outcomes_tx.clone();
+        let order = build_order(tag)?;
+        let tag = tag.to_string();
+
+        tokio::spawn(async move {
+            let outcome = match worker.place_bracket_order(order).await {
+                Ok(responses) => Outcome::Acked(responses),
+                Err(e) => Outcome::Failed(e),
+            };
+            let _ = report.send((tag, outcome)).await;
+        });
+    }
+
+    drop(outcomes_tx);
+
+    while let Some((tag, outcome)) = outcomes.recv().await {
+        match outcome {
+            Outcome::Acked(responses) => info!("{tag}: acked, {} frames", responses.len()),
+            Outcome::Failed(e) => error!("{tag}: {e}"),
+        }
+    }
 
     handle.disconnect().await?;
     Ok(())
+}
+
+enum Outcome {
+    Acked(Vec<RithmicResponse>),
+    Failed(RithmicError),
+}
+
+fn build_order(localid: &str) -> Result<RithmicBracketOrder, Box<dyn std::error::Error>> {
+    Ok(RithmicBracketOrder::new()
+        .symbol("ESU6")
+        .exchange("CME")
+        .quantity(1)
+        .action(OrderSide::Buy)
+        .price_type(OrderType::Limit)
+        .duration(TimeInForce::Day)
+        .localid(localid)
+        .price(5000.00)
+        .target(20)
+        .stop(10)
+        .build()?)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,10 +169,10 @@
 //! whatever the real cause was. The cause goes out on the subscription channel,
 //! so look there if you need to tell a heartbeat timeout from a dead socket.
 //!
-//! A request has no deadline of its own: Rithmic answers it or the connection
-//! drops. Wrap the call in [`tokio::time::timeout`] if you want a ceiling —
-//! see `examples/request_timeout.rs`. Giving up cancels nothing on Rithmic's
-//! side, so reconcile an order rather than re-sending it.
+//! The crate does not time out requests. A request finishes when Rithmic
+//! answers it or the connection drops. If you need timeout handling, see
+//! `examples/request_timeout.rs`. Timing out on your side does not cancel
+//! anything on Rithmic's, so reconcile an order rather than re-sending it.
 //!
 //! ([`ConnectionFailed`](RithmicError::ConnectionFailed) comes from `connect()`
 //! rather than a handle method, and only under [`ConnectStrategy::Simple`] —


### PR DESCRIPTION
## Issues

**1.** `examples/request_timeout.rs` showed one way to wrap a call in `tokio::time::timeout`, and it is the way that loses the reply. The response channel lives inside the call's future, so passing that future to `timeout` by value drops the channel on expiry, and a reply arriving afterwards has nowhere to go. An acceptable trade on a read, not on an order placement.

**2.** The `src/lib.rs` error-handling section recommended the same form with no qualification.

**3.** The README and `examples/.env.blank` document a default for `RITHMIC_REQUEST_TIMEOUT_SECS`, which no longer sets any timeout.

**4.** Nothing in CI builds the `serde` feature, while `[package.metadata.docs.rs]` sets `all-features = true`.

**5.** `Cargo.toml` still says 3.0.0 and the changelog has no `[3.1.0]` link, though the 3.1.0 section is written.

## Solutions

**1.** Rewrote the example around the order plant, showing three shapes: wrapping a read directly; `tokio::spawn` plus `timeout(d, &mut task)`, which borrows the `JoinHandle` rather than consuming it so the request keeps running and the reply is still there to await; and an `mpsc` channel that each placement reports its outcome into.

**2.** `lib.rs` now points at the example instead of recommending a form.

**3.** Removed both blocks. `RithmicConfig` still rejects a non-numeric value, and the changelog's Deprecated section records the change.

**4.** CI runs `clippy --all-targets --all-features` alongside the default-feature run, and builds docs with `--all-features` to match docs.rs. No extra test run: the feature gates two `use serde::...` lines and nothing else, so the test set is identical with it on or off.

**5.** Bumped `Cargo.toml` and the README install line to 3.1.0, added the `[3.1.0]` changelog link, and moved `[Unreleased]` onto it.