### PR TITLE
Expose selective trade and BBO ticker subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `subscribe_trades` / `unsubscribe_trades` and `subscribe_bbo` /
+  `unsubscribe_bbo` expose the ticker protocol's independent last-trade and BBO
+  update bits while preserving the existing combined `subscribe` / `unsubscribe`
+  helpers.
+
 ## [3.1.0]
 
 ### Requests no longer time out

--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ handle.subscribe("ESM6", "CME").await?;
 // Unsubscribe when done
 handle.unsubscribe("ESM6", "CME").await?;
 
+// Or control last trades and BBO independently
+handle.subscribe_trades("ESM6", "CME").await?;
+handle.subscribe_bbo("ESM6", "CME").await?;
+handle.unsubscribe_trades("ESM6", "CME").await?;
+handle.unsubscribe_bbo("ESM6", "CME").await?;
+
 // Additional market data subscriptions
 handle.subscribe_instrument_status("ESM6", "CME").await?;
 handle.subscribe_open_interest("ESM6", "CME").await?;

--- a/src/plants/ticker_plant.rs
+++ b/src/plants/ticker_plant.rs
@@ -738,6 +738,37 @@ impl RithmicTickerPlantHandle {
         .await
     }
 
+    /// Subscribe only to last-trade updates for a specific symbol.
+    ///
+    /// This sends template 100 with only [`UpdateBits::LastTrade`] set. Use
+    /// [`Self::subscribe`] when both last trades and BBO updates are wanted.
+    pub async fn subscribe_trades(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, RithmicError> {
+        self.request_market_data_update(
+            symbol,
+            exchange,
+            vec![UpdateBits::LastTrade],
+            Request::Subscribe,
+        )
+        .await
+    }
+
+    /// Subscribe only to best-bid-and-offer updates for a specific symbol.
+    ///
+    /// This sends template 100 with only [`UpdateBits::Bbo`] set. Use
+    /// [`Self::subscribe`] when both last trades and BBO updates are wanted.
+    pub async fn subscribe_bbo(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, RithmicError> {
+        self.request_market_data_update(symbol, exchange, vec![UpdateBits::Bbo], Request::Subscribe)
+            .await
+    }
+
     /// Subscribe to order book depth-by-order updates for a specific symbol
     ///
     /// # Arguments
@@ -782,6 +813,40 @@ impl RithmicTickerPlantHandle {
             symbol,
             exchange,
             vec![UpdateBits::LastTrade, UpdateBits::Bbo],
+            Request::Unsubscribe,
+        )
+        .await
+    }
+
+    /// Unsubscribe only from last-trade updates for a specific symbol.
+    ///
+    /// Other update bits, including BBO, are not included in this request.
+    pub async fn unsubscribe_trades(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, RithmicError> {
+        self.request_market_data_update(
+            symbol,
+            exchange,
+            vec![UpdateBits::LastTrade],
+            Request::Unsubscribe,
+        )
+        .await
+    }
+
+    /// Unsubscribe only from best-bid-and-offer updates for a specific symbol.
+    ///
+    /// Other update bits, including last trades, are not included in this request.
+    pub async fn unsubscribe_bbo(
+        &self,
+        symbol: &str,
+        exchange: &str,
+    ) -> Result<RithmicResponse, RithmicError> {
+        self.request_market_data_update(
+            symbol,
+            exchange,
+            vec![UpdateBits::Bbo],
             Request::Unsubscribe,
         )
         .await

--- a/src/plants/ticker_plant/tests.rs
+++ b/src/plants/ticker_plant/tests.rs
@@ -93,6 +93,84 @@ fn test_handle() -> (RithmicTickerPlantHandle, mpsc::Receiver<TickerPlantCommand
     (handle, command_receiver)
 }
 
+async fn assert_selective_request<F, Fut>(
+    call: F,
+    expected_fields: Vec<UpdateBits>,
+    expected_request: Request,
+) where
+    F: FnOnce(RithmicTickerPlantHandle) -> Fut,
+    Fut: std::future::Future<Output = Result<RithmicResponse, RithmicError>> + Send + 'static,
+{
+    let (handle, mut commands) = test_handle();
+    let task = tokio::spawn(call(handle));
+    let command = commands.recv().await.expect("request must reach the actor");
+    let TickerPlantCommand::Subscribe {
+        symbol,
+        exchange,
+        fields,
+        request_type,
+        response_sender,
+    } = command
+    else {
+        panic!("selective helper sent the wrong command")
+    };
+    assert_eq!(symbol, "ESH6");
+    assert_eq!(exchange, "CME");
+    assert_eq!(fields, expected_fields);
+    assert_eq!(request_type, expected_request);
+    let _ = response_sender.send(Err(RithmicError::SendFailed));
+    assert!(matches!(task.await, Ok(Err(RithmicError::SendFailed))));
+}
+
+#[tokio::test]
+async fn selective_trade_helpers_send_only_the_last_trade_bit() {
+    assert_selective_request(
+        |handle| async move { handle.subscribe_trades("ESH6", "CME").await },
+        vec![UpdateBits::LastTrade],
+        Request::Subscribe,
+    )
+    .await;
+    assert_selective_request(
+        |handle| async move { handle.unsubscribe_trades("ESH6", "CME").await },
+        vec![UpdateBits::LastTrade],
+        Request::Unsubscribe,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn selective_bbo_helpers_send_only_the_bbo_bit() {
+    assert_selective_request(
+        |handle| async move { handle.subscribe_bbo("ESH6", "CME").await },
+        vec![UpdateBits::Bbo],
+        Request::Subscribe,
+    )
+    .await;
+    assert_selective_request(
+        |handle| async move { handle.unsubscribe_bbo("ESH6", "CME").await },
+        vec![UpdateBits::Bbo],
+        Request::Unsubscribe,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn combined_helpers_remain_backward_compatible() {
+    let combined = vec![UpdateBits::LastTrade, UpdateBits::Bbo];
+    assert_selective_request(
+        |handle| async move { handle.subscribe("ESH6", "CME").await },
+        combined.clone(),
+        Request::Subscribe,
+    )
+    .await;
+    assert_selective_request(
+        |handle| async move { handle.unsubscribe("ESH6", "CME").await },
+        combined,
+        Request::Unsubscribe,
+    )
+    .await;
+}
+
 #[tokio::test]
 async fn disconnect_sends_close_even_when_logout_fails() {
     let (handle, mut command_receiver) = test_handle();

--- a/src/plants/ticker_plant/tests.rs
+++ b/src/plants/ticker_plant/tests.rs
@@ -1,12 +1,16 @@
+use prost::Message;
 use tokio::net::TcpStream;
 
 use super::*;
 use crate::{
     plants::test_support::{
         self, Responder, assert_close_still_sent, assert_rejected_after_close,
-        assert_sent_while_open, assert_wire_silent,
+        assert_sent_while_open, assert_wire_silent, read_wire_request,
     },
-    rti::request_market_data_update::{Request, UpdateBits},
+    rti::{
+        RequestMarketDataUpdate,
+        request_market_data_update::{Request, UpdateBits},
+    },
 };
 
 async fn plant_with_wire() -> (TickerPlant, mpsc::Sender<TickerPlantCommand>, TcpStream) {
@@ -93,82 +97,86 @@ fn test_handle() -> (RithmicTickerPlantHandle, mpsc::Receiver<TickerPlantCommand
     (handle, command_receiver)
 }
 
-async fn assert_selective_request<F, Fut>(
-    call: F,
-    expected_fields: Vec<UpdateBits>,
-    expected_request: Request,
-) where
+async fn decoded_public_request<F, Fut>(call: F) -> RequestMarketDataUpdate
+where
     F: FnOnce(RithmicTickerPlantHandle) -> Fut,
     Fut: std::future::Future<Output = Result<RithmicResponse, RithmicError>> + Send + 'static,
 {
-    let (handle, mut commands) = test_handle();
-    let task = tokio::spawn(call(handle));
-    let command = commands.recv().await.expect("request must reach the actor");
-    let TickerPlantCommand::Subscribe {
-        symbol,
-        exchange,
-        fields,
-        request_type,
-        response_sender,
-    } = command
-    else {
-        panic!("selective helper sent the wrong command")
+    let (plant, command_sender, mut client) = plant_with_wire().await;
+    let subscription_sender = plant.core.subscription_sender.clone();
+    let handle = RithmicTickerPlantHandle {
+        sender: command_sender.clone(),
+        subscription_receiver: subscription_sender.subscribe(),
+        subscription_sender: subscription_sender.clone(),
     };
-    assert_eq!(symbol, "ESH6");
-    assert_eq!(exchange, "CME");
-    assert_eq!(fields, expected_fields);
-    assert_eq!(request_type, expected_request);
-    let _ = response_sender.send(Err(RithmicError::SendFailed));
-    assert!(matches!(task.await, Ok(Err(RithmicError::SendFailed))));
+    let stop = RithmicTickerPlantHandle {
+        sender: command_sender,
+        subscription_receiver: subscription_sender.subscribe(),
+        subscription_sender,
+    };
+    let actor = tokio::spawn(async move {
+        let mut plant = plant;
+        plant.run().await;
+    });
+    let task = tokio::spawn(call(handle));
+    let request = RequestMarketDataUpdate::decode(&*read_wire_request(&mut client).await)
+        .expect("the actor serialized a ticker request");
+    stop.abort();
+    let _ = actor.await;
+    assert!(matches!(
+        task.await,
+        Ok(Err(RithmicError::ConnectionClosed))
+    ));
+    request
 }
 
 #[tokio::test]
 async fn selective_trade_helpers_send_only_the_last_trade_bit() {
-    assert_selective_request(
-        |handle| async move { handle.subscribe_trades("ESH6", "CME").await },
-        vec![UpdateBits::LastTrade],
-        Request::Subscribe,
-    )
-    .await;
-    assert_selective_request(
-        |handle| async move { handle.unsubscribe_trades("ESH6", "CME").await },
-        vec![UpdateBits::LastTrade],
-        Request::Unsubscribe,
-    )
-    .await;
+    let subscribe =
+        decoded_public_request(
+            |handle| async move { handle.subscribe_trades("ESH6", "CME").await },
+        )
+        .await;
+    assert_eq!(subscribe.update_bits, Some(UpdateBits::LastTrade as u32));
+    assert_eq!(subscribe.request, Some(Request::Subscribe as i32));
+
+    let unsubscribe =
+        decoded_public_request(
+            |handle| async move { handle.unsubscribe_trades("ESH6", "CME").await },
+        )
+        .await;
+    assert_eq!(unsubscribe.update_bits, Some(UpdateBits::LastTrade as u32));
+    assert_eq!(unsubscribe.request, Some(Request::Unsubscribe as i32));
 }
 
 #[tokio::test]
 async fn selective_bbo_helpers_send_only_the_bbo_bit() {
-    assert_selective_request(
-        |handle| async move { handle.subscribe_bbo("ESH6", "CME").await },
-        vec![UpdateBits::Bbo],
-        Request::Subscribe,
-    )
-    .await;
-    assert_selective_request(
-        |handle| async move { handle.unsubscribe_bbo("ESH6", "CME").await },
-        vec![UpdateBits::Bbo],
-        Request::Unsubscribe,
-    )
-    .await;
+    let subscribe =
+        decoded_public_request(|handle| async move { handle.subscribe_bbo("ESH6", "CME").await })
+            .await;
+    assert_eq!(subscribe.update_bits, Some(UpdateBits::Bbo as u32));
+    assert_eq!(subscribe.request, Some(Request::Subscribe as i32));
+
+    let unsubscribe =
+        decoded_public_request(|handle| async move { handle.unsubscribe_bbo("ESH6", "CME").await })
+            .await;
+    assert_eq!(unsubscribe.update_bits, Some(UpdateBits::Bbo as u32));
+    assert_eq!(unsubscribe.request, Some(Request::Unsubscribe as i32));
 }
 
 #[tokio::test]
 async fn combined_helpers_remain_backward_compatible() {
-    let combined = vec![UpdateBits::LastTrade, UpdateBits::Bbo];
-    assert_selective_request(
-        |handle| async move { handle.subscribe("ESH6", "CME").await },
-        combined.clone(),
-        Request::Subscribe,
-    )
-    .await;
-    assert_selective_request(
-        |handle| async move { handle.unsubscribe("ESH6", "CME").await },
-        combined,
-        Request::Unsubscribe,
-    )
-    .await;
+    let combined = (UpdateBits::LastTrade as u32) | (UpdateBits::Bbo as u32);
+    let subscribe =
+        decoded_public_request(|handle| async move { handle.subscribe("ESH6", "CME").await }).await;
+    assert_eq!(subscribe.update_bits, Some(combined));
+    assert_eq!(subscribe.request, Some(Request::Subscribe as i32));
+
+    let unsubscribe =
+        decoded_public_request(|handle| async move { handle.unsubscribe("ESH6", "CME").await })
+            .await;
+    assert_eq!(unsubscribe.update_bits, Some(combined));
+    assert_eq!(unsubscribe.request, Some(Request::Unsubscribe as i32));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- add trade-only subscribe/unsubscribe helpers using the existing ticker actor
- add BBO-only subscribe/unsubscribe helpers using the existing ticker actor
- preserve the existing combined helpers unchanged

## Reason
On a conventional trading platform, we might only require BBO to monitor open positions for open pnl reporting purposes. (to ensure open pnl is calulated in a timely manner and as a failsafe if pnl plant is not reporting)

If the platform has many open positions across many symbols, it becomes important to minimise the number of active subscriptions.

In this case, Trades will not be needed if charting is no longer required, but the BBO is still required to trigger platform managed Risk management and ledger updates.

Example: 

- When subscribing to charts we try MBO subscription and emit trades and bbo from mbo, assuming a DOM will also be active.
- If mbo sub rejects we fallback to trades + bbo.
- If charting is no longer interested we fall back to bbo, only if there is an open position.
- This allows exponentially more open positions to be monitored on exponentially more tickers, while using 50% less subscriptions.

## Validation

- `cargo test plants::ticker_plant`

These helpers expose the protocol's existing independent `LastTrade` and `Bbo` update bits without bypassing request correlation or the actor.
